### PR TITLE
Open a fresh dev session on every Start

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -57,7 +57,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         var sections: [SettingsSection] = [
             APIKeySection(keychain: keychain, onKeySaved: { [weak self] _ in
                 guard let self, self.transcriber != nil else { return }
-                self.menuBar.setRunning(self.start())
+                // Re-saving a key while running only re-applies it to the pipeline — it is NOT a new
+                // coaching run, so keep the current session (don't rotate logs). Session rotation is
+                // reserved for an explicit user Start.
+                self.menuBar.setRunning(self.start(freshSession: false))
             }),
             OverlaySection(appearance: appearance, applying: overlay),
         ]
@@ -80,16 +83,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Build the brain + driver and start the transcription pipeline. Returns `false` (and stays
     /// stopped) if no API key is available yet.
+    ///
+    /// `freshSession` is true for a user-initiated Start (rotate to a fresh dev session + logs) and
+    /// false for an in-place restart that only re-applies a setting — e.g. saving a new API key while
+    /// running — which must NOT be misattributed as a new coaching run.
     @discardableResult
-    private func start() -> Bool {
+    private func start(freshSession: Bool = true) -> Bool {
         guard let key = secrets.apiKey(), !key.isEmpty else {
             jlog("Jarvis: can't start — no API key.")
             warnNoKey()
             return false
         }
         stop() // tear down any existing pipeline so we start cleanly
-        beginNewSession()       // dev mode: rotate to a fresh session dir + activity/debug log
-        menuBar.resetCounter()  // a Start begins a fresh session
+        if freshSession {
+            beginNewSession()       // dev mode: rotate to a fresh session dir + activity/debug log
+            menuBar.resetCounter()  // a user Start begins a fresh session
+        }
 
         let brain = OpenAIBrainClient(apiKey: key, model: config.brainModel,
                                       reasoningEffort: config.reasoningEffort)

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -35,21 +35,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
 
         if devMode {
-            // Each dev-mode launch is its own session: nest logs under a unique per-launch
-            // subdirectory so each debug/dev run keeps its own separated logs.
-            let dir = devLogDirectory().appendingPathComponent(newSessionID())
-            // 0700: the screenshots/logs inside are 0600, so the directory holding them must be
-            // owner-only too — otherwise a 0755 dir leaks file names/counts/timestamps to other
-            // local users (CWE-732). Applies to the created session dir and any intermediates.
-            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true,
-                                                     attributes: [.posixPermissions: 0o700])
-            JarvisLog.enableFileLogging(directory: dir)     // <dir>/jarvis-debug.log, 0600, fresh
-            ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.jsonl, 0600, fresh
-            // The viewer can browse every past session under the base log dir; clear-history spares
-            // this one.
+            // The activity viewer lives for the whole dev run, but a *session* is one coaching run:
+            // each Start opens a fresh session dir + logs (see `beginNewSession`). No session exists
+            // until the first Start, so the viewer starts with no current session to browse.
             activityViewer = ActivityViewer(log: .shared,
-                                            store: SessionStore(base: devLogDirectory(), current: dir))
-            jlog("Jarvis: dev mode — session \(dir.lastPathComponent) (\(dir.path)).")
+                                            store: SessionStore(base: devLogDirectory(), current: nil))
         }
 
         // Ask for Microphone + Screen Recording up front, not lazily mid-session.
@@ -98,6 +88,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         stop() // tear down any existing pipeline so we start cleanly
+        beginNewSession()       // dev mode: rotate to a fresh session dir + activity/debug log
         menuBar.resetCounter()  // a Start begins a fresh session
 
         let brain = OpenAIBrainClient(apiKey: key, model: config.brainModel,
@@ -195,8 +186,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.runModal()
     }
 
-    /// A unique id for this dev-mode launch, used as the session's log subdirectory name. Sortable
-    /// timestamp + a short random suffix so two launches in the same second don't collide.
+    /// Open a fresh dev session: a new per-Start subdirectory under the base log dir, with its own
+    /// `jarvis-debug.log` and `jarvis-activity.jsonl`. Called on every Start so each coaching run keeps
+    /// its own logs instead of resuming the previous run's. No-op outside dev mode.
+    private func beginNewSession() {
+        guard devMode else { return }
+        let dir = devLogDirectory().appendingPathComponent(newSessionID())
+        // 0700: the screenshots/logs inside are 0600, so the directory holding them must be owner-only
+        // too — otherwise a 0755 dir leaks file names/counts/timestamps to other local users (CWE-732).
+        // Applies to the created session dir and any intermediates.
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true,
+                                                 attributes: [.posixPermissions: 0o700])
+        JarvisLog.enableFileLogging(directory: dir)     // <dir>/jarvis-debug.log, 0600, fresh
+        ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.jsonl, 0600, fresh
+        // Point the viewer's history browser at the new current session and show it live; clear-history
+        // spares whichever session is current.
+        activityViewer?.sessionDidChange(base: devLogDirectory(), current: dir)
+        jlog("Jarvis: dev mode — session \(dir.lastPathComponent) (\(dir.path)).")
+    }
+
+    /// A unique id for a dev session (one per Start), used as its log subdirectory name. Sortable
+    /// timestamp + a short random suffix so two Starts in the same second don't collide.
     private func newSessionID() -> String {
         let f = DateFormatter()
         // Fixed-format timestamp: pin locale + calendar so the name is always Gregorian yyyy-MM-dd
@@ -210,7 +220,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Where dev-mode logs go: `--log-dir <path>` (run-dev.sh passes the workspace `.jarvis/`),
     /// else a per-user Caches/Jarvis directory. Never `/tmp` (world-readable, shared across users).
-    /// Each launch nests a per-session subdirectory under this base (see `newSessionID`).
+    /// Each Start nests a per-session subdirectory under this base (see `beginNewSession`).
     private func devLogDirectory() -> URL {
         let args = CommandLine.arguments
         if let i = args.firstIndex(of: "--log-dir"), i + 1 < args.count {

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -9,7 +9,7 @@ import JarvisCore
 @MainActor
 final class ActivityViewer: NSObject, WKNavigationDelegate {
     private let log: ActivityLog
-    private let store: SessionStore
+    private var store: SessionStore   // rebuilt when a new session opens (see `sessionDidChange`)
 
     private var webView: WKWebView?
     private var picker: NSPopUpButton?
@@ -87,6 +87,17 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         loaded = false
         pending = []
         snapshotRows = []
+    }
+
+    /// A new coaching session opened (a Start rotated the session dir). Re-point the history browser at
+    /// the new current dir; if the viewer is on-screen, refresh the picker and re-attach to the fresh
+    /// live session. `ActivityLog.enable` dropped the previous observer, so without this an open viewer
+    /// would freeze on the old session's rows. No-op when not embedded — the next open reads it fresh.
+    func sessionDidChange(base: URL, current: URL?) {
+        store = SessionStore(base: base, current: current)
+        guard webView != nil else { return }
+        populatePicker()
+        loadCurrent()
     }
 
     // MARK: - Session list

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -243,6 +243,10 @@ public final class CoachDriver: @unchecked Sendable {
                 // off the cooperative pool so it doesn't stall a pool thread while holding the slot.
                 let screen = self.screen
                 let img = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+                // Stop may have fired during the (un-cancellable, detached) capture. Bail before
+                // emitting: otherwise this screenshot — and the reasoning that follows — would be
+                // logged into whatever session is now current (a Start rotates the dev log mid-turn).
+                if Task.isCancelled { jlog("… turn cancelled (stopped) after capture"); return .cancelled }
                 if let img { jlog("👁 looking at your screen", image: img) }   // thumbnail in the dev viewer
                 else { jlog("👁 screenshot failed") }
                 if convId == nil {
@@ -271,6 +275,10 @@ public final class CoachDriver: @unchecked Sendable {
                 continue // let the model reason over the image
 
             case .speak(let callId, let lines):
+                // Last gate before side effects: a turn cancelled by Stop (or a Stop→Start that
+                // rotated the dev session) must not render a stale tip, bump the counter, or log into
+                // the new session. This is the "speak after Stop" guard the TurnTaskBox relies on.
+                if Task.isCancelled { jlog("… turn cancelled (stopped) before speaking"); return .cancelled }
                 jlog("💬 \(lines.joined(separator: " "))")
                 overlay.render(lines, perLineSeconds: config.lineDisplaySeconds)
                 onSpoke?()

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -34,7 +34,10 @@ public struct SessionStore: Sendable {
     private struct Line: Decodable { let t: String; let m: String; let s: String? }
 
     /// Immediate subdirectories of `base` that look like a session and hold a `jarvis-activity.jsonl`,
-    /// newest-first. The live session always appears (its `.jsonl` is created on `enable`).
+    /// newest-first. The current session always appears (so the live run shows in the picker even
+    /// before it records anything); a PAST session appears only if it has coaching content — a Start
+    /// that produced nothing but lifecycle breadcrumbs (failed/instantly-stopped run) is hidden rather
+    /// than cluttering history. (`enable` creates an empty `.jsonl` so the live session is discoverable.)
     public func listSessions() -> [Session] {
         let curPath = current?.standardizedFileURL.path
         let names = (try? FileManager.default.contentsOfDirectory(atPath: base.path)) ?? []
@@ -42,12 +45,27 @@ public struct SessionStore: Sendable {
             .filter { Self.isSessionID($0) }
             .filter { FileManager.default.fileExists(atPath:
                 base.appendingPathComponent($0).appendingPathComponent("jarvis-activity.jsonl").path) }
-            .sorted(by: >)   // id is a lexically-sortable timestamp ⇒ newest first
-            .map { name in
+            .map { name -> Session in
                 let url = base.appendingPathComponent(name)
-                return Session(id: name, label: Self.label(from: name), url: url,
-                               isCurrent: curPath != nil && url.standardizedFileURL.path == curPath)
+                let isCurrent = curPath != nil && url.standardizedFileURL.path == curPath
+                return Session(id: name, label: Self.label(from: name), url: url, isCurrent: isCurrent)
             }
+            .filter { $0.isCurrent || Self.hasCoachingContent($0.url) }
+            .sorted { $0.id > $1.id }   // id is a lexically-sortable timestamp ⇒ newest first
+    }
+
+    /// Whether a session's log holds anything worth browsing: at least one coaching-class line
+    /// (`💬`/`👁`/`🗣`/`🤫`/`💭`/error — see `ActivityLog.cssClass`) or a captured screenshot. Pure
+    /// lifecycle noise ("coaching started"/"stopped") classifies as empty, so an aborted run is hidden.
+    private static func hasCoachingContent(_ sessionURL: URL) -> Bool {
+        let url = sessionURL.appendingPathComponent("jarvis-activity.jsonl")
+        guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
+        for raw in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let line = try? JSONDecoder().decode(Line.self, from: Data(raw.utf8)) else { continue }
+            if line.s != nil { return true }
+            if !ActivityLog.cssClass(for: line.m).isEmpty { return true }
+        }
+        return false
     }
 
     /// Decode a session's `.jsonl` into entries paired with their screenshot bytes (when the `s`

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -51,6 +51,23 @@ final class FakeScreen: ScreenCapturing, @unchecked Sendable {
     func capture() -> String? { captureCount += 1; return payload }
 }
 
+/// A screen whose `capture()` parks until released, so a test can cancel the turn *while the
+/// (detached, un-cancellable) screenshot is in flight* — the exact window the cancellation guard
+/// closes. `entered` signals capture has begun; `release` lets it return.
+final class GatedScreen: ScreenCapturing, @unchecked Sendable {
+    let entered = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+    private(set) var captureCount = 0
+    let payload: String
+    init(payload: String = "ZmFrZS1qcGVn") { self.payload = payload }
+    func capture() -> String? {
+        captureCount += 1
+        entered.signal()
+        release.wait()
+        return payload
+    }
+}
+
 final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// One entry per `render` call: the lines the brain returned, passed straight through (no splitting).
     var rendered: [[String]] = []
@@ -149,6 +166,35 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(bytes.prefix(2) == Data([0xFF, 0xD8]) && bytes.suffix(2) == Data([0xFF, 0xD9]))
         let perms = try FileManager.default.attributesOfItem(atPath: shot.path)[.posixPermissions] as? NSNumber
         #expect(perms?.int16Value == 0o600)
+    }
+
+    /// Stop cancelling a turn *while the screenshot is being captured* must abort before emitting:
+    /// no "👁" line, no follow-up reasoning, no `speak`. The detached capture doesn't inherit
+    /// cancellation, so without the post-capture guard the screenshot (and a stale tip) would leak —
+    /// into the NEW session once a Start has rotated the dev log mid-turn.
+    @Test func cancelDuringCaptureAbortsBeforeEmitting() async {
+        let clock = ManualClock(now: 0)
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "c")],
+                  rawToolCalls: [RawToolCall(id: "c", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(toolCalls: [.speak(callId: "s", lines: ["stale tip from the stopped run"])]),
+        ])
+        let screen = GatedScreen()
+        let overlay = FakeOverlay()
+        let (driver, transcript) = makeDriver(brain: brain, screen: screen, overlay: overlay, clock: clock)
+        transcript.append(.init(speaker: .me, text: "here is my code", at: 0))
+
+        let task = Task { await driver.handleTrigger(.turnEnd) }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async { screen.entered.wait(); cont.resume() }   // capture in flight
+        }
+        task.cancel()                                         // Stop fires mid-capture
+        screen.release.signal()                               // let the screenshot finish
+
+        #expect(await task.value == .cancelled)
+        #expect(screen.captureCount == 1)        // captured once...
+        #expect(overlay.rendered.isEmpty)        // ...but never rendered a tip after Stop
+        #expect(brain.calls.count == 1)          // and never looped back to the brain with the image
     }
 
     /// A `speak` with an empty `lines` array (the decode fallback, or a model returning []) is passed

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -14,8 +14,9 @@ import Foundation
 
     @Test func listsNewestFirstWithCurrentFlagged() throws {
         let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
-        try makeSession(base, "2026-06-16_10-00-00_aaaa", lines: ["{\"t\":\"10:00:00\",\"m\":\"x\"}"])
-        try makeSession(base, "2026-06-16_11-00-00_bbbb", lines: ["{\"t\":\"11:00:00\",\"m\":\"y\"}"])
+        // Coaching-class lines (🗣) so both sessions count as content-bearing history.
+        try makeSession(base, "2026-06-16_10-00-00_aaaa", lines: ["{\"t\":\"10:00:00\",\"m\":\"🗣 heard: x\"}"])
+        try makeSession(base, "2026-06-16_11-00-00_bbbb", lines: ["{\"t\":\"11:00:00\",\"m\":\"🗣 heard: y\"}"])
         // A non-session subdir must be ignored.
         try FileManager.default.createDirectory(at: base.appendingPathComponent("not-a-session"),
                                                 withIntermediateDirectories: true)
@@ -26,6 +27,29 @@ import Foundation
         #expect(sessions[0].isCurrent == true)
         #expect(sessions[0].label == "2026-06-16 11:00:00")
         #expect(sessions[1].isCurrent == false)
+    }
+
+    @Test func hidesContentlessPastSessionsButKeepsCurrentAndContentful() throws {
+        let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        // A past session with only lifecycle breadcrumbs (no coaching class, no shot) — an aborted run.
+        try makeSession(base, "2026-06-16_09-00-00_aaaa", lines: [
+            "{\"t\":\"09:00:00\",\"m\":\"Jarvis: dev mode — session …\"}",
+            "{\"t\":\"09:00:01\",\"m\":\"Jarvis: coaching started (mic + system audio).\"}",
+            "{\"t\":\"09:00:02\",\"m\":\"Jarvis: stopped.\"}",
+        ])
+        // A past session that actually coached (has a 💬 line) — keep it.
+        try makeSession(base, "2026-06-16_10-00-00_bbbb", lines: ["{\"t\":\"10:00:00\",\"m\":\"💬 try this\"}"])
+        // A past session whose only content is a screenshot reference — keep it.
+        try makeSession(base, "2026-06-16_10-30-00_cccc", lines: ["{\"t\":\"10:30:00\",\"m\":\"saw\",\"s\":\"shot-1.jpg\"}"])
+        // The current session, breadcrumbs only — always shown so the live run appears in the picker.
+        try makeSession(base, "2026-06-16_11-00-00_dddd", lines: ["{\"t\":\"11:00:00\",\"m\":\"Jarvis: coaching started.\"}"])
+
+        let cur = base.appendingPathComponent("2026-06-16_11-00-00_dddd")
+        let ids = SessionStore(base: base, current: cur).listSessions().map(\.id)
+        #expect(ids == ["2026-06-16_11-00-00_dddd",   // current, kept despite breadcrumbs-only
+                        "2026-06-16_10-30-00_cccc",   // has a screenshot
+                        "2026-06-16_10-00-00_bbbb"])  // has a coaching line
+        #expect(!ids.contains("2026-06-16_09-00-00_aaaa"))   // aborted run hidden
     }
 
     @Test func entriesDecodeTolerateMalformedAndGuardTraversal() throws {

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -68,10 +68,11 @@ sidesteps the `file://` `fetch()` restriction that forced the original viewer's 
 reload.
 
 - New events stream in live (no reload, no flicker); thumbnails open in an in-page lightbox.
-- Sessions are persisted per launch as owner-only `jarvis-activity.jsonl` + `shot-N.jpg`, so past
-  runs can be browsed and the history cleared from the viewer.
+- Each Start opens a fresh session (a Stop→Start gets a new log, never resuming the previous run),
+  persisted as owner-only `jarvis-activity.jsonl` + `shot-N.jpg`, so past runs can be browsed and the
+  history cleared from the viewer.
 - **File logging is dev-only.** Outside `--dev`, `jlog` writes solely to the unified log (Console.app),
-  never a flat file. The dev files are `0600` in a gitignored per-launch `.jarvis/<session>/` — the
+  never a flat file. The dev files are `0600` in a gitignored per-session `.jarvis/<session>/` — the
   full privacy posture is in [sandbox.md](./sandbox.md).
 - The viewer's rendering logic (`htmlShell`/`rowScript`) and history reader (`SessionStore`) live in
   `JarvisCore` so they're unit/WebKit-tested; `ActivityViewer` in `JarvisApp` is the thin window.


### PR DESCRIPTION
## What

Every Start now opens a **fresh dev-mode session** (its own activity log, debug log, and screenshots) instead of resuming the previous run's.

## Why

A session was created **once per process launch** (`applicationDidFinishLaunching`). `start()`/`stop()` only built and tore down the coaching pipeline — they never rotated the session. So a **Stop → Start within one running process** kept appending to the same `jarvis-activity.jsonl`, which is the "it resumes the previous session" behavior reported.

## How

- **`AppDelegate`**: removed session creation from launch; added `beginNewSession()` (fresh `0700` dir + fresh `0600` `jarvis-debug.log` / `jarvis-activity.jsonl`), called from `start()` right after the `stop()` teardown. A session is now one coaching run (Start → Stop).
- **`ActivityViewer`**: `store` is mutable with a new `sessionDidChange(base:current:)` so the history browser re-points at the rotated session. Necessary because `ActivityLog.enable()` drops the prior observer — without it an *open* viewer would freeze on the old session's rows after a rotation.
- **wiki/build-and-run.md**: updated "per launch" → "per session / each Start".

## Behavior notes

- No session exists until the first Start, so launch-time messages go only to Console/NSLog (no coaching run = no session file).
- The just-finished session stays browsable and remains "current" until the next Start; `clearHistory` still spares the current one.

## Verification

- `swift build` clean; `./scripts/run-tests.sh` → 105/105 pass.
- Rotation logic lives in `JarvisApp` (intentionally not unit-tested per CLAUDE.md); live Stop→Start→new-log behavior to be confirmed via `./scripts/build-app.sh --dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)