### PR TITLE
Add test-only CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+# Test-only CI: compiles and runs the JarvisCore test suite. It deliberately does NOT build or sign
+# the .app bundle — a CI runner can't grant the interactive TCC permissions (Microphone, Screen
+# Recording) or exercise the live capture pipeline, so a bundled artifact would carry no extra
+# signal. Bundling/signing stays a local step (scripts/build-app.sh).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs on the same ref so a quick succession of pushes doesn't pile up.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show toolchain
+        run: swift --version
+
+      - name: Run tests
+        run: ./scripts/run-tests.sh

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-# swift-testing ships with the Command Line Tools but is not on the default search path.
-FW=/Library/Developer/CommandLineTools/Library/Developer/Frameworks
-IOP=/Library/Developer/CommandLineTools/Library/Developer/usr/lib
-exec swift test \
-  -Xswiftc -F -Xswiftc "$FW" \
-  -Xlinker -F -Xlinker "$FW" \
-  -Xlinker -rpath -Xlinker "$FW" \
-  -Xlinker -rpath -Xlinker "$IOP" \
-  "$@"
+
+# On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
+# search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's
+# already on the toolchain path, so plain `swift test` works — detect which toolchain is active.
+if [ "$(xcode-select -p 2>/dev/null)" = "/Library/Developer/CommandLineTools" ]; then
+  FW=/Library/Developer/CommandLineTools/Library/Developer/Frameworks
+  IOP=/Library/Developer/CommandLineTools/Library/Developer/usr/lib
+  exec swift test \
+    -Xswiftc -F -Xswiftc "$FW" \
+    -Xlinker -F -Xlinker "$FW" \
+    -Xlinker -rpath -Xlinker "$FW" \
+    -Xlinker -rpath -Xlinker "$IOP" \
+    "$@"
+else
+  exec swift test "$@"
+fi


### PR DESCRIPTION
Adds a minimal GitHub Actions workflow that runs the test suite on every PR and push to `main`.

## What

- **`.github/workflows/ci.yml`** — checks out, prints the toolchain, and runs `./scripts/run-tests.sh` on a `macos-15` runner. Concurrency-cancels superseded runs on the same ref.
- **`scripts/run-tests.sh` made portable** — it now only adds the Command-Line-Tools swift-testing search paths when the *active* toolchain is CLT (`xcode-select -p`). On the CLT-only Mac it behaves exactly as before; on an Xcode-based CI runner it falls through to plain `swift test`. One script, both environments.

## Deliberately test-only (no bundle build)

Per the discussion: a CI runner can't grant the interactive TCC permissions (Microphone, Screen Recording) or exercise the live capture pipeline, so a CI-built `.app` would carry no extra signal over `swift build`/`swift test`. Bundling + signing stays a local step (`scripts/build-app.sh`). If a downloadable/notarized release ever becomes a goal, that's when a bundle+notarize job earns its place.

## Verification

- `./scripts/run-tests.sh` runs green locally — **36 tests in 10 suites pass** — with the portability change.

## Note

Independent of #5 (README + script cleanup) — disjoint files, so the two can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)