### PR TITLE
Use async stopCapture() in SystemAudioInput start path

### DIFF
--- a/Sources/JarvisApp/Capture/SystemAudioInput.swift
+++ b/Sources/JarvisApp/Capture/SystemAudioInput.swift
@@ -79,7 +79,7 @@ final class SystemAudioInput: NSObject, SCStreamOutput, SCStreamDelegate, @unche
             // SCStream requires startCapture() to COMPLETE before stopCapture() — they must not run
             // concurrently. So stop() defers the actual teardown of a not-yet-started stream to here:
             // if stop() raced in during the await above, we stop the stream now, after start finished.
-            if markStartedOrShouldStop() { stream.stopCapture { _ in }; return }
+            if markStartedOrShouldStop() { try? await stream.stopCapture(); return }
             jlog("Jarvis system audio: capturing 'them' side via ScreenCaptureKit")
         } catch {
             jlog("Jarvis system audio: capture unavailable (\(error)); mic ('me') side still active")


### PR DESCRIPTION
## What

Fixes the Swift 6 build warning on `swift build -c release`:

```
SystemAudioInput.swift:82:51: warning: consider using asynchronous alternative function
  if markStartedOrShouldStop() { stream.stopCapture { _ in }; return }
```

The startup-race teardown in `startCapture()` called the completion-handler `stopCapture { _ in }` from within an `async` context. Swapped it for `try? await stream.stopCapture()` — behaviorally identical fire-and-forget teardown (errors ignored), warning gone.

## Notes

- The identical call in the synchronous `stop()` (line 112) is intentionally left as-is — the async form isn't callable from a sync context and it doesn't emit the warning. Each call site uses the correct API for its context.
- The unrelated `ld: warning: search path '/usr/local/lib' is not a directory` is toolchain noise (a default linker search path absent on Apple-Silicon machines without Intel Homebrew), not introduced by this repo and not addressed here.

## Verification

`swift build -c release` is clean of the async warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)