### PR TITLE
Menu-bar Start/Stop, no-auto-start, and a dev-mode live activity viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ wiki/build_html.py
 *.xcodeproj
 .DS_Store
 secrets.env
+
+# Dev-mode activity/debug logs (screen-derived content — never commit)
+.jarvis/

--- a/README.md
+++ b/README.md
@@ -10,26 +10,55 @@ The implementation plan is [`wiki/plan-phase2-build.md`](./wiki/plan-phase2-buil
 No Xcode needed — Swift 6 + Command Line Tools only.
 
 ```bash
-./scripts/run-tests.sh        # run the unit + offline-pipeline tests (26 tests)
-./scripts/build-app.sh release   # build + ad-hoc sign Jarvis.app
+./scripts/run-tests.sh        # run the unit + offline-pipeline tests (30 tests)
+./scripts/make-signing-identity.sh   # one-time: create the stable "Jarvis Dev" signing identity
+./scripts/build-app.sh release       # build + sign Jarvis.app (so TCC permissions persist)
 ```
+
+Run `make-signing-identity.sh` **once**. It creates a stable self-signed identity so macOS
+Microphone / Screen Recording grants persist across rebuilds; without it `build-app.sh` falls back
+to ad-hoc signing and macOS re-prompts every build.
 
 ## Running Jarvis
 
 1. **Build** the app: `./scripts/build-app.sh release` → produces `Jarvis.app`.
-2. **Set your OpenAI API key** via the menu bar → **"Set OpenAI API Key…"**. It saves to your login Keychain and **starts coaching immediately — no relaunch**. (An `OPENAI_API_KEY` env var also works as a headless fallback.)
-3. **Launch**: `open ./Jarvis.app` (or run `./Jarvis.app/Contents/MacOS/JarvisApp` in a terminal to see logs). A 🟢 Jarvis menu-bar item appears; it's a menu-bar-only app (no Dock icon).
-4. **Grant permissions** when macOS prompts: **Microphone** and **Screen Recording** (System Settings → Privacy & Security). Screen Recording has no prompt dialog for the `screencapture` path — add Jarvis under Privacy & Security → Screen Recording if needed.
+2. **Launch via `open`**: `open ./Jarvis.app`. A **⚪️ Jarvis** menu-bar item appears (menu-bar-only app, no Dock icon). Always launch with `open`, *not* the bare binary — launching the executable from a terminal makes macOS attribute the permission grants to the shell, so they look "denied".
+3. **Grant permissions** when macOS prompts (first run only): **Microphone** and **Screen Recording** (System Settings → Privacy & Security). These persist afterward. To recover a stale *denied* state, run `tccutil reset Microphone com.jarvis.coach` (or `ScreenCapture`) and relaunch.
+4. **Set your OpenAI API key** via the menu bar → **"Set OpenAI API Key…"**. It saves to your login Keychain. (An `OPENAI_API_KEY` env var also works as a headless fallback.) Jarvis does **not** auto-start.
+5. **Start / Stop** coaching from the menu bar (**Start Jarvis** / **Stop Jarvis**). The icon shows the only two states: **⚪️ stopped** and **🟢 running**.
+
+### Dev mode — live activity viewer
+
+```bash
+./scripts/run-dev.sh        # rebuild, launch via `open --args --dev`, auto-open the viewer
+```
+
+In **dev mode** Jarvis writes a self-contained, auto-refreshing HTML page and opens it in your
+browser so you can *watch it think* without tailing a log file. It reloads every second and
+color-codes each event:
+
+- 🗣 `you finished a thought` / 🤫 `quiet for 12s` — why the coach loop woke up
+- 💭 `thinking…` — calling the brain
+- 👁 `looking at your screen` — the model invoked `capture_screen`
+- 💬 `…the tip it spoke…` — a `speak` call rendered to the overlay
+- `… nothing useful to add, staying silent` / `… held back (cooldown or rate cap)`
+
+Every `jlog` line (lifecycle, errors, realtime-socket events) is mirrored in too. The page is
+written to `/tmp/jarvis-activity.html` (override with the `JARVIS_ACTIVITY_HTML` env var); it's
+regenerated fresh each session. To enable the viewer on a manual launch, add the flag yourself:
+`open ./Jarvis.app --args --dev`.
 
 ### Live smoke checklist (what to verify by hand)
 
 These need a human, a real key, and granted permissions — see [`wiki/specification.md` §8](./wiki/specification.md#8-self-verification-plan):
 
-- Model IDs are **doc-verified** (`gpt-5.5` via the Responses API; `gpt-4o-transcribe` over the GA Realtime API) — no edit expected. The connect URL + session payload are unit-tested in `RealtimeSessionTests`. The one thing only a live run can confirm is that the transcription session negotiates end-to-end (a real key + mic); watch the Console for `transcription session ready` and any `error event` lines.
-- Speak — confirm transcript lines arrive (watch Console / terminal logs).
-- With a LeetCode problem on screen, say *"Jarvis, I'm stuck on two-sum"* — expect a coaching overlay within ~2s, and observe a `capture_screen` call.
+Run with `./scripts/run-dev.sh` and watch the **live activity viewer** (above) — it shows each step below as it happens.
+
+- Model IDs are **doc-verified** (`gpt-5.5` via the Responses API; `gpt-4o-transcribe` over the GA Realtime API) — no edit expected. The connect URL + session payload are unit-tested in `RealtimeSessionTests`. The one thing only a live run can confirm is that the transcription session negotiates end-to-end (a real key + mic); watch for `transcription session ready` and any `error event` lines.
+- Press **Start Jarvis**, then speak — confirm transcript turns drive 🗣/💭 lines in the viewer.
+- With a LeetCode problem on screen, say *"Jarvis, I'm stuck on two-sum"* — expect a coaching overlay within ~2s, and observe a 👁 `looking at your screen` (`capture_screen`) line.
 - Confirm the screenshot excludes the overlay window.
-- Rapid triggers don't exceed 4 interjections/minute; **Mute** silences output.
+- Rapid triggers don't exceed 4 interjections/minute (look for `… held back` lines); **Stop Jarvis** halts the pipeline entirely.
 
 ### Status of the build
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The implementation plan is [`wiki/plan-phase2-build.md`](./wiki/plan-phase2-buil
 No Xcode needed — Swift 6 + Command Line Tools only.
 
 ```bash
-./scripts/run-tests.sh        # run the unit + offline-pipeline tests (30 tests)
+./scripts/run-tests.sh        # run the unit + offline-pipeline tests (36 tests)
 ./scripts/make-signing-identity.sh   # one-time: create the stable "Jarvis Dev" signing identity
 ./scripts/build-app.sh release       # build + sign Jarvis.app (so TCC permissions persist)
 ```
@@ -37,16 +37,19 @@ In **dev mode** Jarvis writes a self-contained, auto-refreshing HTML page and op
 browser so you can *watch it think* without tailing a log file. It reloads every second and
 color-codes each event:
 
-- 🗣 `you finished a thought` / 🤫 `quiet for 12s` — why the coach loop woke up
+- 🗣 `heard: "…"` — what you actually said (transcribed) / 🤫 `quiet for 12s` — why it woke
 - 💭 `thinking…` — calling the brain
 - 👁 `looking at your screen` — the model invoked `capture_screen`
 - 💬 `…the tip it spoke…` — a `speak` call rendered to the overlay
 - `… nothing useful to add, staying silent` / `… held back (cooldown or rate cap)`
 
-Every `jlog` line (lifecycle, errors, realtime-socket events) is mirrored in too. The page is
-written to `/tmp/jarvis-activity.html` (override with the `JARVIS_ACTIVITY_HTML` env var); it's
-regenerated fresh each session. To enable the viewer on a manual launch, add the flag yourself:
-`open ./Jarvis.app --args --dev`.
+Every `jlog` line (lifecycle, errors, realtime-socket events) is mirrored in too. **File logging is
+dev-only and owner-only:** the activity HTML and `jarvis-debug.log` are written to the `--log-dir`
+(`run-dev.sh` uses a **gitignored `.jarvis/`** in the workspace; default otherwise is a per-user
+`Caches/Jarvis`) with `0600` permissions, truncated fresh each session — never world-readable `/tmp`.
+Outside dev mode nothing is written to a file (just the unified log). Env overrides `JARVIS_LOG` /
+`JARVIS_ACTIVITY_HTML` exist for headless use. To enable on a manual launch:
+`open ./Jarvis.app --args --dev --log-dir ./.jarvis`.
 
 ### Live smoke checklist (what to verify by hand)
 

--- a/Sources/JarvisApp/AppDelegate.swift
+++ b/Sources/JarvisApp/AppDelegate.swift
@@ -15,20 +15,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private var overlay: OverlayPanel!
     private var menuBar: MenuBarController!
-    private var driver: CoachDriver!
     private var transcriber: RealtimeTranscriber?
     private var audio: AudioInput?
+    /// In-flight coaching turns, so Stop can cancel one mid-brain-call (otherwise it could speak
+    /// after the user pressed Stop).
+    private var turns: TurnTaskBox?
 
-    /// Dev mode (`open ./Jarvis.app --args --dev`): auto-opens the live activity HTML for the session.
+    /// Dev mode (`open ./Jarvis.app --args --dev`): enables owner-only file logging and auto-opens
+    /// the live activity HTML for the session.
     private let devMode = CommandLine.arguments.contains("--dev")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
 
         if devMode {
-            ActivityLog.shared.reset()                       // fresh page for this session
-            NSWorkspace.shared.open(ActivityLog.shared.htmlURL)
-            jlog("Jarvis: dev mode — live activity viewer opened in your browser.")
+            let dir = devLogDirectory()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            JarvisLog.enableFileLogging(directory: dir)     // <dir>/jarvis-debug.log, 0600, fresh
+            ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.html, 0600, fresh
+            if let url = ActivityLog.shared.htmlURL { NSWorkspace.shared.open(url) }
+            jlog("Jarvis: dev mode — activity viewer opened (\(dir.path)).")
         }
 
         // Ask for Microphone + Screen Recording up front, not lazily mid-session.
@@ -39,10 +45,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // The menu drives the pipeline lifecycle. Jarvis does NOT auto-start; the user presses Start.
         menuBar.onStart = { [weak self] in self?.start() ?? false }
         menuBar.onStop = { [weak self] in self?.stop() }
-        // A pasted key is stored but does not auto-start; restart only if already running.
+        // A pasted key is stored but does not auto-start; restart only if already running, and
+        // reflect the real outcome back into the menu state.
         menuBar.onKeySaved = { [weak self] _ in
             guard let self, self.transcriber != nil else { return }
-            self.stop(); _ = self.start()
+            self.menuBar.setRunning(self.start())
         }
 
         if secrets.apiKey()?.isEmpty == false {
@@ -57,29 +64,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @discardableResult
     private func start() -> Bool {
         guard let key = secrets.apiKey(), !key.isEmpty else {
-            jlog("Jarvis: can't start — no API key. Use “Set OpenAI API Key…” first.")
+            jlog("Jarvis: can't start — no API key.")
+            warnNoKey()
             return false
         }
         stop() // tear down any existing pipeline so we start cleanly
+        menuBar.resetCounter()  // a Start begins a fresh session
 
         let brain = OpenAIBrainClient(apiKey: key, model: config.brainModel,
                                       reasoningEffort: config.reasoningEffort)
         let driver = CoachDriver(config: config, transcript: transcript, guardrails: guardrails,
                                  brain: brain, screen: ScreenCaptureCLI(), overlay: overlay, clock: clock,
                                  onSpoke: { [weak self] in Task { @MainActor in self?.menuBar.noteSpoke() } })
-        self.driver = driver
 
         let transcriber = RealtimeTranscriber(apiKey: key, model: config.transcriptionModel,
                                               transcript: transcript, clock: clock,
                                               silenceTimeout: config.silenceTimeoutSeconds)
         // CoachDriver is @unchecked Sendable; capture it (not @MainActor self) in the callbacks.
-        transcriber.onTurnEnd = { Task { await driver.handleTrigger(.turnEnd) } }
-        transcriber.onSilence = { secs in Task { await driver.handleTrigger(.silence(secondsQuiet: secs)) } }
+        // Route turns through TurnTaskBox so Stop can cancel an in-flight one.
+        let turns = TurnTaskBox()
+        transcriber.onTurnEnd = { turns.run { await driver.handleTrigger(.turnEnd) } }
+        transcriber.onSilence = { secs in turns.run { await driver.handleTrigger(.silence(secondsQuiet: secs)) } }
+        // Reconnect gave up (bad key / quota): stop cleanly and correct the menu instead of lying 🟢.
+        transcriber.onTerminalFailure = { [weak self] in
+            Task { @MainActor in self?.stop(); self?.menuBar.setRunning(false) }
+        }
         let audio = AudioInput(captureSystemAudio: true) { [weak transcriber] pcm in
             transcriber?.sendAudio(pcm)
         }
         self.transcriber = transcriber
         self.audio = audio
+        self.turns = turns
         transcriber.connect()
         audio.start()
         jlog("Jarvis: coaching started.")
@@ -89,11 +104,52 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Stop and tear down the transcription pipeline. Safe to call when already stopped.
     private func stop() {
         let wasRunning = transcriber != nil
+        turns?.cancelAll(); turns = nil      // cancel any in-flight coaching turn
         transcriber?.stop()
         audio?.stop()
         transcriber = nil
         audio = nil
-        driver = nil
         if wasRunning { jlog("Jarvis: stopped.") }
+    }
+
+    private func warnNoKey() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "No OpenAI API key set"
+        alert.informativeText = "Choose “Set OpenAI API Key…” from the Jarvis menu, then press Start."
+        alert.alertStyle = .informational
+        alert.runModal()
+    }
+
+    /// Where dev-mode logs go: `--log-dir <path>` (run-dev.sh passes the workspace `.jarvis/`),
+    /// else a per-user Caches/Jarvis directory. Never `/tmp` (world-readable, shared across users).
+    private func devLogDirectory() -> URL {
+        let args = CommandLine.arguments
+        if let i = args.firstIndex(of: "--log-dir"), i + 1 < args.count {
+            return URL(fileURLWithPath: args[i + 1])
+        }
+        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        return caches.appendingPathComponent("Jarvis")
+    }
+}
+
+/// Tracks the unstructured Tasks spawned per transcription trigger so Stop can cancel any in-flight
+/// coaching turn. `@unchecked Sendable`: all access to `tasks` is guarded by the lock.
+private final class TurnTaskBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var tasks: [Task<Void, Never>] = []
+
+    func run(_ op: @escaping @Sendable () async -> Void) {
+        let task = Task { await op() }
+        lock.lock()
+        tasks.removeAll { $0.isCancelled }
+        tasks.append(task)
+        lock.unlock()
+    }
+
+    func cancelAll() {
+        lock.lock(); let snapshot = tasks; tasks.removeAll(); lock.unlock()
+        snapshot.forEach { $0.cancel() }
     }
 }

--- a/Sources/JarvisApp/AppDelegate.swift
+++ b/Sources/JarvisApp/AppDelegate.swift
@@ -19,32 +19,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var transcriber: RealtimeTranscriber?
     private var audio: AudioInput?
 
+    /// Dev mode (`open ./Jarvis.app --args --dev`): auto-opens the live activity HTML for the session.
+    private let devMode = CommandLine.arguments.contains("--dev")
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
+
+        if devMode {
+            ActivityLog.shared.reset()                       // fresh page for this session
+            NSWorkspace.shared.open(ActivityLog.shared.htmlURL)
+            jlog("Jarvis: dev mode — live activity viewer opened in your browser.")
+        }
 
         // Ask for Microphone + Screen Recording up front, not lazily mid-session.
         Permissions.primeAll()
 
         overlay = OverlayPanel()
-        menuBar = MenuBarController(guardrails: guardrails, keychain: keychain)
-        // Pasting a key in the menu starts coaching immediately — no relaunch.
-        menuBar.onKeySaved = { [weak self] key in self?.applyKey(key) }
+        menuBar = MenuBarController(keychain: keychain)
+        // The menu drives the pipeline lifecycle. Jarvis does NOT auto-start; the user presses Start.
+        menuBar.onStart = { [weak self] in self?.start() ?? false }
+        menuBar.onStop = { [weak self] in self?.stop() }
+        // A pasted key is stored but does not auto-start; restart only if already running.
+        menuBar.onKeySaved = { [weak self] _ in
+            guard let self, self.transcriber != nil else { return }
+            self.stop(); _ = self.start()
+        }
 
-        // Start now if a key is already present (Keychain or OPENAI_API_KEY).
-        if let key = secrets.apiKey(), !key.isEmpty {
-            applyKey(key)
+        if secrets.apiKey()?.isEmpty == false {
+            jlog("Jarvis: ready — press Start in the menu bar to begin coaching.")
         } else {
-            jlog("Jarvis: no API key yet — paste it via the menu bar (it saves to your Keychain).")
+            jlog("Jarvis: no API key yet — paste it via the menu bar, then press Start.")
         }
     }
 
-    /// (Re)build the brain + driver for `key` and (re)start the transcription pipeline.
-    private func applyKey(_ key: String) {
-        // Tear down any existing pipeline so a new key replaces it cleanly.
-        transcriber?.stop()
-        audio?.stop()
-        transcriber = nil
-        audio = nil
+    /// Build the brain + driver and start the transcription pipeline. Returns `false` (and stays
+    /// stopped) if no API key is available yet.
+    @discardableResult
+    private func start() -> Bool {
+        guard let key = secrets.apiKey(), !key.isEmpty else {
+            jlog("Jarvis: can't start — no API key. Use “Set OpenAI API Key…” first.")
+            return false
+        }
+        stop() // tear down any existing pipeline so we start cleanly
 
         let brain = OpenAIBrainClient(apiKey: key, model: config.brainModel,
                                       reasoningEffort: config.reasoningEffort)
@@ -67,5 +83,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         transcriber.connect()
         audio.start()
         jlog("Jarvis: coaching started.")
+        return true
+    }
+
+    /// Stop and tear down the transcription pipeline. Safe to call when already stopped.
+    private func stop() {
+        let wasRunning = transcriber != nil
+        transcriber?.stop()
+        audio?.stop()
+        transcriber = nil
+        audio = nil
+        driver = nil
+        if wasRunning { jlog("Jarvis: stopped.") }
     }
 }

--- a/Sources/JarvisApp/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBarController.swift
@@ -1,28 +1,34 @@
 import AppKit
 import JarvisCore
 
-/// Menu-bar status item: on/off (mute), API-key entry, and a session interjection counter.
+/// Menu-bar status item: start/stop, API-key entry, and a session interjection counter.
+/// Exactly two states: ⚪️ stopped and 🟢 running.
 @MainActor
 final class MenuBarController: NSObject {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    private let guardrails: Guardrails
     private let keychain: KeychainSecretStore
     private let counterItem = NSMenuItem(title: "Interjections: 0", action: nil, keyEquivalent: "")
+    private let startStopItem = NSMenuItem(title: "Start Jarvis", action: nil, keyEquivalent: "s")
     private var interjections = 0
+    /// Whether the listen/coach pipeline is currently running.
+    private(set) var isRunning = false
 
-    var onMuteChanged: ((Bool) -> Void)?
-    /// Fired after a new key is saved to the Keychain, so the app can start coaching immediately.
+    /// Fired when the user asks to start the pipeline. Returns `true` if it actually started
+    /// (e.g. a key was available), so the menu can reflect the real state.
+    var onStart: (() -> Bool)?
+    /// Fired when the user asks to stop the pipeline.
+    var onStop: (() -> Void)?
+    /// Fired after a new key is saved to the Keychain. The app does *not* auto-start; the user
+    /// presses Start when ready.
     var onKeySaved: ((String) -> Void)?
 
-    init(guardrails: Guardrails, keychain: KeychainSecretStore) {
-        self.guardrails = guardrails
+    init(keychain: KeychainSecretStore) {
         self.keychain = keychain
         super.init()
-        statusItem.button?.title = "🟢 Jarvis"
         let menu = NSMenu()
-        let mute = NSMenuItem(title: "Mute", action: #selector(toggleMute), keyEquivalent: "m")
-        mute.target = self
-        menu.addItem(mute)
+        startStopItem.target = self
+        startStopItem.action = #selector(toggleStartStop)
+        menu.addItem(startStopItem)
         let key = NSMenuItem(title: "Set OpenAI API Key…", action: #selector(setKey), keyEquivalent: "k")
         key.target = self
         menu.addItem(key)
@@ -32,6 +38,7 @@ final class MenuBarController: NSObject {
         let quit = NSMenuItem(title: "Quit Jarvis", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
         menu.addItem(quit)
         statusItem.menu = menu
+        refreshUI()
     }
 
     func noteSpoke() {
@@ -39,12 +46,33 @@ final class MenuBarController: NSObject {
         counterItem.title = "Interjections: \(interjections)"
     }
 
-    @objc private func toggleMute(_ sender: NSMenuItem) {
-        let nowMuted = !guardrails.isMuted
-        guardrails.setMuted(nowMuted)
-        sender.state = nowMuted ? .on : .off
-        statusItem.button?.title = nowMuted ? "🔇 Jarvis" : "🟢 Jarvis"
-        onMuteChanged?(nowMuted)
+    /// Reflect the pipeline's running state in the menu (e.g. when a start attempt fails because
+    /// no API key is set yet, or when the app stops the pipeline on its own).
+    func setRunning(_ running: Bool) {
+        isRunning = running
+        refreshUI()
+    }
+
+    @objc private func toggleStartStop() {
+        if isRunning {
+            onStop?()
+            isRunning = false
+        } else {
+            isRunning = onStart?() ?? false
+        }
+        refreshUI()
+    }
+
+    /// Single source of truth for the status title and the start/stop label.
+    private func refreshUI() {
+        startStopItem.title = isRunning ? "Stop Jarvis" : "Start Jarvis"
+        let icon: String
+        if !isRunning {
+            icon = "⚪️"                                   // stopped
+        } else {
+            icon = "🟢"                                   // running, listening
+        }
+        statusItem.button?.title = "\(icon) Jarvis"
     }
 
     // MARK: - API key dialog
@@ -96,8 +124,8 @@ final class MenuBarController: NSObject {
         let token = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty else { return }
         keychain.setApiKey(token)            // saved locally in the login Keychain
-        statusItem.button?.title = "🟢 Jarvis"
-        onKeySaved?(token)                   // start coaching now — no relaunch needed
+        onKeySaved?(token)                   // stored; user presses Start when ready (no auto-start)
+        refreshUI()
     }
 
     @objc private func saveKeyDialog() { NSApp.stopModal(withCode: .OK) }

--- a/Sources/JarvisApp/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBarController.swift
@@ -46,8 +46,15 @@ final class MenuBarController: NSObject {
         counterItem.title = "Interjections: \(interjections)"
     }
 
-    /// Reflect the pipeline's running state in the menu (e.g. when a start attempt fails because
-    /// no API key is set yet, or when the app stops the pipeline on its own).
+    /// Reset the per-session interjection count (called on each Start).
+    func resetCounter() {
+        interjections = 0
+        counterItem.title = "Interjections: 0"
+    }
+
+    /// The single source of truth for running state. The app calls this for state it drives itself
+    /// (a failed/asynchronously-dead Start, a key-save restart, a terminal socket failure), and
+    /// `toggleStartStop` routes through it too — so the menu can never disagree with the pipeline.
     func setRunning(_ running: Bool) {
         isRunning = running
         refreshUI()
@@ -56,23 +63,16 @@ final class MenuBarController: NSObject {
     @objc private func toggleStartStop() {
         if isRunning {
             onStop?()
-            isRunning = false
+            setRunning(false)
         } else {
-            isRunning = onStart?() ?? false
+            setRunning(onStart?() ?? false)
         }
-        refreshUI()
     }
 
     /// Single source of truth for the status title and the start/stop label.
     private func refreshUI() {
         startStopItem.title = isRunning ? "Stop Jarvis" : "Start Jarvis"
-        let icon: String
-        if !isRunning {
-            icon = "⚪️"                                   // stopped
-        } else {
-            icon = "🟢"                                   // running, listening
-        }
-        statusItem.button?.title = "\(icon) Jarvis"
+        statusItem.button?.title = isRunning ? "🟢 Jarvis" : "⚪️ Jarvis"
     }
 
     // MARK: - API key dialog
@@ -125,9 +125,16 @@ final class MenuBarController: NSObject {
         guard !token.isEmpty else { return }
         keychain.setApiKey(token)            // saved locally in the login Keychain
         onKeySaved?(token)                   // stored; user presses Start when ready (no auto-start)
-        refreshUI()
+        flashConfirmation()                  // visible acknowledgement that the key registered
     }
 
     @objc private func saveKeyDialog() { NSApp.stopModal(withCode: .OK) }
     @objc private func cancelKeyDialog() { NSApp.stopModal(withCode: .cancel) }
+
+    /// Briefly show a checkmark in the menu-bar title so the user sees the key save took effect,
+    /// then restore the normal ⚪️/🟢 state.
+    private func flashConfirmation() {
+        statusItem.button?.title = "✓ Key saved"
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in self?.refreshUI() }
+    }
 }

--- a/Sources/JarvisApp/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/RealtimeTranscriber.swift
@@ -16,7 +16,11 @@ import JarvisCore
 final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @unchecked Sendable {
     var onTurnEnd: (@Sendable () -> Void)?
     var onSilence: (@Sendable (TimeInterval) -> Void)?
+    /// Fired when reconnection is abandoned after `maxReconnects` consecutive failures (e.g. a bad
+    /// key / quota), so the app can flip the menu back to ⚪️ stopped instead of lying green.
+    var onTerminalFailure: (@Sendable () -> Void)?
 
+    private let maxReconnects = 6
     private let apiKey: String
     private let model: String
     private let transcript: RollingTranscript
@@ -25,6 +29,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private let silenceTimeout: TimeInterval
 
     private let lock = NSLock()
+    private var session: URLSession?     // retained so stop() can invalidate it (URLSession holds its delegate)
     private var task: URLSessionWebSocketTask?
     private var silenceTimer: Timer?
     private var pingTimer: Timer?
@@ -53,7 +58,11 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         let session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         let task = session.webSocketTask(with: req)
-        lock.lock(); self.task = task; isReconnecting = false; lock.unlock()
+        lock.lock()
+        self.session?.invalidateAndCancel()   // release the previous session's delegate retain
+        self.session = session
+        self.task = task; isReconnecting = false
+        lock.unlock()
         task.resume()
         configureSession()
         receiveLoop()
@@ -67,8 +76,10 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         silenceTimer?.invalidate(); silenceTimer = nil
         pingTimer?.invalidate(); pingTimer = nil
         let t = task; task = nil
+        let s = session; session = nil
         lock.unlock()
         t?.cancel(with: .goingAway, reason: nil)
+        s?.invalidateAndCancel()             // breaks the URLSession→delegate(self)→closures→driver retain chain
     }
 
     private func configureSession() {
@@ -113,6 +124,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
             if let transcriptText = obj["transcript"] as? String, !transcriptText.isEmpty {
                 let at = clock.now() - sessionStart
                 transcript.append(.init(speaker: .me, text: transcriptText, at: at))
+                jlog("🗣 heard: \"\(transcriptText)\"")   // show what was actually said in the viewer
                 resetSilenceTimer()
                 onTurnEnd?()
             }
@@ -140,9 +152,15 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private func scheduleReconnect() {
         lock.lock()
         if stopped || isReconnecting { lock.unlock(); return }
+        if reconnectAttempt >= maxReconnects {
+            lock.unlock()
+            jlog("Jarvis realtime: giving up after \(maxReconnects) reconnect attempts — stopping")
+            onTerminalFailure?()
+            return
+        }
         isReconnecting = true
         let attempt = reconnectAttempt
-        reconnectAttempt = min(attempt + 1, 6)
+        reconnectAttempt = attempt + 1
         lock.unlock()
 
         let delay = min(30.0, pow(2.0, Double(attempt)))   // 1, 2, 4, 8, 16, 30…

--- a/Sources/JarvisCore/ActivityLog.swift
+++ b/Sources/JarvisCore/ActivityLog.swift
@@ -1,42 +1,47 @@
 import Foundation
 
-/// Mirrors every `jlog` line into a self-contained, auto-refreshing HTML file so you can *watch*
-/// Jarvis think in a browser instead of tailing a flat file. Open it once:
-///
-///     open /tmp/jarvis-activity.html
-///
-/// The page reloads itself every second and scrolls to the newest line. No server, no dependencies
-/// — it works straight off `file://`. Path overridable via `JARVIS_ACTIVITY_HTML`.
+/// Mirrors `jlog` lines into a self-contained, auto-refreshing HTML page so you can *watch* Jarvis
+/// think in a browser. **Dev-mode only:** until `enable(directory:)` is called (or the
+/// `JARVIS_ACTIVITY_HTML` env override is set) `record(_:)` is a no-op and nothing is written to
+/// disk. When enabled it writes `<directory>/jarvis-activity.html` with `0600` permissions (owner
+/// only), fresh each session — so the model's screen-derived tips never land in a world-readable or
+/// persistent location. See wiki/sandbox.md.
 public final class ActivityLog: @unchecked Sendable {
     public static let shared = ActivityLog()
 
-    private let path: String
     private let maxLines = 400
     private let queue = DispatchQueue(label: "jarvis.activitylog")   // serializes state + disk writes
     private var lines: [(time: String, message: String)] = []
     private let df: DateFormatter
+    private var fileURL: URL?     // nil ⇒ disabled (no disk writes)
 
-    private init() {
-        path = ProcessInfo.processInfo.environment["JARVIS_ACTIVITY_HTML"] ?? "/tmp/jarvis-activity.html"
+    /// Internal so tests can spin up an isolated instance; the app uses `.shared`.
+    init() {
         df = DateFormatter()
         df.dateFormat = "HH:mm:ss"
+        // Headless/test override: a full file path enables logging immediately.
+        if let p = ProcessInfo.processInfo.environment["JARVIS_ACTIVITY_HTML"] {
+            fileURL = URL(fileURLWithPath: p)
+        }
     }
 
-    /// Where the live HTML page is written — open this in a browser.
-    public var htmlURL: URL { URL(fileURLWithPath: path) }
-
-    /// Clear the buffer and write a fresh page. Call at launch so each session starts clean
-    /// (the file exists before we open it in the browser — written synchronously).
-    public func reset() {
+    /// Turn on the viewer for a dev session: write to `<directory>/jarvis-activity.html` at 0600,
+    /// cleared fresh. The file exists synchronously on return so the caller can open it.
+    public func enable(directory: URL) {
         queue.sync {
+            fileURL = directory.appendingPathComponent("jarvis-activity.html")
             lines.removeAll()
             writeHTML()
         }
     }
 
-    /// Append a line and rewrite the HTML. Cheap and off the caller's thread.
+    /// The HTML page to open in a browser, or nil when logging is disabled.
+    public var htmlURL: URL? { queue.sync { fileURL } }
+
+    /// Append a line and rewrite the HTML. No-op (and no disk write) when disabled.
     public func record(_ message: String, at date: Date = Date()) {
         queue.async { [self] in
+            guard fileURL != nil else { return }
             lines.append((df.string(from: date), message))
             if lines.count > maxLines { lines.removeFirst(lines.count - maxLines) }
             writeHTML()
@@ -44,13 +49,22 @@ public final class ActivityLog: @unchecked Sendable {
     }
 
     private func writeHTML() {
+        guard let url = fileURL, let data = Self.renderHTML(lines).data(using: .utf8) else { return }
+        // createFile (not atomic write) so we can set 0600 in one step — owner-only, never 0644.
+        FileManager.default.createFile(atPath: url.path, contents: data,
+                                       attributes: [.posixPermissions: 0o600])
+    }
+
+    // MARK: - Pure rendering (testable without disk)
+
+    static func renderHTML(_ lines: [(time: String, message: String)]) -> String {
         var rows = ""
         for line in lines {
             rows += "<div class=\"row \(cssClass(for: line.message))\">"
             rows += "<span class=\"t\">\(esc(line.time))</span>"
             rows += "<span class=\"m\">\(esc(line.message))</span></div>\n"
         }
-        let html = """
+        return """
         <!doctype html><html lang="en"><head>
         <meta charset="utf-8">
         <meta http-equiv="refresh" content="1">
@@ -72,26 +86,46 @@ public final class ActivityLog: @unchecked Sendable {
           .think .m{ color: #8b949e; }   /* thinking / silent  */
           .err .m  { color: #f85149; }   /* error              */
         </style></head><body>
-        <header>🟢 Jarvis — live activity <span class="count">(\(lines.count) lines)</span></header>
+        <header>Jarvis — activity log <span class="count">(\(lines.count) lines)</span></header>
         <main>\(rows)</main>
-        <script>window.scrollTo(0, document.body.scrollHeight);</script>
+        <script>
+          // Keep scrollback usable across the 1s reload: only stick to the bottom if the user was
+          // already near it; otherwise restore their previous scroll position.
+          (function () {
+            var KEY = "jarvisActivityScroll";
+            var wasAtBottom = sessionStorage.getItem(KEY + ".atBottom");
+            var prevTop = sessionStorage.getItem(KEY + ".top");
+            if (wasAtBottom === "0" && prevTop !== null) {
+              window.scrollTo(0, parseFloat(prevTop));
+            } else {
+              window.scrollTo(0, document.body.scrollHeight);
+            }
+            window.addEventListener("scroll", function () {
+              var nearBottom = (window.innerHeight + window.scrollY) >= (document.body.scrollHeight - 40);
+              sessionStorage.setItem(KEY + ".atBottom", nearBottom ? "1" : "0");
+              sessionStorage.setItem(KEY + ".top", String(window.scrollY));
+            });
+          })();
+        </script>
         </body></html>
         """
-        try? html.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    /// Map a line to a colour class by its leading marker / keywords.
-    private func cssClass(for message: String) -> String {
-        let m = message.lowercased()
-        if m.contains("error") || m.contains("failed") || m.contains("denied") { return "err" }
-        if message.contains("💬") { return "say" }
-        if message.contains("👁") { return "see" }
-        if message.contains("🗣") || message.contains("🤫") { return "hear" }
-        if message.contains("💭") || m.contains("stay") || m.contains("held back") { return "think" }
+    /// Colour class keyed on the line's **leading marker** (the intentional emoji prefix), not a
+    /// substring match anywhere — so a coaching tip that happens to contain "failed" isn't
+    /// mis-coloured as an error.
+    static func cssClass(for message: String) -> String {
+        let m = message.trimmingCharacters(in: .whitespaces)
+        if m.hasPrefix("💬") { return "say" }
+        if m.hasPrefix("👁") { return "see" }
+        if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
+        if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
+        let low = m.lowercased()
+        if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
         return ""
     }
 
-    private func esc(_ s: String) -> String {
+    static func esc(_ s: String) -> String {
         s.replacingOccurrences(of: "&", with: "&amp;")
          .replacingOccurrences(of: "<", with: "&lt;")
          .replacingOccurrences(of: ">", with: "&gt;")

--- a/Sources/JarvisCore/ActivityLog.swift
+++ b/Sources/JarvisCore/ActivityLog.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// Mirrors every `jlog` line into a self-contained, auto-refreshing HTML file so you can *watch*
+/// Jarvis think in a browser instead of tailing a flat file. Open it once:
+///
+///     open /tmp/jarvis-activity.html
+///
+/// The page reloads itself every second and scrolls to the newest line. No server, no dependencies
+/// — it works straight off `file://`. Path overridable via `JARVIS_ACTIVITY_HTML`.
+public final class ActivityLog: @unchecked Sendable {
+    public static let shared = ActivityLog()
+
+    private let path: String
+    private let maxLines = 400
+    private let queue = DispatchQueue(label: "jarvis.activitylog")   // serializes state + disk writes
+    private var lines: [(time: String, message: String)] = []
+    private let df: DateFormatter
+
+    private init() {
+        path = ProcessInfo.processInfo.environment["JARVIS_ACTIVITY_HTML"] ?? "/tmp/jarvis-activity.html"
+        df = DateFormatter()
+        df.dateFormat = "HH:mm:ss"
+    }
+
+    /// Where the live HTML page is written — open this in a browser.
+    public var htmlURL: URL { URL(fileURLWithPath: path) }
+
+    /// Clear the buffer and write a fresh page. Call at launch so each session starts clean
+    /// (the file exists before we open it in the browser — written synchronously).
+    public func reset() {
+        queue.sync {
+            lines.removeAll()
+            writeHTML()
+        }
+    }
+
+    /// Append a line and rewrite the HTML. Cheap and off the caller's thread.
+    public func record(_ message: String, at date: Date = Date()) {
+        queue.async { [self] in
+            lines.append((df.string(from: date), message))
+            if lines.count > maxLines { lines.removeFirst(lines.count - maxLines) }
+            writeHTML()
+        }
+    }
+
+    private func writeHTML() {
+        var rows = ""
+        for line in lines {
+            rows += "<div class=\"row \(cssClass(for: line.message))\">"
+            rows += "<span class=\"t\">\(esc(line.time))</span>"
+            rows += "<span class=\"m\">\(esc(line.message))</span></div>\n"
+        }
+        let html = """
+        <!doctype html><html lang="en"><head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="1">
+        <title>Jarvis Activity</title>
+        <style>
+          :root { color-scheme: dark; }
+          body { margin: 0; background: #0d1117; color: #c9d1d9;
+                 font: 13px/1.6 ui-monospace, SFMono-Regular, Menlo, monospace; }
+          header { position: sticky; top: 0; padding: 10px 16px; background: #161b22;
+                   border-bottom: 1px solid #30363d; font-weight: 600; }
+          header .count { color: #8b949e; font-weight: 400; }
+          main { padding: 8px 16px 40px; }
+          .row { display: flex; gap: 12px; padding: 1px 0; white-space: pre-wrap; }
+          .t { color: #6e7681; flex: 0 0 auto; }
+          .m { flex: 1 1 auto; }
+          .say .m  { color: #3fb950; }   /* spoke              */
+          .see .m  { color: #d29922; }   /* looked at screen   */
+          .hear .m { color: #58a6ff; }   /* heard you          */
+          .think .m{ color: #8b949e; }   /* thinking / silent  */
+          .err .m  { color: #f85149; }   /* error              */
+        </style></head><body>
+        <header>🟢 Jarvis — live activity <span class="count">(\(lines.count) lines)</span></header>
+        <main>\(rows)</main>
+        <script>window.scrollTo(0, document.body.scrollHeight);</script>
+        </body></html>
+        """
+        try? html.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    /// Map a line to a colour class by its leading marker / keywords.
+    private func cssClass(for message: String) -> String {
+        let m = message.lowercased()
+        if m.contains("error") || m.contains("failed") || m.contains("denied") { return "err" }
+        if message.contains("💬") { return "say" }
+        if message.contains("👁") { return "see" }
+        if message.contains("🗣") || message.contains("🤫") { return "hear" }
+        if message.contains("💭") || m.contains("stay") || m.contains("held back") { return "think" }
+        return ""
+    }
+
+    private func esc(_ s: String) -> String {
+        s.replacingOccurrences(of: "&", with: "&amp;")
+         .replacingOccurrences(of: "<", with: "&lt;")
+         .replacingOccurrences(of: ">", with: "&gt;")
+    }
+}

--- a/Sources/JarvisCore/CoachDriver.swift
+++ b/Sources/JarvisCore/CoachDriver.swift
@@ -56,7 +56,12 @@ public final class CoachDriver: @unchecked Sendable {
         guard beginHandling() else { return }   // one interjection at a time
         defer { endHandling() }
 
-        jlog(triggerLabel(reason))
+        // Stop may have cancelled this turn before it got the slot.
+        if Task.isCancelled { return }
+
+        // Turn-end already shows up as the "🗣 heard:" line from the transcriber; only the silence
+        // trigger needs its own marker.
+        if case .silence(let secs) = reason { jlog("🤫 quiet for \(Int(secs))s") }
 
         guard guardrails.allow() else {
             jlog("… held back (cooldown or rate cap)")
@@ -94,6 +99,9 @@ public final class CoachDriver: @unchecked Sendable {
                 return
             }
 
+            // If Stop fired during the (possibly slow) brain round-trip, don't act on the result.
+            if Task.isCancelled { return }
+
             // No tool call → stay silent.
             guard let call = response.toolCalls.first else {
                 jlog("… nothing useful to add, staying silent")
@@ -121,14 +129,6 @@ public final class CoachDriver: @unchecked Sendable {
                 onSpoke?()
                 return
             }
-        }
-    }
-
-    /// A short, human-readable marker for why the loop woke up — shown in the activity viewer.
-    private func triggerLabel(_ reason: TriggerReason) -> String {
-        switch reason {
-        case .turnEnd:               return "🗣 you finished a thought"
-        case .silence(let secs):     return "🤫 quiet for \(Int(secs))s"
         }
     }
 }

--- a/Sources/JarvisCore/CoachDriver.swift
+++ b/Sources/JarvisCore/CoachDriver.swift
@@ -56,7 +56,12 @@ public final class CoachDriver: @unchecked Sendable {
         guard beginHandling() else { return }   // one interjection at a time
         defer { endHandling() }
 
-        guard guardrails.allow() else { return }
+        jlog(triggerLabel(reason))
+
+        guard guardrails.allow() else {
+            jlog("… held back (cooldown or rate cap)")
+            return
+        }
 
         let now = clock.now()
         let ctx = TriggerContext(
@@ -75,6 +80,8 @@ public final class CoachDriver: @unchecked Sendable {
             """),
         ]
 
+        jlog("💭 thinking…")
+
         var iterations = 0
         while iterations < maxToolIterations {
             iterations += 1
@@ -88,10 +95,14 @@ public final class CoachDriver: @unchecked Sendable {
             }
 
             // No tool call → stay silent.
-            guard let call = response.toolCalls.first else { return }
+            guard let call = response.toolCalls.first else {
+                jlog("… nothing useful to add, staying silent")
+                return
+            }
 
             switch call {
             case .captureScreen(let callId):
+                jlog("👁 looking at your screen")
                 // Replay the model's function call, then the tool result + the screenshot image.
                 convo.append(.assistantToolCalls(response.rawToolCalls))
                 if let img = screen.capture() {
@@ -103,12 +114,21 @@ public final class CoachDriver: @unchecked Sendable {
                 continue // let the model reason over the image
 
             case .speak(_, let text):
+                jlog("💬 \(text)")
                 overlay.render(text, maxSentences: config.maxSentences,
                                perSentenceSeconds: config.sentenceDisplaySeconds)
                 guardrails.noteSpoke()
                 onSpoke?()
                 return
             }
+        }
+    }
+
+    /// A short, human-readable marker for why the loop woke up — shown in the activity viewer.
+    private func triggerLabel(_ reason: TriggerReason) -> String {
+        switch reason {
+        case .turnEnd:               return "🗣 you finished a thought"
+        case .silence(let secs):     return "🤫 quiet for \(Int(secs))s"
         }
     }
 }

--- a/Sources/JarvisCore/Log.swift
+++ b/Sources/JarvisCore/Log.swift
@@ -1,25 +1,53 @@
 import Foundation
 
-/// Lightweight logger: writes to the unified log (Console) AND appends to a file, so logs are
-/// readable no matter how the app is launched (LaunchServices `open` vs. direct exec). The file
-/// path can be overridden with the `JARVIS_LOG` env var; defaults to /tmp/jarvis-debug.log.
+/// Dev-only file logging config. By default `jlog` writes ONLY to the unified log (Console.app);
+/// no flat file is created. In dev mode the app calls `JarvisLog.enableFileLogging(directory:)`,
+/// after which `jlog` also appends to `<directory>/jarvis-debug.log` (created `0600`, truncated
+/// fresh for the session). This keeps screen-derived coaching text out of any world-readable or
+/// persistent file outside dev mode — see wiki/sandbox.md ("no recording to disk").
+public enum JarvisLog {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var directory: URL?   // guarded by `lock`
+
+    public static func enableFileLogging(directory dir: URL) {
+        lock.lock(); directory = dir; lock.unlock()
+        // Fresh, owner-only file for the session.
+        let url = dir.appendingPathComponent("jarvis-debug.log")
+        FileManager.default.createFile(atPath: url.path, contents: Data(),
+                                       attributes: [.posixPermissions: 0o600])
+    }
+
+    /// The debug-log file, or nil when file logging is disabled.
+    static var debugLogURL: URL? {
+        lock.lock(); let dir = directory; lock.unlock()
+        if let dir { return dir.appendingPathComponent("jarvis-debug.log") }
+        // Headless/test override.
+        if let p = ProcessInfo.processInfo.environment["JARVIS_LOG"] { return URL(fileURLWithPath: p) }
+        return nil
+    }
+}
+
+/// Lightweight logger: always writes to the unified log (Console) and mirrors into the dev activity
+/// viewer; additionally appends to the dev debug file when file logging is enabled.
 public func jlog(_ message: String) {
     NSLog("%@", message)
-    ActivityLog.shared.record(message)        // mirror into the live HTML viewer
-    let path = ProcessInfo.processInfo.environment["JARVIS_LOG"] ?? "/tmp/jarvis-debug.log"
-    let line = "\(Self_timestamp()) \(message)\n"
+    ActivityLog.shared.record(message)        // dev-only HTML viewer (no-op when disabled)
+
+    guard let url = JarvisLog.debugLogURL else { return }
+    let line = "\(logTimestamp()) \(message)\n"
     guard let data = line.data(using: .utf8) else { return }
-    let url = URL(fileURLWithPath: path)
     if let fh = try? FileHandle(forWritingTo: url) {
         defer { try? fh.close() }
         _ = try? fh.seekToEnd()
         try? fh.write(contentsOf: data)
     } else {
-        try? data.write(to: url)
+        // First write of the session (or after enable truncated it): create owner-only.
+        FileManager.default.createFile(atPath: url.path, contents: data,
+                                       attributes: [.posixPermissions: 0o600])
     }
 }
 
-private func Self_timestamp() -> String {
+private func logTimestamp() -> String {
     let f = DateFormatter()
     f.dateFormat = "HH:mm:ss.SSS"
     return f.string(from: Date())

--- a/Sources/JarvisCore/Log.swift
+++ b/Sources/JarvisCore/Log.swift
@@ -5,6 +5,7 @@ import Foundation
 /// path can be overridden with the `JARVIS_LOG` env var; defaults to /tmp/jarvis-debug.log.
 public func jlog(_ message: String) {
     NSLog("%@", message)
+    ActivityLog.shared.record(message)        // mirror into the live HTML viewer
     let path = ProcessInfo.processInfo.environment["JARVIS_LOG"] ?? "/tmp/jarvis-debug.log"
     let line = "\(Self_timestamp()) \(message)\n"
     guard let data = line.data(using: .utf8) else { return }

--- a/Tests/JarvisCoreTests/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/ActivityLogTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import JarvisCore
+
+@Suite struct ActivityLogTests {
+    @Test func escapesHtmlMetacharacters() {
+        #expect(ActivityLog.esc("a & b < c > d") == "a &amp; b &lt; c &gt; d")
+        // & must be escaped first so we don't double-escape the entities we just inserted.
+        #expect(ActivityLog.esc("<&>") == "&lt;&amp;&gt;")
+    }
+
+    @Test func cssClassKeysOnLeadingMarker() {
+        #expect(ActivityLog.cssClass(for: "💬 use a hash map") == "say")
+        #expect(ActivityLog.cssClass(for: "👁 looking at your screen") == "see")
+        #expect(ActivityLog.cssClass(for: "🗣 heard: \"hello\"") == "hear")
+        #expect(ActivityLog.cssClass(for: "🤫 quiet for 8s") == "hear")
+        #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
+        #expect(ActivityLog.cssClass(for: "… held back (cooldown or rate cap)") == "think")
+        #expect(ActivityLog.cssClass(for: "Jarvis realtime error event: oops") == "err")
+        #expect(ActivityLog.cssClass(for: "Jarvis: coaching started.") == "")
+    }
+
+    @Test func coachingTipContainingFailedIsNotMiscolouredAsError() {
+        // A spoken tip can legitimately contain the word "failed"; it must stay a 💬 say line.
+        #expect(ActivityLog.cssClass(for: "💬 your test failed because the loop is off-by-one") == "say")
+    }
+
+    @Test func renderHtmlEscapesContentAndCountsLines() {
+        let html = ActivityLog.renderHTML([
+            ("10:00:00", "💬 a < b & c"),
+            ("10:00:01", "🗣 heard: \"hi\""),
+        ])
+        #expect(html.contains("a &lt; b &amp; c"))     // content escaped
+        #expect(!html.contains("a < b & c"))           // raw content not present
+        #expect(html.contains("(2 lines)"))            // line count rendered
+        #expect(html.contains("class=\"row say\""))    // 💬 routed to say
+        #expect(html.contains("http-equiv=\"refresh\""))
+    }
+
+    @Test func enableWritesOwnerOnlyFileSynchronously() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jarvis-test-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let log = ActivityLog()                 // isolated instance, not the shared singleton
+        log.enable(directory: dir)
+
+        let url = try #require(log.htmlURL)
+        #expect(FileManager.default.fileExists(atPath: url.path))  // exists synchronously after enable()
+        let perms = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value == 0o600)     // owner-only, never world-readable
+    }
+
+    @Test func recordIsNoOpWhenDisabled() {
+        let log = ActivityLog()                 // never enabled, no env override
+        #expect(log.htmlURL == nil)
+        log.record("💬 should not crash or write anything")
+        #expect(log.htmlURL == nil)
+    }
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -32,4 +32,6 @@ fi
 codesign --verify --verbose "$APP"
 
 echo "✅ built $APP"
-echo "   run: open ./$APP   (or ./$APP/Contents/MacOS/$BIN_NAME for console logs)"
+echo "   run: open ./$APP        (always via 'open' — launching the bare binary makes macOS"
+echo "                            attribute Mic/Screen-Recording grants to the shell, not Jarvis)"
+echo "   dev: ./scripts/run-dev.sh   (dev mode + live activity viewer; logs to ./.jarvis/)"

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Dev run: (re)build the signed .app, then launch it in dev mode via LaunchServices.
+#
+# Launching with `open` (not the bare binary) is REQUIRED so macOS attributes the Microphone /
+# Screen Recording grants to Jarvis itself — running the executable from a terminal makes TCC
+# attribute them to the shell, which always looks "denied". `--args --dev` turns on the live
+# activity viewer, which auto-opens an HTML page in your browser for this session.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+./scripts/build-app.sh release
+
+# Replace any running instance so the new build (and a fresh session) takes over.
+pkill -f "Jarvis.app/Contents/MacOS/JarvisApp" 2>/dev/null || true
+sleep 1
+
+echo "▶ launching Jarvis (dev mode) — activity viewer will open in your browser"
+open ./Jarvis.app --args --dev

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -14,5 +14,9 @@ cd "$(dirname "$0")/.."
 pkill -f "Jarvis.app/Contents/MacOS/JarvisApp" 2>/dev/null || true
 sleep 1
 
-echo "▶ launching Jarvis (dev mode) — activity viewer will open in your browser"
-open ./Jarvis.app --args --dev
+# Logs go to a gitignored .jarvis/ in the workspace (owner-only, 0600, fresh each session) so the
+# model's screen-derived tips never land in world-readable /tmp or in git.
+LOGDIR="$PWD/.jarvis"
+mkdir -p "$LOGDIR"
+echo "▶ launching Jarvis (dev mode) — activity viewer will open in your browser; logs in $LOGDIR"
+open ./Jarvis.app --args --dev --log-dir "$LOGDIR"

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -70,7 +70,7 @@ moments the model judges worthwhile.
 | **CoachDriver** | The event loop. On triggers, enforce guardrails, call the brain with the transcript + timing context and tools, route tool calls. | `gpt-5.5` (vision + tool-use). |
 | **ScreenTool** | Fulfill `capture_screen`: take a silent screenshot of the active display, excluding the overlay window. | macOS `screencapture` CLI / ScreenCaptureKit. |
 | **Overlay** | Render `speak` output: ≤3 sentences, ~5s each, non-activating, always-on-top, excluded from capture. | AppKit NSPanel. |
-| **MenuBar** | On/off, mute, status indicator, one-time API-key entry. | AppKit menu-bar item; Keychain for the key. |
+| **MenuBar** | Manual **Start/Stop** of the pipeline (two states: ⚪️ stopped / 🟢 running — no auto-start), status indicator, one-time API-key entry. | AppKit menu-bar item; Keychain for the key. |
 
 Each component has one job and a narrow interface. The CoachDriver is the only place the
 "intelligence" lives, and even there the intelligence is the model — the driver just wires events
@@ -94,8 +94,9 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 
 - **App Sandbox** with only the entitlements it needs (screen recording, audio input), giving
   **no general filesystem access** — the hardened posture for a shippable build. *For the current
-  personal build this is relaxed:* the app is ad-hoc signed and unsandboxed, relying on macOS **TCC
-  prompts** for Screen Recording + Microphone. It can therefore technically read the user's files;
+  personal build this is relaxed:* the app is unsandboxed and signed with a stable self-signed
+  identity (`Jarvis Dev`, so grants persist), relying on macOS **TCC prompts** for Screen Recording
+  + Microphone. It can therefore technically read the user's files;
   that tradeoff is accepted for the personal tool. See [sandbox.md](./sandbox.md).
 - **API key in the Keychain**, never plaintext on disk.
 - **Built and run in the main `forrest` account inside a git worktree** (recoverability). The
@@ -103,8 +104,11 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 - **Egress is narrow and explicit:** audio to `gpt-4o-transcribe`; a screenshot + transcript window
   to `gpt-5.5` *only when the model triggers a capture/response*. No recording to disk in the MVP.
 - **Behavioral guardrails:** a cooldown after each utterance, a rate cap (max N interjections per
-  minute), a global mute hotkey, and a visible "listening" indicator. These directly counter the
-  central failure mode of a proactive agent — talking too much or at the wrong moment.
+  minute), and a visible "listening" indicator. The user also has a hard **Start/Stop** in the menu
+  bar — coaching never runs until explicitly started, and stopping tears the pipeline down entirely
+  (a stronger control than the earlier mute, which is no longer exposed in the menu; the latent mute
+  flag remains in `Guardrails`). These directly counter the central failure mode of a proactive
+  agent — talking too much or at the wrong moment.
 
 ## 6. Non-Goals (v1)
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -8,7 +8,9 @@
 
 Two layers below are **relaxed** for the personal build, by explicit decision:
 
-- **No App Sandbox.** The app is **ad-hoc signed and unsandboxed**; Screen Recording + Microphone
+- **No App Sandbox.** The app is **unsandboxed**, signed with a **stable self-signed identity
+  (`Jarvis Dev`)** — not ad-hoc, so TCC grants persist across rebuilds (see
+  [specification.md §9](./specification.md#9-build--run-constraints)). Screen Recording + Microphone
   are granted via **TCC prompts** at first run. Consequence: the app *could* read the user's files —
   accepted for a personal tool. (Hardened model: §1.)
 - **No separate account.** The build and the app run in the **main `forrest` account**, inside a
@@ -27,8 +29,8 @@ granted; everything else is denied by default.
 
 ### 1. App Sandbox (OS-enforced) — *hardened model; relaxed in the current build*
 
-> **Current build:** App Sandbox is **off**; the app is ad-hoc signed and relies on TCC prompts.
-> The description below is the target for a shippable version.
+> **Current build:** App Sandbox is **off**; the app is signed with a stable self-signed identity
+> (`Jarvis Dev`) and relies on TCC prompts. The description below is the target for a shippable version.
 
 The app ships with the macOS App Sandbox enabled and requests **only** the entitlements it needs:
 
@@ -80,7 +82,9 @@ database. Temp screenshots are deleted after use.
 
 - **Cooldown** between spoken responses.
 - **Rate cap** (max interjections per minute).
-- **Global mute** hotkey.
+- **Manual Start/Stop** in the menu bar — coaching never runs until started, and Stop tears the
+  pipeline down entirely (replaces the earlier user-facing mute; the latent mute flag remains in
+  `Guardrails` but is no longer exposed in the menu).
 - **Visible "listening" indicator** — the user always knows when Jarvis is active (also a consent cue).
 - **Session counter** of tokens/calls in the menu bar, so runaway behavior is visible immediately.
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -76,7 +76,18 @@ Narrow and explicit. Data leaves the machine only via:
   `capture_screen` and/or a coaching turn. No screen content leaves the machine on idle turns.
 
 In the MVP there is **no recording to disk** — no rolling screen/audio archive, no "recall"
-database. Temp screenshots are deleted after use.
+database. Temp screenshots are deleted after use. This guarantee covers the **sensitive captured
+streams** (mic audio, screenshots, and the transcript derived from them): audio streams to the API
+and is dropped, the transcript lives in memory, and nothing is persisted in normal operation.
+
+**Dev-mode logging is the one bounded exception, and it is hardened to not break the guarantee.**
+File logging (the activity HTML + `jarvis-debug.log`, which include the model's spoken tips and the
+transcribed "heard:" lines) is written **only when the `--dev` flag is set** — normal launches log
+solely to the unified log, never a flat file. When on, the files go to the `--log-dir` (a
+**gitignored `.jarvis/` in the workspace**, or a per-user `Caches/Jarvis`) with **`0600`** owner-only
+permissions, **truncated fresh each session** — never `/tmp` (which is world-readable and shared
+across user accounts). So even the dev affordance produces no world-readable or persistent record.
+See [specification.md §9](./specification.md#9-build--run-constraints).
 
 ## Behavioral Guardrails (anti-annoyance = anti-misbehavior)
 
@@ -86,7 +97,7 @@ database. Temp screenshots are deleted after use.
   pipeline down entirely (replaces the earlier user-facing mute; the latent mute flag remains in
   `Guardrails` but is no longer exposed in the menu).
 - **Visible "listening" indicator** — the user always knows when Jarvis is active (also a consent cue).
-- **Session counter** of tokens/calls in the menu bar, so runaway behavior is visible immediately.
+- **Session interjection counter** in the menu bar (reset on each Start), so runaway behavior is visible immediately.
 
 ## Consent Note
 

--- a/wiki/specification.md
+++ b/wiki/specification.md
@@ -174,8 +174,9 @@ do speak, call the speak tool with at most 3 short sentences.
 > [migrate-to-responses](https://developers.openai.com/api/docs/guides/migrate-to-responses).
 
 API key is read from the **Keychain**, entered via the menu bar ("Set OpenAI API Key…"), which
-saves it locally and starts coaching immediately (no relaunch). An `OPENAI_API_KEY` env var is a
-headless fallback. Never stored in plaintext or committed.
+saves it locally. Jarvis does **not** auto-start — the user presses **Start Jarvis** in the menu
+bar to begin (and **Stop Jarvis** to halt); the menu bar shows two states only, ⚪️ stopped and
+🟢 running. An `OPENAI_API_KEY` env var is a headless fallback. Never stored in plaintext or committed.
 
 ## 6. Audio Sources
 
@@ -215,7 +216,7 @@ The build agent must produce and run these. (See the development goal: the agent
    `capture_screen`.
 4. `capture_screen` returns a valid image and the overlay window is absent from it.
 5. Guardrails hold: rapid triggers do not produce more than `maxInterjectionsPerMinute` responses;
-   mute silences output.
+   **Stop Jarvis** halts the pipeline entirely.
 
 **Guardrail / cost guard:** a session token-and-call counter surfaced in the menu bar, so runaway
 behavior is visible.
@@ -230,10 +231,42 @@ behavior is visible.
   compiles and runs with `swiftc`. Build with `swift build`.
 - **Packaging:** the executable is assembled into a `.app` bundle by hand — a minimal
   `Contents/MacOS/<bin>` + `Contents/Info.plist` carrying `NSMicrophoneUsageDescription` and the
-  bundle identifier — and **ad-hoc signed** with `codesign -s - --deep`. A build script does this.
+  stable bundle identifier `com.jarvis.coach`. `scripts/build-app.sh` does this.
+- **Signing for permission persistence.** The bundle is signed with a **stable self-signed identity
+  (`Jarvis Dev`)**, created once by `scripts/make-signing-identity.sh`, *not* ad-hoc. This is the
+  crux of permission persistence: macOS TCC keys a grant to the code signature + bundle id + bundle
+  path, so an ad-hoc signature (which changes every build) makes macOS forget Microphone/Screen
+  Recording and re-prompt on each rebuild. With the stable identity, **grants persist across
+  rebuilds and relaunches.** If the identity is missing, `build-app.sh` falls back to ad-hoc and
+  prints a warning — grants will reset each build until you run the identity script once.
 - **Permissions: TCC prompts, not entitlements.** Screen Recording and Microphone are granted by
-  the OS on first use (no App-Sandbox entitlement file). The app must be a signed `.app` bundle for
-  the grants to attach and persist.
+  the OS on first use (no App-Sandbox entitlement file). `Permissions.primeAll()` requests them at
+  launch and is **idempotent**: once a permission is `authorized` it only logs and never re-prompts,
+  and Start/Stop never touches permissions. Persistence holds as long as three things stay fixed:
+  the **stable signing identity**, the **bundle id** (`com.jarvis.coach`), and the **bundle path**
+  (moving `Jarvis.app` re-prompts). Recover a stale *denied* state — which macOS won't re-prompt for
+  — with `tccutil reset Microphone com.jarvis.coach` (or `ScreenCapture`), then relaunch and Allow.
 - **Account:** built in the main `forrest` account inside a **git worktree** (the restricted-account
   requirement is waived for the personal build — see [sandbox.md](./sandbox.md)).
+- **Always launch with `open ./Jarvis.app`**, never the bare binary. Running the executable from a
+  terminal makes TCC attribute the grants to the shell, so the app reports Microphone/Screen
+  Recording as "denied" even when they're granted. To pass flags, use `open ./Jarvis.app --args …`.
 - Target: a working MVP in **< 2 days of autonomous Claude Code build**.
+
+### Dev mode — live activity viewer
+
+For watching Jarvis reason during development, a **dev mode** is enabled by the launch flag
+`--dev` (`scripts/run-dev.sh` rebuilds and launches with it via `open ./Jarvis.app --args --dev`).
+In dev mode the app writes a **self-contained, auto-refreshing HTML page** and opens it in the
+default browser for the session:
+
+- `ActivityLog` (in `JarvisCore`) mirrors **every `jlog` line** into the page — so lifecycle,
+  errors, realtime-socket events, and the coach's per-turn decisions all appear with no extra
+  wiring. The page reloads every second (`<meta http-equiv="refresh">`), color-codes events, and
+  scrolls to the newest line. No server — it works straight off `file://`.
+- The `CoachDriver` emits human-readable decision markers the viewer keys on: 🗣 turn-end / 🤫
+  silence (why it woke), 💭 thinking, 👁 `capture_screen`, 💬 the spoken tip, and `… staying
+  silent` / `… held back` when it declines.
+- Output path defaults to `/tmp/jarvis-activity.html`, overridable with `JARVIS_ACTIVITY_HTML`;
+  it's reset fresh at the start of each dev session. The viewer is **dev-only** — normal launches
+  don't open it (though `ActivityLog` still maintains the file).

--- a/wiki/specification.md
+++ b/wiki/specification.md
@@ -200,7 +200,8 @@ The build agent must produce and run these. (See the development goal: the agent
 
 **Unit tests (pure logic, run anywhere):**
 - CoachDriver guardrails: cooldown suppresses a second response inside the window; rate cap blocks
-  the (N+1)th interjection in a minute; mute suppresses all output.
+  the (N+1)th interjection in a minute; the latent mute flag (still in `Guardrails`, not exposed in
+  the menu) suppresses all output.
 - Overlay formatting: a 5-sentence input renders exactly 3 sentences; sentence splitting is correct.
 
 **Offline pipeline test (mock OpenAI client, run anywhere):**
@@ -218,8 +219,8 @@ The build agent must produce and run these. (See the development goal: the agent
 5. Guardrails hold: rapid triggers do not produce more than `maxInterjectionsPerMinute` responses;
    **Stop Jarvis** halts the pipeline entirely.
 
-**Guardrail / cost guard:** a session token-and-call counter surfaced in the menu bar, so runaway
-behavior is visible.
+**Guardrail / cost guard:** a session **interjection** counter surfaced in the menu bar (reset on
+each Start), so runaway behavior is visible.
 
 ## 9. Build & Run Constraints
 
@@ -256,17 +257,22 @@ behavior is visible.
 ### Dev mode — live activity viewer
 
 For watching Jarvis reason during development, a **dev mode** is enabled by the launch flag
-`--dev` (`scripts/run-dev.sh` rebuilds and launches with it via `open ./Jarvis.app --args --dev`).
-In dev mode the app writes a **self-contained, auto-refreshing HTML page** and opens it in the
-default browser for the session:
+`--dev` (`scripts/run-dev.sh` rebuilds and launches via `open ./Jarvis.app --args --dev --log-dir
+"$PWD/.jarvis"`). In dev mode the app writes a **self-contained, auto-refreshing HTML page** and
+opens it in the default browser for the session:
 
 - `ActivityLog` (in `JarvisCore`) mirrors **every `jlog` line** into the page — so lifecycle,
   errors, realtime-socket events, and the coach's per-turn decisions all appear with no extra
   wiring. The page reloads every second (`<meta http-equiv="refresh">`), color-codes events, and
-  scrolls to the newest line. No server — it works straight off `file://`.
-- The `CoachDriver` emits human-readable decision markers the viewer keys on: 🗣 turn-end / 🤫
-  silence (why it woke), 💭 thinking, 👁 `capture_screen`, 💬 the spoken tip, and `… staying
-  silent` / `… held back` when it declines.
-- Output path defaults to `/tmp/jarvis-activity.html`, overridable with `JARVIS_ACTIVITY_HTML`;
-  it's reset fresh at the start of each dev session. The viewer is **dev-only** — normal launches
-  don't open it (though `ActivityLog` still maintains the file).
+  keeps your scroll position unless you're pinned to the bottom. No server — it works off `file://`.
+- The viewer keys on human-readable markers: 🗣 `heard: "…"` (your transcribed speech, logged by
+  the transcriber) / 🤫 silence (why it woke), 💭 thinking, 👁 `capture_screen`, 💬 the spoken tip,
+  and `… staying silent` / `… held back` when the coach declines.
+- **Privacy posture (important).** File logging is **off unless dev mode is on** — outside dev mode
+  `jlog` writes only to the unified log (Console.app), never a flat file. In dev mode the activity
+  HTML *and* `jarvis-debug.log` are written to the `--log-dir` (default per-user `Caches/Jarvis`;
+  `run-dev.sh` points it at a **gitignored `.jarvis/` in the workspace**) with **`0600`** (owner-only)
+  permissions, truncated fresh each session. Never `/tmp` (world-readable, shared across users).
+  Env overrides `JARVIS_LOG` / `JARVIS_ACTIVITY_HTML` exist for headless/test use. This keeps the
+  model's screen-derived tips out of any world-readable or persistent location — see
+  [sandbox.md](./sandbox.md).

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -6,8 +6,8 @@
 
 **Build complete (headless) — awaiting the live smoke run.** Phase 1 was **skipped** (2026-06-14)
 and the native Swift app was built directly per [plan-phase2-build.md](./plan-phase2-build.md). The
-tested harness (config, transcript, guardrails, coach tool-loop, OpenAI client) is **green: 26
-tests pass**; the signed `Jarvis.app` builds, ad-hoc signs, and launches. The app shell, overlay,
+tested harness (config, transcript, guardrails, coach tool-loop, OpenAI client) is **green: 30
+tests pass**; `Jarvis.app` builds, signs with the stable `Jarvis Dev` identity, and launches. The app shell, overlay,
 mic capture, and realtime transcriber **compile and launch** but their *live* behavior (real mic,
 websocket, TCC grants, real `OPENAI_API_KEY`, real model IDs) is verified only by the human smoke
 checklist in [specification.md §8](./specification.md#8-self-verification-plan) / the
@@ -27,8 +27,9 @@ checklist in [specification.md §8](./specification.md#8-self-verification-plan)
   best behavior reference), but Natively is now at most a reference, not a base.
 - **Toolchain:** **SwiftPM + the Command Line Tools**, *no full Xcode required* — the CLT SDK ships
   ScreenCaptureKit, AVFoundation, AppKit, SwiftUI, Vision, CoreAudio. The app is packaged into a
-  `.app` bundle by hand and **ad-hoc signed** (`codesign -s -`); macOS **TCC prompts** grant Screen
-  Recording + Microphone at first run (in place of formal App-Sandbox entitlements). See
+  `.app` bundle by hand and signed with a **stable self-signed identity** (`Jarvis Dev`, so TCC
+  grants persist across rebuilds); macOS **TCC prompts** grant Screen Recording + Microphone at first
+  run (in place of formal App-Sandbox entitlements). See
   [specification.md](./specification.md#9-build--run-constraints).
 - **Where it's built:** on the MacBook, in the **main `forrest` account**, inside a **git worktree**
   for recoverability. The earlier HARD REQUIREMENT to build in a separate restricted account is
@@ -53,7 +54,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **System audio in the MVP** (budget-permitting; mic is the critical path) | [specification.md](./specification.md) |
 | ~~Two-phase build~~ → **Skip Phase 1; build native Swift directly** (2026-06-14) | this page; [fork-evaluation.md](./fork-evaluation.md) |
 | **Native Swift app** (cleanest sandbox/footprint on macOS) | [architecture.md](./architecture.md), [fork-evaluation.md](./fork-evaluation.md) |
-| **Toolchain: SwiftPM + Command Line Tools** (no full Xcode; manual bundle + ad-hoc sign; TCC prompts) | [specification.md](./specification.md#9-build--run-constraints) |
+| **Toolchain: SwiftPM + Command Line Tools** (no full Xcode; manual bundle + stable self-signed `Jarvis Dev` identity so TCC grants persist; TCC prompts) | [specification.md](./specification.md#9-build--run-constraints) |
 | ~~Build in a separate restricted account (HARD)~~ → **build in main `forrest` account, in a git worktree; hard requirement waived for the personal build** (2026-06-14) | [sandbox.md](./sandbox.md) |
 
 ## Open Questions / To Confirm
@@ -67,21 +68,28 @@ A compact log — the *rationale* for each lives in the linked design page, not 
   threatened. See [specification.md](./specification.md#6-audio-sources).
 - Minimum macOS version target. Build host is macOS 26.5; ScreenCaptureKit screen+audio capture
   needs macOS 13+. Target **macOS 14+** unless a needed API forces higher.
-- Whether ad-hoc signing lets the TCC Screen-Recording/Microphone grants *persist* across rebuilds
-  (a stable bundle path + signature usually suffices; confirm on the live smoke run).
+- ~~Whether ad-hoc signing lets the TCC Screen-Recording/Microphone grants *persist* across
+  rebuilds~~ **Resolved (2026-06-14):** ad-hoc signing does *not* — it changes identity each build,
+  so macOS re-prompts. The fix shipped: build with a **stable self-signed identity (`Jarvis Dev`,
+  via `scripts/make-signing-identity.sh`)** + the fixed bundle id `com.jarvis.coach`. Grants then
+  persist across rebuilds/relaunches as long as the `.app` path doesn't move. See
+  [specification.md §9](./specification.md#9-build--run-constraints).
 
 ## Next Action
 
 The headless build is done ([plan-phase2-build.md](./plan-phase2-build.md) Tasks 0–14 complete).
 Remaining is the **human smoke run** — build, run, and validate live:
 
-1. `./scripts/build-app.sh release` → `open ./Jarvis.app`; grant Microphone + Screen Recording.
-2. Paste your OpenAI key via the menu bar ("Set OpenAI API Key…") — it saves to the Keychain and
-   starts coaching immediately. Model IDs are doc-verified; no edit expected.
+1. `./scripts/build-app.sh release` → `open ./Jarvis.app`; grant Microphone + Screen Recording
+   (one-time; they persist afterward — see [specification.md §9](./specification.md#9-build--run-constraints)).
+2. Paste your OpenAI key via the menu bar ("Set OpenAI API Key…") — it saves to the Keychain. Jarvis
+   does **not** auto-start; press **Start Jarvis** in the menu to begin (⚪️ stopped → 🟢 running),
+   **Stop Jarvis** to halt. Model IDs are doc-verified; no edit expected.
 3. Run the **live smoke checklist** ([README](../README.md#live-smoke-checklist-what-to-verify-by-hand)
    / [specification.md §8](./specification.md#8-self-verification-plan)): speak → transcript;
    "I'm stuck on two-sum" → coaching overlay + observed `capture_screen`; overlay excluded from the
-   screenshot; rate cap + mute hold.
+   screenshot; rate cap holds and **Stop Jarvis** halts the pipeline. (Run via `./scripts/run-dev.sh`
+   to watch each step in the live activity viewer.)
 4. **Only remaining live unknown:** the GA Realtime transcription-session wiring in
    `Sources/JarvisApp/RealtimeTranscriber.swift` — the config/events follow current docs, but the
    bare-WebSocket connect for a transcription-only session is the one thing untested headlessly. If

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -6,7 +6,7 @@
 
 **Build complete (headless) — awaiting the live smoke run.** Phase 1 was **skipped** (2026-06-14)
 and the native Swift app was built directly per [plan-phase2-build.md](./plan-phase2-build.md). The
-tested harness (config, transcript, guardrails, coach tool-loop, OpenAI client) is **green: 30
+tested harness (config, transcript, guardrails, coach tool-loop, OpenAI client, activity log) is **green: 36
 tests pass**; `Jarvis.app` builds, signs with the stable `Jarvis Dev` identity, and launches. The app shell, overlay,
 mic capture, and realtime transcriber **compile and launch** but their *live* behavior (real mic,
 websocket, TCC grants, real `OPENAI_API_KEY`, real model IDs) is verified only by the human smoke


### PR DESCRIPTION
## What & why

Active-development changes to make Jarvis testable by hand:

### Menu / lifecycle
- **Manual Start/Stop** in the menu bar; **Jarvis no longer auto-starts**. Pasting an API key stores it but does not begin coaching.
- Menu reduced to **two states**: ⚪️ stopped / 🟢 running. The user-facing **Mute** item is removed (the latent mute flag remains in `Guardrails` core).
- `AppDelegate` split into `start()` / `stop()` that build and tear down the audio + transcriber pipeline. Start cancels in-flight turns and reflects real connection state in the menu.

### Dev-mode live activity viewer
- New `JarvisCore/ActivityLog` mirrors **every `jlog` line** into a self-contained, auto-refreshing HTML page — watch Jarvis think in a browser without tailing a file.
- `CoachDriver`/transcriber log the decisions: 🗣 `heard: "…"` (your transcribed speech) · 🤫 silence · 💭 thinking · 👁 `capture_screen` · 💬 spoke · `… stayed silent`.
- Dev mode via the `--dev` launch flag; `scripts/run-dev.sh` rebuilds and launches via `open --args --dev --log-dir ./.jarvis`, auto-opening the viewer.
- **Logging is dev-only and owner-only:** outside `--dev`, only the unified log (no flat file); in dev, files are `0600`, truncated per session, in a **gitignored `.jarvis/`** — never world-readable `/tmp`.

### Docs
- Document the dev-mode viewer + privacy posture in README + `wiki/specification.md` + `wiki/sandbox.md`.
- Fix drift: ad-hoc → **stable `Jarvis Dev` signing identity** (permission persistence), no-auto-start + Start/Stop, mute removal, launch-via-`open` caveat, interjection counter (not "tokens/calls"), and the 26 → 36 test count.

## Verification
- `./scripts/run-tests.sh` → **36 tests pass** (incl. new `ActivityLogTests`).
- Built + stable-signed `Jarvis.app`; launched via `open`, confirmed permissions persist and the activity viewer streams live.
- Note: the no-key alert, menu state transitions, and the viewer's transcript line are verified by build + reasoning — still to be eyeballed in a live `run-dev.sh` smoke run.

## Review

This branch was reviewed from multiple angles via a multi-agent workflow (**27 confirmed / 4 refuted**); all confirmed findings are **addressed** in commit `881d6bc` — see the [resolution comment](https://github.com/JINGBANZ/jarvis/pull/4#issuecomment-4701883958) for the per-cluster breakdown:

- **Security:** dev-only, `0600`, gitignored-workspace logging (was world-readable `/tmp`, always-on).
- **Lifecycle:** `setRunning` wired so 🟢 can't lie; `URLSession` invalidated (retain-leak fix).
- **Stop:** cancels in-flight turns so it can't speak after Stop.
- **UX:** no-key alert, transcript shown in viewer, key-save confirmation, counter reset, scroll preserved.
- **Cleanups / docs / tests:** dead code removed, doc overclaims fixed, `ActivityLogTests` added.

Refuted findings (left as-is): driver force-unwrap crash, architecture "mute?" framing, "latent mute flag is dead", `esc()` XSS framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)