### PR TITLE
Overlay screen-capture invisibility: harden, verify, add regression tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,13 +6,20 @@ let package = Package(
     platforms: [.macOS(.v14)],
     targets: [
         .target(name: "JarvisCore"),
+        // The AppKit overlay lives in its own library target (not the executable) so it can be
+        // imported by tests — see Tests/JarvisOverlayTests for the screen-capture invisibility checks.
+        .target(name: "JarvisOverlay", dependencies: ["JarvisCore"]),
         .executableTarget(
             name: "JarvisApp",
-            dependencies: ["JarvisCore"]
+            dependencies: ["JarvisCore", "JarvisOverlay"]
         ),
         .testTarget(
             name: "JarvisCoreTests",
             dependencies: ["JarvisCore"]
+        ),
+        .testTarget(
+            name: "JarvisOverlayTests",
+            dependencies: ["JarvisOverlay"]
         ),
     ]
 )

--- a/Sources/JarvisApp/AppDelegate.swift
+++ b/Sources/JarvisApp/AppDelegate.swift
@@ -1,5 +1,6 @@
 import AppKit
 import JarvisCore
+import JarvisOverlay
 
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {

--- a/Sources/JarvisCore/ScreenCapture.swift
+++ b/Sources/JarvisCore/ScreenCapture.swift
@@ -6,8 +6,9 @@ public protocol ScreenCapturing: Sendable {
 }
 
 /// Uses the built-in `screencapture -x -t jpg` (silent). The main display only.
-/// NOTE: excluding Jarvis's own overlay window is handled by the overlay being a
-/// non-capturable panel (sharingType .none) in JarvisApp; see OverlayPanel.
+/// NOTE: excluding Jarvis's own overlay window is handled by the overlay being a non-capturable
+/// panel (sharingType = .none) in JarvisApp; see OverlayPanel and wiki/overlay-invisibility.md
+/// (verified: the overlay never appears in this CLI's output on macOS 26.5).
 public struct ScreenCaptureCLI: ScreenCapturing {
     public init() {}
 

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -2,14 +2,18 @@ import AppKit
 import JarvisCore
 
 /// A non-activating, always-on-top panel that shows coaching sentences one at a time and is
-/// excluded from screen capture (so the model never sees Jarvis's own output).
+/// excluded from screen capture — both so Jarvis's own brain never sees its output and so the
+/// overlay stays invisible in anyone else's screen share or recording (Zoom/Meet/Teams/QuickTime).
+/// See `init` and wiki/overlay-invisibility.md.
 @MainActor
-final class OverlayPanel: NSObject, OverlayRendering {
+public final class OverlayPanel: NSObject, OverlayRendering {
     private let panel: NSPanel
     private let label: NSTextField
     private var hideWorkItem: DispatchWorkItem?
+    /// Test hook (internal): counts how many times `show()` has re-asserted capture exclusion.
+    private(set) var captureExclusionReassertCount = 0
 
-    override init() {
+    public override init() {
         panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 520, height: 80),
                         styleMask: [.nonactivatingPanel, .borderless],
                         backing: .buffered, defer: false)
@@ -21,7 +25,13 @@ final class OverlayPanel: NSObject, OverlayRendering {
         panel.hasShadow = true
         panel.ignoresMouseEvents = true
         panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
-        // Exclude from screen capture so capture_screen never sees the overlay.
+        // Exclude from ALL screen capture. This one flag does double duty: it keeps the overlay out
+        // of Jarvis's own `capture_screen` shots (so the brain never reads its own output) AND hides
+        // it from anyone else's screen share or recording. It is the same OS mechanism every
+        // comparable tool uses (Electron's setContentProtection / Tauri's contentProtected both map
+        // to it); there is no other public API. Verified on macOS 26.5 across the screencapture CLI,
+        // SCScreenshotManager, and a live SCStream. Re-asserted in show(). See
+        // wiki/overlay-invisibility.md.
         panel.sharingType = .none
 
         label = NSTextField(wrappingLabelWithString: "")
@@ -52,13 +62,19 @@ final class OverlayPanel: NSObject, OverlayRendering {
     }
 
     /// OverlayRendering witness — nonisolated so it satisfies the protocol; hops to the main actor.
-    nonisolated func render(_ text: String, maxSentences: Int, perSentenceSeconds: TimeInterval) {
+    public nonisolated func render(_ text: String, maxSentences: Int, perSentenceSeconds: TimeInterval) {
         let sentences = splitIntoSentences(text, maxSentences: maxSentences)
         guard !sentences.isEmpty else { return }
         Task { @MainActor in self.show(sentences, each: perSentenceSeconds) }
     }
 
     private func show(_ sentences: [String], each: TimeInterval) {
+        // Re-assert capture exclusion on every display: an NSApp activation-policy flip (e.g. the
+        // API-key dialog in MenuBarController.setKey) can make WindowServer drop sharingType on some
+        // macOS versions/configs. Cheap insurance against a silent, high-impact regression — the
+        // overlay becoming visible to a screen share with no signal. See wiki/overlay-invisibility.md.
+        panel.sharingType = .none
+        captureExclusionReassertCount += 1
         hideWorkItem?.cancel()
         var idx = 0
         func next() {
@@ -74,4 +90,9 @@ final class OverlayPanel: NSObject, OverlayRendering {
     }
 
     private func hide() { panel.orderOut(nil) }
+
+    // MARK: - Test hooks (internal; reached via `@testable import JarvisOverlay`)
+
+    /// The panel's current capture-sharing type. `.none` means excluded from screen capture.
+    var currentSharingType: NSWindow.SharingType { panel.sharingType }
 }

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -1,6 +1,9 @@
 import Testing
 import AppKit
-import ScreenCaptureKit
+// @preconcurrency: on the Xcode toolchain (used by CI) ScreenCaptureKit's async results are
+// non-Sendable and would otherwise error when crossing back to the @MainActor helper. The CLT
+// toolchain is laxer; this keeps both green.
+@preconcurrency import ScreenCaptureKit
 @testable import JarvisOverlay
 
 /// Regression tests for the overlay's screen-capture invisibility (see wiki/overlay-invisibility.md).

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -17,10 +17,12 @@ import AppKit
 ///      Needs a GUI session + Screen Recording permission, which CI can't grant, so it is opt-in:
 ///      run with `JARVIS_RUN_CAPTURE_TESTS=1 ./scripts/run-tests.sh`. Otherwise it returns early.
 ///
-/// Note: the bundled swift-testing toolchain miscompiles `@MainActor` + `async` `@Test`
-/// ("global variable must be a compile-time constant to use @section"), and XCTest isn't available on
-/// a Command-Line-Tools-only install. So the async tests are nonisolated `@Test`s that `await` a
-/// `@MainActor` helper, which keeps the AppKit work on the main actor while sidestepping the bug.
+/// Note: only the `@MainActor` + `async` `@Test` *combination* miscompiles on the bundled
+/// swift-testing toolchain ("global variable must be a compile-time constant to use @section"); a
+/// synchronous `@MainActor @Test` (like `overlaySetsCaptureExclusionAtInit` below) is fine. And
+/// XCTest isn't available on a Command-Line-Tools-only install. So the *async* tests are nonisolated
+/// `@Test`s that `await` a `@MainActor` helper — keeping the AppKit work on the main actor while
+/// sidestepping the bug.
 @Suite struct OverlayInvisibilityTests {
 
     @MainActor @Test
@@ -34,11 +36,11 @@ import AppKit
         await checkReassertOnShow()
     }
 
-    @Test
+    // Condition trait so opting out reports as *skipped* (not a green pass) — important for a
+    // security-adjacent test where "skipped" and "passed" must be distinguishable.
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1",
+                   "opt-in: set JARVIS_RUN_CAPTURE_TESTS=1 and grant Screen Recording to run the live capture test"))
     func protectedWindowIsExcludedFromScreenCaptureKit() async {
-        guard ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1" else {
-            return   // not opted in — skip silently (see the suite doc comment for how to run it)
-        }
         await checkScreenCaptureKitExclusion()
     }
 }
@@ -93,6 +95,8 @@ private func checkScreenCaptureKitExclusion() async {
         cfg.height = display.height
         let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
 
+        // tolerance 40 deliberately wide: the capture round-trips through the display profile
+        // (sRGB fill → deviceRGB scan), so exact RGB drifts. Don't tighten it without re-checking.
         let counts = countMatchingPixels(image, targets: [protectedColor, controlColor], tolerance: 40, step: 3)
         let protectedCount = counts[0]
         let controlCount = counts[1]
@@ -101,8 +105,9 @@ private func checkScreenCaptureKitExclusion() async {
         #expect(controlCount > 500,
                 "control window not found in capture (\(controlCount) px) — capture or display mapping is wrong")
         // The real assertion: the .none window must be essentially absent. A leak would produce a
-        // pixel count comparable to the control (same size); exclusion produces ~0.
-        #expect(protectedCount * 20 < controlCount,
+        // pixel count comparable to the control (same size); exclusion produces ~0. Phrased as
+        // "control dominates" (control is >20x protected, i.e. protected is <5%).
+        #expect(controlCount > protectedCount * 20,
                 "sharingType=.none window LEAKED into ScreenCaptureKit (protected=\(protectedCount) px, control=\(controlCount) px) — the overlay would be visible in a screen share")
     } catch {
         Issue.record("ScreenCaptureKit capture failed: \(error)")

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -1,0 +1,162 @@
+import Testing
+import AppKit
+import ScreenCaptureKit
+@testable import JarvisOverlay
+
+/// Regression tests for the overlay's screen-capture invisibility (see wiki/overlay-invisibility.md).
+///
+/// Two layers:
+///   1. Fast property tests — verify `OverlayPanel` sets `sharingType = .none` and *re-asserts* it on
+///      `render()`. No screen-recording permission needed, so they run everywhere (including CI) and
+///      catch the most likely regression: the flag being removed or the re-assert deleted.
+///   2. On-screen capture test — actually captures the screen with ScreenCaptureKit (the API
+///      Zoom/Meet/Teams use) and proves a `.none` window is excluded while a control window is not.
+///      Needs a GUI session + Screen Recording permission, which CI can't grant, so it is opt-in:
+///      run with `JARVIS_RUN_CAPTURE_TESTS=1 ./scripts/run-tests.sh`. Otherwise it returns early.
+///
+/// Note: the bundled swift-testing toolchain miscompiles `@MainActor` + `async` `@Test`
+/// ("global variable must be a compile-time constant to use @section"), and XCTest isn't available on
+/// a Command-Line-Tools-only install. So the async tests are nonisolated `@Test`s that `await` a
+/// `@MainActor` helper, which keeps the AppKit work on the main actor while sidestepping the bug.
+@Suite struct OverlayInvisibilityTests {
+
+    @MainActor @Test
+    func overlaySetsCaptureExclusionAtInit() {
+        let overlay = OverlayPanel()
+        #expect(overlay.currentSharingType == .none)
+    }
+
+    @Test
+    func overlayReassertsExclusionWhenShown() async {
+        await checkReassertOnShow()
+    }
+
+    @Test
+    func protectedWindowIsExcludedFromScreenCaptureKit() async {
+        guard ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1" else {
+            return   // not opted in — skip silently (see the suite doc comment for how to run it)
+        }
+        await checkScreenCaptureKitExclusion()
+    }
+}
+
+// MARK: - Main-actor checks (called via `await` from the nonisolated tests)
+
+@MainActor
+private func checkReassertOnShow() async {
+    // macOS 26 normalizes sharingType (won't hold a non-`.none` value we write), so we can't simulate
+    // a "dropped flag". Instead assert the re-assert code actually runs: showing a response must
+    // re-apply exclusion (and leave it `.none`). Guards the defense-in-depth re-assert from deletion.
+    let overlay = OverlayPanel()
+    let before = overlay.captureExclusionReassertCount
+
+    overlay.render("Stay hidden. Even after a reset.", maxSentences: 3, perSentenceSeconds: 0.05)
+    try? await Task.sleep(nanoseconds: 300_000_000)   // real await → lets render's main-actor hop run
+
+    #expect(overlay.captureExclusionReassertCount > before, "render() must re-assert capture exclusion")
+    #expect(overlay.currentSharingType == .none)
+}
+
+@MainActor
+private func checkScreenCaptureKitExclusion() async {
+    guard CGPreflightScreenCaptureAccess() else {
+        Issue.record("JARVIS_RUN_CAPTURE_TESTS=1 is set but this process lacks Screen Recording permission — grant it to the terminal and re-run.")
+        return
+    }
+    guard let screen = NSScreen.main else { Issue.record("no main screen"); return }
+
+    // Rare, well-separated colors so a solid-fill scan can't be fooled by ordinary UI pixels.
+    let protectedColor: (r: UInt8, g: UInt8, b: UInt8) = (123, 47, 201)   // purple
+    let controlColor:   (r: UInt8, g: UInt8, b: UInt8) = (47, 201, 123)   // teal
+
+    let f = screen.frame
+    let protectedPanel = makeSolidPanel(color: protectedColor, protected: true,
+                                        rect: NSRect(x: f.minX + 140, y: f.minY + 380, width: 900, height: 240))
+    let controlPanel = makeSolidPanel(color: controlColor, protected: false,
+                                      rect: NSRect(x: f.minX + 140, y: f.minY + 90, width: 900, height: 240))
+    defer { protectedPanel.orderOut(nil); controlPanel.orderOut(nil) }
+
+    try? await Task.sleep(nanoseconds: 700_000_000)   // let the windows render
+
+    let screenNumber = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID
+    do {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        guard let display = content.displays.first(where: { $0.displayID == screenNumber }) ?? content.displays.first else {
+            Issue.record("no SCDisplay"); return
+        }
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+        let cfg = SCStreamConfiguration()
+        cfg.width = display.width
+        cfg.height = display.height
+        let image = try await SCScreenshotManager.captureImage(contentFilter: filter, configuration: cfg)
+
+        let counts = countMatchingPixels(image, targets: [protectedColor, controlColor], tolerance: 40, step: 3)
+        let protectedCount = counts[0]
+        let controlCount = counts[1]
+
+        // Sanity: capture is live and the control window IS visible (rules out a blank/failed grab).
+        #expect(controlCount > 500,
+                "control window not found in capture (\(controlCount) px) — capture or display mapping is wrong")
+        // The real assertion: the .none window must be essentially absent. A leak would produce a
+        // pixel count comparable to the control (same size); exclusion produces ~0.
+        #expect(protectedCount * 20 < controlCount,
+                "sharingType=.none window LEAKED into ScreenCaptureKit (protected=\(protectedCount) px, control=\(controlCount) px) — the overlay would be visible in a screen share")
+    } catch {
+        Issue.record("ScreenCaptureKit capture failed: \(error)")
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeSolidPanel(color: (r: UInt8, g: UInt8, b: UInt8), protected: Bool, rect: NSRect) -> NSPanel {
+    let panel = NSPanel(contentRect: rect, styleMask: [.nonactivatingPanel, .borderless],
+                        backing: .buffered, defer: false)
+    panel.level = .floating
+    panel.isFloatingPanel = true
+    panel.hidesOnDeactivate = false
+    panel.isOpaque = true
+    panel.backgroundColor = NSColor(srgbRed: CGFloat(color.r) / 255, green: CGFloat(color.g) / 255,
+                                    blue: CGFloat(color.b) / 255, alpha: 1)
+    panel.ignoresMouseEvents = true
+    panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+    if protected { panel.sharingType = .none }
+    panel.orderFrontRegardless()
+    return panel
+}
+
+/// Draws the image into a known RGBA8 buffer and counts pixels (sampled every `step`) within
+/// `tolerance` of each target color. Returns one count per target.
+private func countMatchingPixels(_ image: CGImage,
+                                 targets: [(r: UInt8, g: UInt8, b: UInt8)],
+                                 tolerance: Int, step: Int) -> [Int] {
+    let w = image.width, h = image.height
+    let bytesPerRow = w * 4
+    var buf = [UInt8](repeating: 0, count: bytesPerRow * h)
+    var counts = [Int](repeating: 0, count: targets.count)
+    buf.withUnsafeMutableBytes { raw in
+        guard let base = raw.baseAddress,
+              let ctx = CGContext(data: base, width: w, height: h, bitsPerComponent: 8,
+                                  bytesPerRow: bytesPerRow, space: CGColorSpaceCreateDeviceRGB(),
+                                  bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return }
+        ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+        let px = base.assumingMemoryBound(to: UInt8.self)   // read via the pointer, not `buf` (exclusivity)
+        var y = 0
+        while y < h {
+            let row = y * bytesPerRow
+            var x = 0
+            while x < w {
+                let p = row + x * 4
+                let r = Int(px[p]), g = Int(px[p + 1]), b = Int(px[p + 2])
+                for (i, t) in targets.enumerated() {
+                    if abs(r - Int(t.r)) <= tolerance, abs(g - Int(t.g)) <= tolerance, abs(b - Int(t.b)) <= tolerance {
+                        counts[i] += 1
+                    }
+                }
+                x += step
+            }
+            y += step
+        }
+    }
+    return counts
+}

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -14,6 +14,7 @@
 - **[architecture.md](./architecture.md)** — the vision, the harness loop, components, data flow, safety, and design principles.
 - **[specification.md](./specification.md)** — the buildable spec: tool schemas, the coach prompt, config, pseudocode, latency budget, and the self-verification plan. This is the page another agent should be able to one-shot from.
 - **[sandbox.md](./sandbox.md)** — the security/isolation model (file-access restriction, entitlements, egress).
+- **[overlay-invisibility.md](./overlay-invisibility.md)** — how the coaching overlay stays out of screen recordings and screen shares (the `sharingType = .none` mechanism), with empirical verification on macOS 26.5 and the limits.
 - **[landscape-survey.md](./landscape-survey.md)** — every tool and product we tried or evaluated, and how each measured up. ("What I tried.")
 - **[fork-evaluation.md](./fork-evaluation.md)** — code-level evaluation of open-source apps as a fork base for the PoC, and why they're all Electron/Tauri rather than native Swift.
 - **[fix-responsiveness-vad-stop.md](./fix-responsiveness-vad-stop.md)** — root-cause analysis (verified from five angles) and fix plan for the first live smoke run's issues: direct-address responsiveness, mid-sentence turn-detection, and noisy Stop.

--- a/wiki/overlay-invisibility.md
+++ b/wiki/overlay-invisibility.md
@@ -1,0 +1,132 @@
+# Overlay Invisibility — Hiding the Coaching Overlay from Screen Capture
+
+> How Jarvis keeps its on-screen coaching overlay out of screen recordings and screen shares (so an
+> interviewer's Zoom/Meet/Teams never sees it) **and** out of Jarvis's own screen captures (so the
+> brain never reads back its own output). The mechanism, how the alternatives do it, the empirical
+> verification, and the limits.
+
+## The Requirement
+
+Jarvis draws short coaching tips in a floating overlay ([`OverlayPanel`](../Sources/JarvisOverlay/OverlayPanel.swift)).
+That overlay must be invisible to two distinct audiences:
+
+1. **Other apps capturing the screen** — the interviewer's Zoom/Meet/Teams share, a QuickTime/OBS
+   recording, the macOS screenshot tool.
+2. **Jarvis's own `capture_screen`** — otherwise the brain would read its own coaching text back in
+   the next screenshot (a feedback loop). See [`ScreenCapture.swift`](../Sources/JarvisCore/ScreenCapture.swift).
+
+Both are solved by the *same* single flag.
+
+## The Mechanism — there is exactly one
+
+macOS exposes one window-level content-protection flag:
+
+```swift
+panel.sharingType = .none   // NSWindow.SharingType.none / NSWindowSharingNone
+```
+
+It marks the window's contents as unreadable by other processes' capture paths. **There is no other
+public API for this.** Apple DTS, verbatim: *"At this time there are no public APIs for preventing
+screen capture."* Every comparable tool funnels down to this same flag:
+
+| Tool | Framework | Capture-hiding call | Resolves to |
+|---|---|---|---|
+| **Jarvis** | native Swift | `panel.sharingType = .none` | — |
+| Interview Coder (AGPL), Glass, cheating-daddy | Electron | `win.setContentProtection(true)` | `NSWindow.sharingType = .none` |
+| Pluely | Tauri | `"contentProtected": true` | `.none` |
+| Natively | Electron + Rust FFI | `setContentProtection(true)` **and** `msg_send![window, setSharingType: 0]` | `.none` |
+| Cluely / LockedIn / Final Round | closed | content-protection flag (marketing aside) | `.none` |
+
+Electron's `setContentProtection(true)` is literally `[window setSharingType:NSWindowSharingNone]`
+in `native_window_mac.mm`; Tauri's `contentProtected` is the same on macOS. The "low-level GPU/Metal
+hooks" some products market are dressing on this one flag. **Jarvis is at full parity, using the
+native API directly.**
+
+> Deprecation note: the `sharingType` property and the `.none` / `.readOnly` cases are **not**
+> deprecated. Only the unrelated `.readWrite` case was deprecated in macOS 15.0. Anyone who says
+> "`sharingType` is deprecated" has conflated it with that one case.
+
+## Empirical Verification (macOS 26.5 Tahoe, 2026-06-16)
+
+The online consensus — and Natively's own source comment — warned that **ScreenCaptureKit ignores
+`.none` on macOS 15+** (it captures the whole composited framebuffer). We tested it directly on this
+machine with a red `sharingType = .none` panel plus a blue control panel (no flag), captured four
+ways:
+
+| Capture path | API | Red `.none` panel | Blue control |
+|---|---|---|---|
+| Jarvis's own brain | `screencapture` CLI | **hidden** | visible |
+| Interviewer (one-shot) | `SCScreenshotManager.captureImage` | **hidden** | visible |
+| **Interviewer (live share)** | **`SCStream`** (what Zoom/Meet/Teams use) | **hidden** | visible |
+| After `setKey()` activation-policy flip | `SCScreenshotManager` | **still hidden** | visible |
+
+**Result:** on macOS 26.5, `.none` hides the overlay from *every* path tested — including the live
+`SCStream` path real screen-shares use — and it survives an `NSApp` activation-policy flip. The
+macOS-15 regression does **not** reproduce on Tahoe; Apple appears to have changed behavior again, or
+it was specific to certain 15.x builds. Behavior here has been version-volatile, so this is
+"verified-now," not "guaranteed-forever" — **re-test on major macOS updates** (the throwaway harness
+used was a handful of standalone Swift programs driving `NSPanel` + ScreenCaptureKit).
+
+## What Jarvis Does
+
+- [`OverlayPanel`](../Sources/JarvisOverlay/OverlayPanel.swift) sets `panel.sharingType = .none` at
+  construction.
+- It **re-asserts** `.none` at the top of `show()` every time a coaching response is displayed.
+  This is defense-in-depth, taken from Natively's documented lesson: flipping `NSApp` activation
+  policy — which Jarvis does in the API-key dialog ([`MenuBarController.setKey()`](../Sources/JarvisApp/MenuBarController.swift))
+  — can, on some OS versions/configs, make WindowServer drop the flag. It does **not** reproduce on
+  macOS 26.5, but the failure would be silent and high-impact (the overlay would become visible to an
+  interviewer with no signal), so re-asserting on every show is cheap insurance.
+
+That is the entire implementation: no package, no entitlement, no private API. `OverlayPanel` lives in
+its own small `JarvisOverlay` library target (not the executable) so the tests below can import it.
+
+## Regression tests
+
+`Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift` guards this in two layers:
+
+1. **Property tests (always run, incl. CI):** assert the panel sets `sharingType = .none` at
+   construction and that `render()` re-asserts it (a counter proves the re-assert code runs — needed
+   because macOS 26 normalizes `sharingType`, so a dropped flag can't be simulated by writing another
+   value). These catch the realistic regression: the flag or the re-assert being deleted.
+2. **On-screen capture test (opt-in, local):** paints a `.none` panel + a control, captures the
+   display with ScreenCaptureKit (the Zoom/Meet/Teams path), and asserts the protected panel is
+   absent while the control is present. CI can't grant Screen Recording, so it skips unless opted in:
+
+   ```sh
+   JARVIS_RUN_CAPTURE_TESTS=1 ./scripts/run-tests.sh --filter OverlayInvisibilityTests
+   ```
+
+   Run it from a terminal that has Screen Recording permission. This is the automated form of the
+   manual verification recorded above — run it after major macOS updates to catch OS-level drift.
+
+> Toolchain note: the tests use swift-testing but the async ones are nonisolated `@Test`s that `await`
+> a `@MainActor` helper. A direct `@MainActor async @Test` miscompiles on the Command-Line-Tools
+> swift-testing ("must be a compile-time constant to use @section"), and XCTest isn't available CLT-only.
+
+## Limits — what `.none` does NOT protect against
+
+`sharingType = .none` is a best-effort window-server hint, not a security boundary. It does nothing
+against:
+
+- **A phone/camera pointed at the screen**, or **HDMI capture cards / external recorders** — they
+  capture downstream of compositing.
+- **OS-version drift** — it worked on ≤14, was reported to leak on 15.4, and works on 26.5. Re-test
+  on macOS upgrades.
+- **Process-level detection** — proctoring agents (Proctorio, Talview) detect the *running
+  app/process*, not pixels. This is a separate, stronger vector; the flag offers zero defense. Other
+  tools respond with process-name disguise — out of scope for Jarvis (a personal tool, not an
+  anti-proctoring product).
+- Note: macOS shows a screen-capture indicator to *whoever is capturing*. It does not expose Jarvis's
+  overlay to the interviewer, but a user recording their **own** screen is flagged to themselves.
+
+## References
+
+- Apple DTS, "no public APIs for preventing screen capture": developer.apple.com/forums/thread/792152
+- Electron `native_window_mac.mm` — `setContentProtection` → `NSWindowSharingNone`
+- Natively `native-module/src/stealth_window.rs` — direct FFI, the SCK-limitation comment, and the
+  activation-policy re-assert loop that motivated Jarvis's `show()` re-assert
+- `SCContentFilter(display:excludingApplications:exceptingWindows:)` — the robust way to exclude
+  windows from *your own* `SCStream`, **if** Jarvis ever moves its brain capture off the
+  `screencapture` CLI onto ScreenCaptureKit
+- [landscape-survey.md](./landscape-survey.md) — the tools surveyed and why we built our own

--- a/wiki/overlay-invisibility.md
+++ b/wiki/overlay-invisibility.md
@@ -100,6 +100,30 @@ its own small `JarvisOverlay` library target (not the executable) so the tests b
    Run it from a terminal that has Screen Recording permission. This is the automated form of the
    manual verification recorded above — run it after major macOS updates to catch OS-level drift.
 
+### Why the capture test isn't in hosted CI
+
+A deliberate, researched choice that matches what every comparable project does:
+
+- **No public API grants Screen Recording non-interactively.** Apple provides no entitlement or
+  test-only bypass for `kTCCServiceScreenCapture`; `CGRequestScreenCaptureAccess()` shows a prompt and
+  a grant needs a relaunch. A PPPC/MDM profile can only *deny* Screen Recording, never silently allow
+  it (Apple Platform Deployment).
+- **Hosted GitHub runners can't do it reliably.** `kTCCServiceScreenCapture` lives in the
+  SIP-protected system `TCC.db`; editing it works only because the macos-13/14 runner images happen to
+  ship with SIP disabled — undocumented and removable. Even when granted, hosted runners return
+  blank/incomplete capture frames (`actions/runner-images#8951`, open), so the test would be flaky or
+  falsely fail. (The runners *do* have a window server, which is why the property tests above run fine
+  in CI.)
+- **Everyone asserts the flag, not the pixels, in CI.** Electron added a private `isContentProtected()`
+  getter specifically to unit-test that the flag is set without capturing — exactly what our
+  `overlaySetsCaptureExclusionAtInit` test does. OBS and alt-tab-macos never pixel-test capture in CI.
+
+So: **flag/property tests gate CI; the pixel-level capture test is opt-in and runs locally** (or on a
+self-hosted Mac with auto-login + a one-time manual grant, if continuous pixel verification is ever
+needed). A capture-test *failure* on a future macOS is a **true signal worth investigating** — it
+means the OS stopped honoring `.none` (as reported on some macOS 15 builds), i.e. the overlay would be
+exposed — not a flaky test.
+
 > Toolchain note: the tests use swift-testing but the async ones are nonisolated `@Test`s that `await`
 > a `@MainActor` helper. A direct `@MainActor async @Test` miscompiles on the Command-Line-Tools
 > swift-testing ("must be a compile-time constant to use @section"), and XCTest isn't available CLT-only.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -57,6 +57,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **Toolchain: SwiftPM + Command Line Tools** (no full Xcode; manual bundle + stable self-signed `Jarvis Dev` identity so TCC grants persist; TCC prompts) | [specification.md](./specification.md#9-build--run-constraints) |
 | ~~Build in a separate restricted account (HARD)~~ → **build in main `forrest` account, in a git worktree; hard requirement waived for the personal build** (2026-06-14) | [sandbox.md](./sandbox.md) |
 | **Respond when addressed; tuned `server_vad`+debounce (not `semantic_vad`); quiet graceful Stop** — fixes from first live smoke run (2026-06-15) | [fix-responsiveness-vad-stop.md](./fix-responsiveness-vad-stop.md) |
+| **Overlay hidden from screen capture/sharing via `sharingType = .none`** — already at parity with every alternative (it's the only mechanism); verified on macOS 26.5 incl. live `SCStream`; re-asserted on `show()` as defense-in-depth (2026-06-16) | [overlay-invisibility.md](./overlay-invisibility.md) |
 
 ## Open Questions / To Confirm
 


### PR DESCRIPTION
## What & why

The overlay's "invisible during screen sharing" capability was **already implemented** via `NSWindow.sharingType = .none` — the same (and only) OS mechanism every alternative uses (Cluely, Interview Coder, Glass, cheating-daddy, Pluely, Natively; Electron's `setContentProtection(true)` and Tauri's `contentProtected: true` both map to it under the hood). This PR **verifies** it, **hardens** it, and adds **regression tests** — no new mechanism, because there isn't a better one.

### Empirical verification (macOS 26.5)

`.none` hides the overlay from every capture path tested — the `screencapture` CLI (Jarvis's own brain), `SCScreenshotManager`, and a **live `SCStream`** (the real Zoom/Meet/Teams path) — and it survives the API-key dialog's `NSApp` activation-policy flip. The widely-reported "macOS 15+ ScreenCaptureKit ignores `.none`" regression does **not** reproduce on Tahoe.

### Changes

- **Hardening:** re-assert `sharingType = .none` on every `show()` (defense-in-depth — Natively documents an activation-policy flip silently dropping the flag on some OS versions; it doesn't on 26.5, but the failure would be silent and high-impact).
- **Testability:** extract `OverlayPanel` into a `JarvisOverlay` library target (was in the `JarvisApp` executable; behavior unchanged).
- **Tests** — `Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift`:
  - property tests (flag set at init + re-asserted on render) — run in CI, no permission needed;
  - opt-in ScreenCaptureKit capture test — `JARVIS_RUN_CAPTURE_TESTS=1` locally.
- **Docs:** new `wiki/overlay-invisibility.md` (mechanism, macOS-version nuance, limits, how to run the tests); comment clarifications in `OverlayPanel`/`ScreenCapture`.

## Test plan

- `./scripts/run-tests.sh` → `Test run with 91 tests in 14 suites passed` (incl. the 2 always-on property tests).
- `JARVIS_RUN_CAPTURE_TESTS=1 ./scripts/run-tests.sh --filter OverlayInvisibilityTests` (with Screen Recording granted) → all 3 pass; the capture test exercises real ScreenCaptureKit (~1.4s).
- `swift build` → `Build complete!`

## Limits / notes

`.none` is a best-effort window-server hint, not a security boundary: it does nothing against a phone camera, HDMI capture, OS-version drift, or proctoring **process** detection (a separate, stronger vector). The capture test can't run in hosted CI (no way to grant Screen Recording on a headless runner), so it's opt-in/local — researching whether CI can grant it; will follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
