### PR TITLE
Tune overlay/silence timing and sharpen the coach prompt

### DIFF
--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -50,7 +50,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private var everConnected = false    // distinguishes the first connect from a reconnect
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
-         silenceTimeout: TimeInterval = 30, silenceMaxInterval: TimeInterval = 240,
+         silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
          silenceDurationMs: Int = 1000,
          turnDebounce: TimeInterval = 0.4, maxBufferedAudioSeconds: TimeInterval = 60) {
         self.apiKey = apiKey
@@ -315,8 +315,8 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
 
     /// Schedule the next "maybe stuck" silence check using the current backoff interval. When it fires
     /// (no speech in the meantime) it reports how long the user has been quiet, then re-arms with the
-    /// next, longer interval — so a long silence is gently re-checked (e.g. 30s, 60s, 120s, …) rather
-    /// than nudged once and never again. Must be called on the main queue.
+    /// next, longer interval — so a long silence is gently re-checked (the interval doubles each step
+    /// up to a cap; see `Config`) rather than nudged once and never again. Must be called on the main queue.
     private func armSilenceTimer() {
         let interval = silenceBackoff.next()
         lock.lock(); silenceTimer?.invalidate()

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -21,7 +21,8 @@ public let coachTools: [ToolDef] = [captureScreenTool, speakTool]
 public let coachSystemPrompt = """
 You are Jarvis, a calm, sharp LeetCode coach sitting beside the user while they solve a problem.
 
-The transcript is labeled by speaker. Lines marked "me:" are the user you coach, thinking aloud.
+The transcript is labeled by speaker. Lines marked "me:" are the user you coach, thinking aloud
+("the user" everywhere below means "me" — never "them").
 Lines marked "them:" are the other person in the room or on the call — an interviewer or caller,
 picked up from system audio. Coach ONLY "me", but DO read "them:" lines as context: an interviewer's
 question or clarification is the very problem "me" is working on, so fold it into your hints to "me".
@@ -47,9 +48,9 @@ complexity of that nested loop?"). If they are making good progress, stay silent
 Don't repeat a hint they have already heard; if they are still stuck after an earlier nudge, escalate
 to a more concrete next step rather than restating the same one.
 
-IF THE USER ASKS YOU TO LOOK AT OR CHECK THEIR SCREEN (e.g. "can you check my screen?", "look at this",
-"can you see my code?"), call capture_screen right away — even if they didn't say your name — then answer
-based on what you see.
+IF "ME" ASKS YOU TO LOOK AT OR CHECK THE SCREEN (e.g. "can you check my screen?", "look at this",
+"can you see my code?"), call capture_screen right away — even without your name — then answer based on
+what you see. A "them:" line is never this request.
 
 WHEN THE USER HAS BEEN SILENT FOR A WHILE, you usually cannot tell whether they are stuck or thinking
 productively without seeing what they are doing — so prefer to call capture_screen to read their

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -20,13 +20,22 @@ public let coachTools: [ToolDef] = [captureScreenTool, speakTool]
 /// The coach system prompt — the only place response behavior is governed (no code-side guardrail).
 public let coachSystemPrompt = """
 You are Jarvis, a calm, sharp LeetCode coach sitting beside the user while they solve a problem.
-You hear them think aloud. You cannot see their screen unless you call capture_screen — do that
-when you need to read the problem or their code to be specific and correct.
 
-You are given timing context: a timestamped transcript, how many seconds the user has been silent,
-and how long they have been on the problem. Use it.
+The transcript is labeled by speaker. Lines marked "me:" are the user you coach, thinking aloud.
+Lines marked "them:" are the other person in the room or on the call — an interviewer or caller,
+picked up from system audio. Coach ONLY "me", but DO read "them:" lines as context: an interviewer's
+question or clarification is the very problem "me" is working on, so fold it into your hints to "me".
+What you must not do is talk back to "them", or treat their words as "me" thinking aloud. And only an
+address from "me" triggers the must-reply rule below — never reply just because "them" asked
+something; keep coaching "me" toward the answer at your normal restraint.
 
-WHEN THE USER ADDRESSES YOU DIRECTLY (says your name "Jarvis", asks you a question, or tells you to
+You cannot see the screen unless you call capture_screen — do that when you need to read the problem
+or their code to be specific and correct.
+
+You are given timing context with every turn: a timestamped transcript, why this turn fired (the user
+just spoke, or has been silent for a while), and how long the session has been running. Use it.
+
+WHEN "ME" ADDRESSES YOU DIRECTLY (says your name "Jarvis", asks you a question, or tells you to
 do something), you MUST reply — call the speak tool with a brief, helpful answer. Never ignore a
 direct address; even a simple greeting deserves a short spoken reply. This overrides the
 stay-quiet-by-default behavior below.
@@ -35,6 +44,8 @@ OTHERWISE, when the user is just thinking aloud, be a restrained, proactive coac
 the solution with short, encouraging, specific hints. Never dump the full solution unless they are
 truly stuck and ask for it. Prefer a pointed question or the next small step (e.g. "What's the time
 complexity of that nested loop?"). If they are making good progress, stay silent — call no tool.
+Don't repeat a hint they have already heard; if they are still stuck after an earlier nudge, escalate
+to a more concrete next step rather than restating the same one.
 
 IF THE USER ASKS YOU TO LOOK AT OR CHECK THEIR SCREEN (e.g. "can you check my screen?", "look at this",
 "can you see my code?"), call capture_screen right away — even if they didn't say your name — then answer
@@ -45,6 +56,16 @@ productively without seeing what they are doing — so prefer to call capture_sc
 current problem and code before deciding whether a nudge would help. A long silence often means they
 are stuck; but if the screen shows steady progress, stay silent and leave them alone.
 
-When you do speak, call the speak tool with at most 3 short lines — one idea per line, since each
-line is shown on the overlay on its own. Keep any code snippet within a single line.
+KEEP IT EASY TO READ. The user is often under interview pressure, where reading and processing text
+is hard. Write the way you would speak to a stressed friend:
+- Use plain, everyday words. Avoid jargon, abbreviations, and academic phrasing. If a simpler word
+  works, use it (say "loop inside a loop" before "nested iteration", "runs slower as the list grows"
+  before "quadratic time complexity").
+- One idea per line. Keep each line short — aim for under ~12 words.
+- Be concrete and direct. Point at the next small action, not an abstract concept
+  (e.g. "Try a hash map to remember what you've seen" beats "Consider an auxiliary data structure").
+- Lead with the most useful thing first, in case they only read one line.
+
+When you do speak, call the speak tool with at most 3 short lines — one idea per line, since each line
+is shown on the overlay on its own. Keep any code snippet within a single line.
 """

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -37,10 +37,10 @@ public struct Config: Sendable {
     public var maxBufferedAudioSeconds: TimeInterval
 
     public init(
-        silenceTimeoutSeconds: TimeInterval = 30,
-        silenceMaxIntervalSeconds: TimeInterval = 240,
+        silenceTimeoutSeconds: TimeInterval = 120,
+        silenceMaxIntervalSeconds: TimeInterval = 960,
         transcriptWindowSeconds: TimeInterval = 90,
-        lineDisplaySeconds: TimeInterval = 5,
+        lineDisplaySeconds: TimeInterval = 15,
         brainModel: String = "gpt-5.5",
         reasoningEffort: String = "low",
         transcriptionModel: String = "gpt-4o-transcribe",

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -23,7 +23,7 @@ public struct TriggerContext: Sendable {
         let elapsed = Int(sessionElapsedSeconds)
         switch reason {
         case .turnEnd:
-            return "Trigger: the user just finished speaking. The session has been running for \(elapsed)s."
+            return "Trigger: a turn just ended — check the transcript labels for who spoke (\"me\" or \"them\"). The session has been running for \(elapsed)s."
         case .silence(let secs):
             return "Trigger: the user has been silent for \(Int(secs))s. The session has been running for \(elapsed)s."
         }

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -23,9 +23,9 @@ public struct TriggerContext: Sendable {
         let elapsed = Int(sessionElapsedSeconds)
         switch reason {
         case .turnEnd:
-            return "Trigger: the user just finished speaking. They have been on this problem for \(elapsed)s."
+            return "Trigger: the user just finished speaking. The session has been running for \(elapsed)s."
         case .silence(let secs):
-            return "Trigger: the user has been silent for \(Int(secs))s. They have been on this problem for \(elapsed)s."
+            return "Trigger: the user has been silent for \(Int(secs))s. The session has been running for \(elapsed)s."
         }
     }
 }

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -1,15 +1,22 @@
 import AppKit
 import JarvisCore
 
-/// A non-activating, always-on-top panel that shows coaching sentences one at a time and is
+/// A non-activating, always-on-top panel that shows coaching tips one line at a time and is
 /// excluded from screen capture — both so Jarvis's own brain never sees its output and so the
 /// overlay stays invisible in anyone else's screen share or recording (Zoom/Meet/Teams/QuickTime).
-/// See `init` and wiki/overlay-invisibility.md.
+/// A newer tip never interrupts one still on screen; it queues and plays after, so no hint is
+/// dropped. See `init` and wiki/overlay-invisibility.md.
 @MainActor
 public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceApplying {
     private let panel: NSPanel
     private let label: NSTextField
-    private var hideWorkItem: DispatchWorkItem?
+    /// Tips waiting their turn. A tip the user may still be reading is never cut off by a newer one —
+    /// arrivals queue here and play in order once the current tip finishes.
+    private var queue: [(lines: [String], each: TimeInterval)] = []
+    private var isShowing = false
+    /// The pending line-advance work, retained so the Settings live preview can suspend tip
+    /// progression while the user adjusts appearance.
+    private var tickWorkItem: DispatchWorkItem?
     /// Whether the panel is currently showing the Settings live preview (vs. a real coaching tip).
     /// Lets `showAppearancePreview(false)` avoid tearing down a genuine tip when Settings closes.
     private var isPreviewing = false
@@ -79,16 +86,27 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
         // overlay becoming visible to a screen share with no signal. See wiki/overlay-invisibility.md.
         reassertCaptureExclusion()
         isPreviewing = false   // a real tip takes over the panel from any Settings preview
-        hideWorkItem?.cancel()
+        // Queue rather than interrupt: a tip the user is still reading must not vanish because a newer
+        // one arrived. Tips play in arrival order and none are dropped.
+        queue.append((lines, each))
+        if !isShowing { showNextTip() }
+    }
+
+    /// Pull the next queued tip and step through its lines one at a time; when it ends, advance to the
+    /// next queued tip, or hide the panel once the queue is empty.
+    private func showNextTip() {
+        guard !queue.isEmpty else { isShowing = false; hide(); return }
+        isShowing = true
+        let tip = queue.removeFirst()
         var idx = 0
         func next() {
-            guard idx < lines.count else { hide(); return }
-            label.stringValue = lines[idx]
+            guard idx < tip.lines.count else { showNextTip(); return }
+            label.stringValue = tip.lines[idx]
             panel.orderFrontRegardless()
             idx += 1
             let work = DispatchWorkItem { MainActor.assumeIsolated { next() } }
-            hideWorkItem = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + each, execute: work)
+            tickWorkItem = work
+            DispatchQueue.main.asyncAfter(deadline: .now() + tip.each, execute: work)
         }
         next()
     }
@@ -123,14 +141,15 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     /// tears down a genuine coaching tip that `show()` put on screen in the meantime.
     public func showAppearancePreview(_ on: Bool) {
         if on {
-            hideWorkItem?.cancel()
+            tickWorkItem?.cancel()   // pause any in-flight tip so it doesn't overwrite the sample
             reassertCaptureExclusion()
             isPreviewing = true
             label.stringValue = Self.previewText
             panel.orderFrontRegardless()
         } else if isPreviewing {
             isPreviewing = false
-            hide()
+            // Resume any tips that queued (or were paused) while Settings was open; else clear.
+            if isShowing || !queue.isEmpty { showNextTip() } else { hide() }
         }
     }
 
@@ -144,4 +163,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
 
     /// The panel background's current alpha (the opacity the user picked).
     var currentBackgroundAlpha: CGFloat { panel.backgroundColor.alphaComponent }
+
+    /// The line currently displayed on the overlay — lets tests assert queue/ordering behavior.
+    var currentText: String { label.stringValue }
 }

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -110,13 +110,16 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
         guard let (tip, line) = active else { return }
         guard line < tip.lines.count else {
             active = nil
+            tickWorkItem = nil   // tip done: drop the fired work item (no lingering self-capture)
             if queue.isEmpty { hide() } else { pumpQueue() }
             return
         }
         label.stringValue = tip.lines[line]
         panel.orderFrontRegardless()
         active = (tip, line + 1)
-        let work = DispatchWorkItem { MainActor.assumeIsolated { self.advance() } }
+        // [weak self] breaks the self -> tickWorkItem -> closure -> self cycle; if the panel is gone
+        // there is nothing to advance.
+        let work = DispatchWorkItem { [weak self] in MainActor.assumeIsolated { self?.advance() } }
         tickWorkItem = work
         DispatchQueue.main.asyncAfter(deadline: .now() + tip.each, execute: work)
     }
@@ -151,7 +154,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     /// tears down a genuine coaching tip that `show()` put on screen in the meantime.
     public func showAppearancePreview(_ on: Bool) {
         if on {
-            tickWorkItem?.cancel()   // pause the active tip; `active` keeps its line index for resume
+            tickWorkItem?.cancel(); tickWorkItem = nil   // pause the active tip; `active` keeps its line index for resume
             reassertCaptureExclusion()
             isPreviewing = true
             label.stringValue = Self.previewText
@@ -181,4 +184,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
 
     /// The line currently displayed on the overlay — lets tests assert queue/ordering behavior.
     var currentText: String { label.stringValue }
+
+    /// Whether the panel is on screen — lets tests assert the drain-then-hide transition.
+    var isPanelVisible: Bool { panel.isVisible }
 }

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -10,15 +10,18 @@ import JarvisCore
 public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceApplying {
     private let panel: NSPanel
     private let label: NSTextField
+    /// One coaching tip: its lines and how long each line is shown.
+    private struct Tip { let lines: [String]; let each: TimeInterval }
     /// Tips waiting their turn. A tip the user may still be reading is never cut off by a newer one —
     /// arrivals queue here and play in order once the current tip finishes.
-    private var queue: [(lines: [String], each: TimeInterval)] = []
-    private var isShowing = false
-    /// The pending line-advance work, retained so the Settings live preview can suspend tip
-    /// progression while the user adjusts appearance.
+    private var queue: [Tip] = []
+    /// The tip currently on screen and the index of the NEXT line to show. Held as instance state (not
+    /// inside the advance closure) so a Settings preview can pause it and later resume the exact line.
+    private var active: (tip: Tip, nextLine: Int)?
+    /// The pending line-advance work, retained so the Settings live preview can cancel (pause) it.
     private var tickWorkItem: DispatchWorkItem?
-    /// Whether the panel is currently showing the Settings live preview (vs. a real coaching tip).
-    /// Lets `showAppearancePreview(false)` avoid tearing down a genuine tip when Settings closes.
+    /// Whether the Settings live preview currently owns the panel. While true, an active tip is paused
+    /// and newly-arriving tips wait in the queue; they resume/play when the preview closes.
     private var isPreviewing = false
     /// Test hook (internal): counts how many times `show()` has re-asserted capture exclusion.
     private(set) var captureExclusionReassertCount = 0
@@ -85,30 +88,37 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
         // macOS versions/configs. Cheap insurance against a silent, high-impact regression — the
         // overlay becoming visible to a screen share with no signal. See wiki/overlay-invisibility.md.
         reassertCaptureExclusion()
-        isPreviewing = false   // a real tip takes over the panel from any Settings preview
         // Queue rather than interrupt: a tip the user is still reading must not vanish because a newer
         // one arrived. Tips play in arrival order and none are dropped.
-        queue.append((lines, each))
-        if !isShowing { showNextTip() }
+        queue.append(Tip(lines: lines, each: each))
+        pumpQueue()
     }
 
-    /// Pull the next queued tip and step through its lines one at a time; when it ends, advance to the
-    /// next queued tip, or hide the panel once the queue is empty.
-    private func showNextTip() {
-        guard !queue.isEmpty else { isShowing = false; hide(); return }
-        isShowing = true
-        let tip = queue.removeFirst()
-        var idx = 0
-        func next() {
-            guard idx < tip.lines.count else { showNextTip(); return }
-            label.stringValue = tip.lines[idx]
-            panel.orderFrontRegardless()
-            idx += 1
-            let work = DispatchWorkItem { MainActor.assumeIsolated { next() } }
-            tickWorkItem = work
-            DispatchQueue.main.asyncAfter(deadline: .now() + tip.each, execute: work)
+    /// Begin the next queued tip if the panel is free. A no-op while a tip is already on screen (the
+    /// new one waits its turn) or while the Settings preview owns the panel (queued tips resume when
+    /// the preview closes) — so a tip is never interrupted or dropped.
+    private func pumpQueue() {
+        guard !isPreviewing, active == nil, !queue.isEmpty else { return }
+        active = (queue.removeFirst(), 0)
+        advance()
+    }
+
+    /// Show the active tip's current line and schedule the next. When the tip's lines are exhausted,
+    /// move on to the next queued tip, or hide the panel if nothing is waiting. Resumable: it reads the
+    /// line index from `active`, so a preview can pause it (cancel the tick) and resume exactly here.
+    private func advance() {
+        guard let (tip, line) = active else { return }
+        guard line < tip.lines.count else {
+            active = nil
+            if queue.isEmpty { hide() } else { pumpQueue() }
+            return
         }
-        next()
+        label.stringValue = tip.lines[line]
+        panel.orderFrontRegardless()
+        active = (tip, line + 1)
+        let work = DispatchWorkItem { MainActor.assumeIsolated { self.advance() } }
+        tickWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + tip.each, execute: work)
     }
 
     private func hide() { panel.orderOut(nil) }
@@ -141,15 +151,20 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     /// tears down a genuine coaching tip that `show()` put on screen in the meantime.
     public func showAppearancePreview(_ on: Bool) {
         if on {
-            tickWorkItem?.cancel()   // pause any in-flight tip so it doesn't overwrite the sample
+            tickWorkItem?.cancel()   // pause the active tip; `active` keeps its line index for resume
             reassertCaptureExclusion()
             isPreviewing = true
             label.stringValue = Self.previewText
             panel.orderFrontRegardless()
         } else if isPreviewing {
             isPreviewing = false
-            // Resume any tips that queued (or were paused) while Settings was open; else clear.
-            if isShowing || !queue.isEmpty { showNextTip() } else { hide() }
+            if active != nil {
+                advance()        // resume the paused tip from the exact line it stopped on
+            } else if !queue.isEmpty {
+                pumpQueue()      // a tip arrived while previewing — play it now
+            } else {
+                hide()           // nothing to show; clear the sample text
+            }
         }
     }
 

--- a/Tests/JarvisCoreTests/Config/ConfigTests.swift
+++ b/Tests/JarvisCoreTests/Config/ConfigTests.swift
@@ -4,10 +4,10 @@ import Testing
 @Suite struct ConfigTests {
     @Test func defaults() {
         let c = Config.default
-        #expect(c.silenceTimeoutSeconds == 30)
-        #expect(c.silenceMaxIntervalSeconds == 240)
+        #expect(c.silenceTimeoutSeconds == 120)
+        #expect(c.silenceMaxIntervalSeconds == 960)
         #expect(c.transcriptWindowSeconds == 90)
-        #expect(c.lineDisplaySeconds == 5)
+        #expect(c.lineDisplaySeconds == 15)
         #expect(c.brainModel == "gpt-5.5")
         #expect(c.reasoningEffort == "low")
         #expect(c.transcriptionModel == "gpt-4o-transcribe")

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct TriggerContextTests {
+    @Test func turnEndPromptLineDescribesSpeechAndSessionElapsed() {
+        let ctx = TriggerContext(reason: .turnEnd, secondsSinceLastSpeech: 0, sessionElapsedSeconds: 95)
+        #expect(ctx.promptLine == "Trigger: the user just finished speaking. The session has been running for 95s.")
+    }
+
+    @Test func silencePromptLineDescribesQuietDurationAndSessionElapsed() {
+        let ctx = TriggerContext(reason: .silence(secondsQuiet: 120), secondsSinceLastSpeech: 120, sessionElapsedSeconds: 600)
+        #expect(ctx.promptLine == "Trigger: the user has been silent for 120s. The session has been running for 600s.")
+    }
+}

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -2,9 +2,9 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct TriggerContextTests {
-    @Test func turnEndPromptLineDescribesSpeechAndSessionElapsed() {
+    @Test func turnEndPromptLineIsSpeakerNeutralAndDescribesSessionElapsed() {
         let ctx = TriggerContext(reason: .turnEnd, secondsSinceLastSpeech: 0, sessionElapsedSeconds: 95)
-        #expect(ctx.promptLine == "Trigger: the user just finished speaking. The session has been running for 95s.")
+        #expect(ctx.promptLine == "Trigger: a turn just ended — check the transcript labels for who spoke (\"me\" or \"them\"). The session has been running for 95s.")
     }
 
     @Test func silencePromptLineDescribesQuietDurationAndSessionElapsed() {

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -66,6 +66,11 @@ import AppKit
         await checkTipsQueue()
     }
 
+    @Test
+    func overlayResumesTipAndQueueAfterSettingsPreview() async {
+        await checkPreviewResumesTip()
+    }
+
     // Condition trait so opting out reports as *skipped* (not a green pass) — important for a
     // security-adjacent test where "skipped" and "passed" must be distinguishable.
     @Test(.enabled(if: ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1",
@@ -123,6 +128,29 @@ private func checkTipsQueue() async {
 
     try? await Task.sleep(nanoseconds: 300_000_000)   // first tip's window elapses; the queued tip takes over
     #expect(overlay.currentText == "second", "the queued tip must display after the first finishes")
+}
+
+// Opening the Settings appearance preview mid-tip must PAUSE the tip (showing the sample), then on
+// close RESUME the exact line it stopped on — and a tip that arrived while the preview was open must
+// play afterwards. Guards the regression where the preview stranded the queue / dropped a tip.
+@MainActor
+private func checkPreviewResumesTip() async {
+    let overlay = OverlayPanel()
+
+    overlay.render(["A1", "A2"], perLineSeconds: 0.4)   // line A1 shows; A2 scheduled at ~0.4s
+    try? await Task.sleep(nanoseconds: 150_000_000)     // ~0.15s: still on A1
+    overlay.showAppearancePreview(true)                 // pause the tip; sample takes the panel
+    overlay.render(["B1"], perLineSeconds: 0.4)         // a new tip arrives while previewing — must wait
+
+    try? await Task.sleep(nanoseconds: 100_000_000)     // ~0.25s
+    #expect(overlay.currentText == "Sample overlay text", "preview must own the panel while open")
+
+    overlay.showAppearancePreview(false)                // close Settings: resume the paused tip at A2
+    try? await Task.sleep(nanoseconds: 150_000_000)     // ~0.40s into A2's window
+    #expect(overlay.currentText == "A2", "the paused tip must resume its remaining line, not be dropped")
+
+    try? await Task.sleep(nanoseconds: 400_000_000)     // A2 elapses (~0.65s); the queued tip plays
+    #expect(overlay.currentText == "B1", "a tip that arrived during preview must play after the resumed tip")
 }
 
 @MainActor

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -61,6 +61,11 @@ import AppKit
         await checkEmptyLinesDoNotShow()
     }
 
+    @Test
+    func overlayQueuesTipsInsteadOfInterrupting() async {
+        await checkTipsQueue()
+    }
+
     // Condition trait so opting out reports as *skipped* (not a green pass) — important for a
     // security-adjacent test where "skipped" and "passed" must be distinguishable.
     @Test(.enabled(if: ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1",
@@ -100,6 +105,24 @@ private func checkEmptyLinesDoNotShow() async {
 
     #expect(overlay.captureExclusionReassertCount == before,
             "empty/whitespace-only lines must not show the overlay")
+}
+
+// A newer tip must not interrupt one still on screen: it queues and plays after the current tip
+// finishes, so no hint is dropped. Uses sub-second display windows with wide margins to stay robust
+// under CI load.
+@MainActor
+private func checkTipsQueue() async {
+    let overlay = OverlayPanel()
+
+    overlay.render(["first"], perLineSeconds: 0.3)
+    try? await Task.sleep(nanoseconds: 80_000_000)    // 80ms into the first tip's 300ms window
+    overlay.render(["second"], perLineSeconds: 0.3)   // arrives mid-display — must queue, not replace
+    try? await Task.sleep(nanoseconds: 80_000_000)    // still inside the first tip's window
+
+    #expect(overlay.currentText == "first", "a newer tip must not interrupt one still on screen")
+
+    try? await Task.sleep(nanoseconds: 300_000_000)   // first tip's window elapses; the queued tip takes over
+    #expect(overlay.currentText == "second", "the queued tip must display after the first finishes")
 }
 
 @MainActor

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -71,6 +71,25 @@ import AppKit
         await checkPreviewResumesTip()
     }
 
+    @Test
+    func overlayHidesPanelAfterQueueDrains() async {
+        await checkDrainThenHide()
+    }
+
+    @MainActor @Test
+    func overlayPreviewWithEmptyQueueHidesOnCloseAndTogglesCleanly() {
+        let overlay = OverlayPanel()
+        // Preview with nothing queued, toggled twice: must not crash, must end hidden and excluded.
+        overlay.showAppearancePreview(true)
+        #expect(overlay.currentText == "Sample overlay text")
+        overlay.showAppearancePreview(false)
+        #expect(!overlay.isPanelVisible, "closing an empty-queue preview must hide the panel")
+        overlay.showAppearancePreview(true)
+        overlay.showAppearancePreview(false)
+        #expect(!overlay.isPanelVisible)
+        #expect(overlay.currentSharingType == .none)
+    }
+
     // Condition trait so opting out reports as *skipped* (not a green pass) — important for a
     // security-adjacent test where "skipped" and "passed" must be distinguishable.
     @Test(.enabled(if: ProcessInfo.processInfo.environment["JARVIS_RUN_CAPTURE_TESTS"] == "1",
@@ -113,21 +132,40 @@ private func checkEmptyLinesDoNotShow() async {
 }
 
 // A newer tip must not interrupt one still on screen: it queues and plays after the current tip
-// finishes, so no hint is dropped. Uses sub-second display windows with wide margins to stay robust
-// under CI load.
+// finishes, so no hint is dropped. Display windows are 0.6s with assertions sampled ~0.3s from each
+// edge, so a loaded CI runloop has to drift >300ms to flip a result — comfortable slack since
+// Task.sleep only ever overshoots.
 @MainActor
 private func checkTipsQueue() async {
     let overlay = OverlayPanel()
 
-    overlay.render(["first"], perLineSeconds: 0.3)
-    try? await Task.sleep(nanoseconds: 80_000_000)    // 80ms into the first tip's 300ms window
-    overlay.render(["second"], perLineSeconds: 0.3)   // arrives mid-display — must queue, not replace
-    try? await Task.sleep(nanoseconds: 80_000_000)    // still inside the first tip's window
+    overlay.render(["first"], perLineSeconds: 0.6)
+    try? await Task.sleep(nanoseconds: 200_000_000)   // 0.2s into the first tip's 0.6s window
+    overlay.render(["second"], perLineSeconds: 0.6)   // arrives mid-display — must queue, not replace
+    try? await Task.sleep(nanoseconds: 200_000_000)   // ~0.4s: still well inside the first tip's window
 
     #expect(overlay.currentText == "first", "a newer tip must not interrupt one still on screen")
 
-    try? await Task.sleep(nanoseconds: 300_000_000)   // first tip's window elapses; the queued tip takes over
+    try? await Task.sleep(nanoseconds: 500_000_000)   // ~0.9s: first window (0.6s) elapsed; queued tip is up
     #expect(overlay.currentText == "second", "the queued tip must display after the first finishes")
+}
+
+// Once the queue fully drains, the panel must hide and reset so the next coaching turn can display.
+@MainActor
+private func checkDrainThenHide() async {
+    let overlay = OverlayPanel()
+
+    overlay.render(["only"], perLineSeconds: 0.3)
+    try? await Task.sleep(nanoseconds: 100_000_000)   // ~0.1s: tip on screen
+    #expect(overlay.isPanelVisible, "the tip should be on screen while displaying")
+
+    try? await Task.sleep(nanoseconds: 400_000_000)   // ~0.5s: the 0.3s window elapsed → drain → hide
+    #expect(!overlay.isPanelVisible, "the panel must hide once the queue drains")
+
+    overlay.render(["again"], perLineSeconds: 0.3)    // a fresh tip after drain must display immediately
+    try? await Task.sleep(nanoseconds: 100_000_000)
+    #expect(overlay.currentText == "again", "state must reset so the next tip shows")
+    #expect(overlay.isPanelVisible)
 }
 
 // Opening the Settings appearance preview mid-tip must PAUSE the tip (showing the sample), then on
@@ -137,19 +175,19 @@ private func checkTipsQueue() async {
 private func checkPreviewResumesTip() async {
     let overlay = OverlayPanel()
 
-    overlay.render(["A1", "A2"], perLineSeconds: 0.4)   // line A1 shows; A2 scheduled at ~0.4s
-    try? await Task.sleep(nanoseconds: 150_000_000)     // ~0.15s: still on A1
+    overlay.render(["A1", "A2"], perLineSeconds: 0.6)   // line A1 shows; A2 scheduled at ~0.6s
+    try? await Task.sleep(nanoseconds: 200_000_000)     // ~0.2s: still on A1
     overlay.showAppearancePreview(true)                 // pause the tip; sample takes the panel
-    overlay.render(["B1"], perLineSeconds: 0.4)         // a new tip arrives while previewing — must wait
+    overlay.render(["B1"], perLineSeconds: 0.6)         // a new tip arrives while previewing — must wait
 
-    try? await Task.sleep(nanoseconds: 100_000_000)     // ~0.25s
+    try? await Task.sleep(nanoseconds: 200_000_000)     // ~0.4s
     #expect(overlay.currentText == "Sample overlay text", "preview must own the panel while open")
 
     overlay.showAppearancePreview(false)                // close Settings: resume the paused tip at A2
-    try? await Task.sleep(nanoseconds: 150_000_000)     // ~0.40s into A2's window
+    try? await Task.sleep(nanoseconds: 300_000_000)     // ~0.3s into A2's resumed 0.6s window
     #expect(overlay.currentText == "A2", "the paused tip must resume its remaining line, not be dropped")
 
-    try? await Task.sleep(nanoseconds: 400_000_000)     // A2 elapses (~0.65s); the queued tip plays
+    try? await Task.sleep(nanoseconds: 600_000_000)     // A2 elapses (~0.7s after resume); the queued tip plays
     #expect(overlay.currentText == "B1", "a tip that arrived during preview must play after the resumed tip")
 }
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -69,6 +69,19 @@ moments the model judges worthwhile.
 6. `speak` renders to the **Overlay**, one line at a time (per-line display time set in `Config`).
    A newer tip never interrupts one still showing — tips queue and play in order, so no hint is lost.
 
+**Why the overlay never interrupts and never drops (and why direct-reply latency is a non-issue).**
+The queue is deliberately strict: a tip the user may still be reading is never cut off, and nothing
+is discarded. The obvious objection — "a direct *'Jarvis, help'* reply could wait tens of seconds
+behind a proactive tip" — does not apply in the real use case: **in a live interview the user never
+addresses Jarvis out loud** (speaking to an AI would expose it), so overlay traffic is *entirely
+proactive coaching* with no latency-critical direct reply to jump the queue. The accepted tradeoff is
+that a queued proactive tip can surface some seconds after it was generated; that is bounded in
+practice because `CoachDriver` runs a single turn in-flight (so tips are produced no faster than one
+brain round-trip) and the prompt keeps the model restrained. So the policy is *not interrupt + not
+drop*, not *show-freshest-only* — and adding direct-reply priority/preemption was considered and
+rejected as solving a problem the interview workflow doesn't have. (The must-reply-on-direct-address
+path still works for testing/practice; it is simply not latency-critical there.)
+
 ## 3. Components
 
 | Component | Responsibility | Built on (borrowed) |

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -53,20 +53,21 @@ moments the model judges worthwhile.
 
 1. The Transcriber emits a **turn-end** event (`gpt-4o-transcribe` server VAD ends the turn after a
    tuned silence window) or a **silence check** fires (you've gone quiet, maybe stuck). The silence
-   check carries *how long* you've been quiet and backs off across a long silence (e.g. 30s, 60s,
-   120s, …), resetting on speech.
+   check carries *how long* you've been quiet and backs off across a long silence (the interval
+   doubles each step up to a cap — see `Config`), resetting on speech.
 2. The CoachDriver calls the brain on **every** trigger — there is no cooldown, rate cap, or
    wake-word gate. Whether to speak (and whether the user just addressed Jarvis) is the model's
    call, governed by the system prompt; the only hard gate is the user's Start/Stop.
 3. It calls **`gpt-5.5`** with the coach system prompt, the recent **timestamped** transcript
-   window, the timing context (seconds silent, time on the problem), and the tool set
+   window, the timing context (seconds silent, session elapsed), and the tool set
    `[capture_screen, speak]`. The timing is what lets the model tell "thinking" from "stuck."
 4. The model may call `capture_screen`. The harness fulfills it (a silent screenshot) and
    returns the image into the conversation. The model may now reason over what's on screen.
 5. The model either calls `speak(lines)` — a tip of up to ~3 short lines, returned **already split**
    into an array (Structured Outputs / `strict:true`), so the client never splits prose on
    punctuation — or returns nothing (stay silent).
-6. `speak` renders to the **Overlay**, one line at a time, ~5 seconds each.
+6. `speak` renders to the **Overlay**, one line at a time (per-line display time set in `Config`).
+   A newer tip never interrupts one still showing — tips queue and play in order, so no hint is lost.
 
 ## 3. Components
 
@@ -77,7 +78,7 @@ moments the model judges worthwhile.
 | **Transcriber** | Maintain a rolling, speaker-labeled, **timestamped** transcript; emit turn-end events and backing-off silence checks (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
 | **CoachDriver** | The event loop. On every trigger, call the brain with the transcript + timing context and tools, route tool calls. No cooldown/rate cap — restraint is the model's. | `gpt-5.5` (vision + tool-use). |
 | **ScreenTool** | Fulfill `capture_screen`: take a silent screenshot of the active display, excluding the overlay window. | macOS `screencapture` CLI. |
-| **Overlay** | Render `speak` output: up to ~3 short lines (model-split), ~5s each, non-activating, always-on-top, excluded from capture. | AppKit NSPanel. |
+| **Overlay** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. | AppKit NSPanel. |
 | **MenuBar** | Manual **Start/Stop** of the pipeline (two states: ⚪️ stopped / 🟢 running — no auto-start), status indicator, one-time API-key entry. | AppKit menu-bar item; Keychain for the key. |
 
 Each component has one job and a narrow interface. The CoachDriver is the only place the
@@ -118,7 +119,7 @@ rather than a per-turn screenshot.
 Target: **turn-end → first overlay line < 2s.** It holds because transcription is continuous
 (no STT latency at trigger time) and most turns are text-only (no `capture_screen`), so the brain
 call is a single short round-trip. The overlay then reveals the already-returned lines one at a
-time (~5s each), so the first tip appears immediately — note the brain response itself is **not**
+time (paced by `Config`), so the first tip appears immediately — note the brain response itself is **not**
 streamed (one buffered request; the overlay just paces the display).
 
 ### Resilience

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -20,7 +20,8 @@ by the human smoke checklist in the [README](../README.md#live-smoke-checklist).
   session for multi-turn memory. **Transcription:** `gpt-4o-transcribe` over the GA Realtime API.
   API-only, no local models. Rationale: [architecture.md](./architecture.md#4-data-flow--cost-model).
 - **Overlay:** the brain returns the tip as a pre-split `lines` array (Structured Outputs); the
-  overlay shows up to ~3 short lines per response, one at a time, ~5 seconds each.
+  overlay shows up to ~3 short lines per response, one at a time. Newer tips queue behind the one on
+  screen rather than interrupting it, so no hint is dropped.
 - **Build approach: native Swift, directly.** The two-phase plan (fork Natively first, then native)
   was dropped: **Phase 1 is skipped** and we build the clean native Swift app now. The fork
   evaluation and survey still stand as the *why-build-our-own* basis ([fork evaluation](./fork-evaluation.md),
@@ -59,9 +60,10 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **Tuned `server_vad`+debounce (not `semantic_vad`); quiet graceful Stop** — fixes from first live smoke run (2026-06-15) | [architecture.md](./architecture.md#models-and-apis) |
 | **Dev activity viewer = in-app `WKWebView`** (live push, no meta-refresh; screenshot lightbox; persisted JSONL session history + clear-history) | [build-and-run.md](./build-and-run.md) |
 | **Overlay hidden from screen capture/sharing via `sharingType = .none`** — verified on macOS 26.5 incl. live `SCStream`; re-asserted on `show()` as defense-in-depth | [overlay-invisibility.md](./overlay-invisibility.md) |
-| **Cut the guardrail layer: no cooldown/rate cap, no wake-word detector; brain self-gates speaking; silence check backs off (30s→240s)** — simplify the flow, cut log noise, natural conversation (2026-06-16) | [architecture.md §5](./architecture.md#5-safety-model) |
+| **Cut the guardrail layer: no cooldown/rate cap, no wake-word detector; brain self-gates speaking; silence check backs off across a long silence** — simplify the flow, cut log noise, natural conversation (2026-06-16) | [architecture.md §5](./architecture.md#5-safety-model) |
 | **`speak` returns a `lines` array via Structured Outputs (`strict:true`), not a free-form string** — the model splits the tip into overlay lines, so the client no longer splits prose on `.`/`!`/`?` (which shattered code like `Array.from(...)`) (2026-06-17) | [architecture.md §2](./architecture.md#2-core-loop) |
 | **Unified Settings window** replaces the separate API-key dialog and log-viewer menu item; overlay text size (12–32 pt, default 18) + background opacity (40–100%, default 78%) are now user-adjustable and persisted via `OverlayAppearance` (UserDefaults) (2026-06-17) | [settings-window.md](./settings-window.md) |
+| **Tuned overlay/silence timing + sharpened coach prompt** — longer per-line overlay display, later first silence nudge over a wider backoff ramp, plain-language hints for interview stress, explicit `me`/`them` speaker handling; overlay now **queues** tips so a newer one never cuts off the current (2026-06-18) | [architecture.md §2](./architecture.md#2-core-loop) |
 
 ## Open Questions / To Confirm
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -64,6 +64,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **`speak` returns a `lines` array via Structured Outputs (`strict:true`), not a free-form string** — the model splits the tip into overlay lines, so the client no longer splits prose on `.`/`!`/`?` (which shattered code like `Array.from(...)`) (2026-06-17) | [architecture.md §2](./architecture.md#2-core-loop) |
 | **Unified Settings window** replaces the separate API-key dialog and log-viewer menu item; overlay text size (12–32 pt, default 18) + background opacity (40–100%, default 78%) are now user-adjustable and persisted via `OverlayAppearance` (UserDefaults) (2026-06-17) | [settings-window.md](./settings-window.md) |
 | **Tuned overlay/silence timing + sharpened coach prompt** — longer per-line overlay display, later first silence nudge over a wider backoff ramp, plain-language hints for interview stress, explicit `me`/`them` speaker handling; overlay now **queues** tips so a newer one never cuts off the current (2026-06-18) | [architecture.md §2](./architecture.md#2-core-loop) |
+| **Overlay is never-interrupt + never-drop, not show-freshest** — direct-reply queue-priority/preemption considered and **rejected**: in a live interview the user never addresses Jarvis aloud, so overlay traffic is all proactive coaching with no latency-critical reply to jump the queue (2026-06-18) | [architecture.md §2](./architecture.md#2-core-loop) |
 
 ## Open Questions / To Confirm
 


### PR DESCRIPTION
## What & why

Tuning the coach's behavior, a holistic prompt review acted on, plus an overlay queue.

### Timing
- **Overlay tips linger longer**: per-line display `5s → 15s`.
- **Silence check starts later and ramps further**: base `30s → 120s` (2 min), backoff cap `240s → 960s` (16 min) — same 8× ratio / multi-step ramp: `2m → 4m → 8m → 16m`, reset on speech.

### Overlay queue (no dropped hints)
- A newer tip **no longer interrupts** one still on screen. `OverlayPanel` now holds a FIFO queue: tips play in arrival order and the current tip is never cut off. Covered by a new `JarvisOverlayTests` case asserting non-interruption + ordering.

### Coach system prompt
- **Plain-language hints** for interview stress (everyday words, one idea per line, concrete next action, most-useful-first).
- **Speaker handling**: transcript is labeled `me:` / `them:`. Coach only `me`; read `them:` (interviewer) lines as *problem context* to fold into hints; never reply just because `them` spoke. Now that **#13 ships live `them` capture**, this is wired to real data.
- **Don't-repeat / escalate** rule.
- **Pronoun consistency**: anchored "the user" = "me", and scoped the screen-check trigger to `me` so a `them:` line can't fire it.
- **Accurate timing wording**: "on this problem" → "the session has been running" (prompt + `Trigger.swift`), pinned by a new `TriggerContextTests`.

### Review follow-ups (from the multi-angle review of this PR)
- De-hardcoded timing values in `wiki/architecture.md` + `wiki/status.md` (reference `Config` per wiki rule 4 so they can't re-drift), noted the queue behavior, added a tuning decision-log entry.
- Dropped `RealtimeTranscriber`'s stale `30`/`240` silence defaults (both call sites pass `Config` explicitly) and de-hardcoded the backoff comment.

## Testing
- `./scripts/run-tests.sh` — **94 tests pass**. `swift build` clean.
- Rebased onto latest `main` (post-#17 `lines` model and post-#13 system-audio `them` capture); conflicts resolved by adopting both upstream changes while keeping the new values, queue, and prompt text.

> Behavioral effects (plainer hints, ignoring interviewer speech as an addressee, queue feel) are model/runtime-driven — confirm with a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)