### PR TITLE
Replace menu-bar icon with robot emoji

### DIFF
--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -2,7 +2,8 @@ import AppKit
 import JarvisCore
 
 /// Menu-bar status item: start/stop, API-key entry, and a session interjection counter.
-/// Exactly two states: ⚪️ stopped and 🟢 running.
+/// Exactly two states, shown as the robot emoji: desaturated (black-and-white) when stopped,
+/// full colour when running.
 @MainActor
 final class MenuBarController: NSObject {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
@@ -82,10 +83,14 @@ final class MenuBarController: NSObject {
         }
     }
 
-    /// Single source of truth for the status title and the start/stop label.
+    /// Single source of truth for the status icon and the start/stop label.
     private func refreshUI() {
         startStopItem.title = isRunning ? "Stop Jarvis" : "Start Jarvis"
-        statusItem.button?.title = isRunning ? "🟢 Jarvis" : "⚪️ Jarvis"
+        guard let button = statusItem.button else { return }
+        let icon = isRunning ? MenuBarIcon.running : MenuBarIcon.stopped
+        icon.isTemplate = false              // keep our own colours/greys; don't tint to the label colour
+        button.image = icon
+        button.title = ""
     }
 
     // MARK: - API key dialog
@@ -145,8 +150,9 @@ final class MenuBarController: NSObject {
     @objc private func cancelKeyDialog() { NSApp.stopModal(withCode: .cancel) }
 
     /// Briefly show a checkmark in the menu-bar title so the user sees the key save took effect,
-    /// then restore the normal ⚪️/🟢 state.
+    /// then restore the normal robot icon.
     private func flashConfirmation() {
+        statusItem.button?.image = nil
         statusItem.button?.title = "✓ Key saved"
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { [weak self] in self?.refreshUI() }
     }

--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -87,9 +87,7 @@ final class MenuBarController: NSObject {
     private func refreshUI() {
         startStopItem.title = isRunning ? "Stop Jarvis" : "Start Jarvis"
         guard let button = statusItem.button else { return }
-        let icon = isRunning ? MenuBarIcon.running : MenuBarIcon.stopped
-        icon.isTemplate = false              // keep our own colours/greys; don't tint to the label colour
-        button.image = icon
+        button.image = isRunning ? MenuBarIcon.running : MenuBarIcon.stopped
         button.title = ""
     }
 

--- a/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
@@ -1,0 +1,44 @@
+import AppKit
+import CoreImage
+
+/// The menu-bar glyph: the robot emoji, in colour while running and desaturated to black-and-white
+/// while stopped. Emoji are inherently colour glyphs, so the stopped variant is rendered to an image
+/// and stripped of saturation. Both variants are rendered once and cached.
+///
+/// OS-bound (AppKit + CoreImage), so it lives in `JarvisApp` rather than Core and is verified by a
+/// live run, not unit tests.
+enum MenuBarIcon {
+    private static let emoji = "🤖"
+    /// Point size that renders to roughly an 18pt-tall glyph — comfortable in the ~22pt menu bar.
+    private static let pointSize: CGFloat = 15
+
+    /// Full-colour robot, shown while the pipeline is running.
+    static let running: NSImage = render(grayscale: false)
+    /// Desaturated robot, shown while stopped.
+    static let stopped: NSImage = render(grayscale: true)
+
+    private static func render(grayscale: Bool) -> NSImage {
+        let string = NSAttributedString(string: emoji,
+                                        attributes: [.font: NSFont.systemFont(ofSize: pointSize)])
+        let size = string.size()
+        let base = NSImage(size: size)
+        base.lockFocus()
+        string.draw(at: .zero)
+        base.unlockFocus()
+        return grayscale ? (desaturate(base) ?? base) : base
+    }
+
+    /// Strip all colour (saturation → 0) so the stopped state reads as black-and-white.
+    private static func desaturate(_ image: NSImage) -> NSImage? {
+        guard let tiff = image.tiffRepresentation,
+              let input = CIImage(data: tiff),
+              let filter = CIFilter(name: "CIColorControls") else { return nil }
+        filter.setValue(input, forKey: kCIInputImageKey)
+        filter.setValue(0.0, forKey: kCIInputSaturationKey)
+        guard let output = filter.outputImage else { return nil }
+        let rep = NSCIImageRep(ciImage: output)
+        let result = NSImage(size: rep.size)
+        result.addRepresentation(rep)
+        return result
+    }
+}

--- a/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
@@ -6,7 +6,9 @@ import CoreImage
 /// and stripped of saturation. Both variants are rendered once and cached.
 ///
 /// OS-bound (AppKit + CoreImage), so it lives in `JarvisApp` rather than Core and is verified by a
-/// live run, not unit tests.
+/// live run, not unit tests. Main-actor-isolated: `NSImage` isn't `Sendable`, and the icons are only
+/// ever touched from the `@MainActor` `MenuBarController`.
+@MainActor
 enum MenuBarIcon {
     private static let emoji = "🤖"
     /// Point size that renders to roughly an 18pt-tall glyph — comfortable in the ~22pt menu bar.

--- a/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarIcon.swift
@@ -2,8 +2,10 @@ import AppKit
 import CoreImage
 
 /// The menu-bar glyph: the robot emoji, in colour while running and desaturated to black-and-white
-/// while stopped. Emoji are inherently colour glyphs, so the stopped variant is rendered to an image
-/// and stripped of saturation. Both variants are rendered once and cached.
+/// while stopped. Emoji are inherently colour glyphs, so the stopped variant is rendered and stripped
+/// of saturation. Both variants share one rendering pipeline — drawn centred into the same 2×-density
+/// bitmap at the same logical point size — so they match exactly and stay crisp on Retina displays.
+/// Rendered once and cached.
 ///
 /// OS-bound (AppKit + CoreImage), so it lives in `JarvisApp` rather than Core and is verified by a
 /// live run, not unit tests. Main-actor-isolated: `NSImage` isn't `Sendable`, and the icons are only
@@ -11,36 +13,57 @@ import CoreImage
 @MainActor
 enum MenuBarIcon {
     private static let emoji = "🤖"
-    /// Point size that renders to roughly an 18pt-tall glyph — comfortable in the ~22pt menu bar.
-    private static let pointSize: CGFloat = 15
+    /// Logical (point) side of the square status image — comfortable in the ~22pt menu bar.
+    private static let side: CGFloat = 18
+    /// Render at 2× the logical size so the glyph is crisp on Retina displays.
+    private static let scale: CGFloat = 2
 
     /// Full-colour robot, shown while the pipeline is running.
-    static let running: NSImage = render(grayscale: false)
+    static let running: NSImage = make(grayscale: false)
     /// Desaturated robot, shown while stopped.
-    static let stopped: NSImage = render(grayscale: true)
+    static let stopped: NSImage = make(grayscale: true)
 
-    private static func render(grayscale: Bool) -> NSImage {
-        let string = NSAttributedString(string: emoji,
-                                        attributes: [.font: NSFont.systemFont(ofSize: pointSize)])
-        let size = string.size()
-        let base = NSImage(size: size)
-        base.lockFocus()
-        string.draw(at: .zero)
-        base.unlockFocus()
-        return grayscale ? (desaturate(base) ?? base) : base
+    private static func make(grayscale: Bool) -> NSImage {
+        let base = renderBitmap()
+        let rep = grayscale ? (desaturate(base) ?? base) : base
+        let image = NSImage(size: NSSize(width: side, height: side))
+        image.addRepresentation(rep)
+        image.isTemplate = false                 // keep our own colours/greys; don't tint to the label colour
+        image.accessibilityDescription = grayscale ? "Jarvis stopped" : "Jarvis running"
+        return image
     }
 
-    /// Strip all colour (saturation → 0) so the stopped state reads as black-and-white.
-    private static func desaturate(_ image: NSImage) -> NSImage? {
-        guard let tiff = image.tiffRepresentation,
-              let input = CIImage(data: tiff),
+    /// Draw the emoji centred into a 2×-density RGBA bitmap whose logical size is `side` points.
+    private static func renderBitmap() -> NSBitmapImageRep {
+        let px = Int((side * scale).rounded())
+        let rep = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: px, pixelsHigh: px,
+                                   bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true,
+                                   isPlanar: false, colorSpaceName: .deviceRGB,
+                                   bytesPerRow: 0, bitsPerPixel: 0)!
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        let string = NSAttributedString(string: emoji,
+                                        attributes: [.font: NSFont.systemFont(ofSize: side * scale)])
+        let glyph = string.size()
+        // Centre in the (pixel-space) canvas so the glyph isn't clipped or baseline-offset.
+        string.draw(at: NSPoint(x: (CGFloat(px) - glyph.width) / 2,
+                                y: (CGFloat(px) - glyph.height) / 2))
+        NSGraphicsContext.restoreGraphicsState()
+        rep.size = NSSize(width: side, height: side)   // logical points → 2× pixel density
+        return rep
+    }
+
+    /// Strip all colour (saturation → 0) so the stopped state reads as black-and-white, keeping the
+    /// same pixel dimensions and logical size as the colour variant.
+    private static func desaturate(_ rep: NSBitmapImageRep) -> NSBitmapImageRep? {
+        guard let cg = rep.cgImage,
               let filter = CIFilter(name: "CIColorControls") else { return nil }
-        filter.setValue(input, forKey: kCIInputImageKey)
+        filter.setValue(CIImage(cgImage: cg), forKey: kCIInputImageKey)
         filter.setValue(0.0, forKey: kCIInputSaturationKey)
-        guard let output = filter.outputImage else { return nil }
-        let rep = NSCIImageRep(ciImage: output)
-        let result = NSImage(size: rep.size)
-        result.addRepresentation(rep)
-        return result
+        guard let output = filter.outputImage,
+              let outCG = CIContext().createCGImage(output, from: output.extent) else { return nil }
+        let outRep = NSBitmapImageRep(cgImage: outCG)
+        outRep.size = rep.size
+        return outRep
     }
 }


### PR DESCRIPTION
## What

Replaces the menu-bar status item's text title (`🟢 Jarvis` / `⚪️ Jarvis`) with the 🤖 robot emoji rendered as an image:

- **Running** → full-colour robot
- **Stopped** → desaturated (black-and-white) robot

Emoji are inherently colour glyphs, so the stopped variant is rendered to an image and stripped of saturation via CoreImage (`CIColorControls`).

## How

- New `Sources/JarvisApp/MenuBar/MenuBarIcon.swift` renders + caches the two variants. Both go through one deterministic pipeline — the emoji is drawn centred into a 2×-density bitmap at a fixed 18pt logical size — so colour and grayscale match exactly and stay crisp on Retina displays. The factory also sets `isTemplate = false` (so our colours/greys aren't tinted away) and an `accessibilityDescription` for VoiceOver. Main-actor-isolated since `NSImage` isn't `Sendable`.
- `MenuBarController.refreshUI()` swaps `button.image` (colour vs. grayscale) instead of setting a text title; `flashConfirmation()` clears the icon during the "✓ Key saved" flash and restores it.

OS-bound (AppKit + CoreImage), so it lives in `JarvisApp` and is verified by a live run, per the repo's testing rules.

## Verification

- `./scripts/run-tests.sh` — all 83 tests pass (no Core/Overlay/Viewer behaviour changed).
- `./scripts/build-app.sh --run` — confirmed the grayscale robot shows when stopped and the colour robot when running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)