### PR TITLE
Expand the overlay window to fit long text

### DIFF
--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -83,28 +83,30 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             label.centerYAnchor.constraint(equalTo: content.centerYAnchor),
         ])
         super.init()
-        resizeToFit("")   // start at the floor height, centered along the bottom
+        resizeToFit()   // label is empty → floor height, centered along the bottom
     }
 
-    /// Height the panel needs to show `text` without clipping: the wrapped text height (measured at the
-    /// label's current font, constrained to the label's width) plus padding above and below, floored at
-    /// `minHeight`. Foundation/AppKit text measurement — no layout pass required.
-    private func fittedHeight(for text: String) -> CGFloat {
-        let font = label.font ?? .systemFont(ofSize: CGFloat(Config.overlayFontSizeDefault), weight: .medium)
+    /// Height the panel needs to show the label's *current* text without clipping: the wrapped text
+    /// height plus padding above and below, floored at `minHeight`. Measured through the label's own
+    /// cell (`cellSize(forBounds:)`) rather than `NSString.boundingRect`, so the wrap width and line
+    /// count match what's actually laid out — the cell reserves a small horizontal inset that a bare
+    /// `boundingRect` ignores, which at large fonts could under-measure by a row and clip the text the
+    /// resize exists to reveal. Callers set `label.stringValue` before invoking, so the cell holds the
+    /// right string.
+    private func fittedHeight() -> CGFloat {
         let innerWidth = Layout.width - 2 * Layout.horizontalPadding
-        let bounding = (text as NSString).boundingRect(
-            with: NSSize(width: innerWidth, height: .greatestFiniteMagnitude),
-            options: [.usesLineFragmentOrigin, .usesFontLeading],
-            attributes: [.font: font])
-        return max(Layout.minHeight, ceil(bounding.height) + 2 * Layout.verticalPadding)
+        let bounds = NSRect(x: 0, y: 0, width: innerWidth, height: .greatestFiniteMagnitude)
+        let measured = label.cell?.cellSize(forBounds: bounds).height ?? 0
+        return max(Layout.minHeight, ceil(measured) + 2 * Layout.verticalPadding)
     }
 
-    /// Re-center the panel along the bottom of the screen and size its height to fit `text`. The bottom
-    /// edge stays pinned at `bottomMargin`, so a taller panel grows *upward* and a long line is fully
-    /// shown rather than clipped by the old fixed height. Off-screen-session-safe: if there's no main
-    /// screen it keeps the current origin (only tests hit that path) and still applies the fitted height.
-    private func resizeToFit(_ text: String) {
-        let h = fittedHeight(for: text)
+    /// Re-center the panel along the bottom of the screen and size its height to fit the label's current
+    /// text. The bottom edge stays pinned at `bottomMargin`, so a taller panel grows *upward* and a long
+    /// line is fully shown rather than clipped by the old fixed height. Off-screen-session-safe: if
+    /// there's no main screen it keeps the current origin (only tests hit that path) and still applies
+    /// the fitted height. Set `label.stringValue` before calling.
+    private func resizeToFit() {
+        let h = fittedHeight()
         let w = Layout.width
         var origin = panel.frame.origin
         if let screen = NSScreen.main {
@@ -160,7 +162,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             return
         }
         label.stringValue = tip.lines[line]
-        resizeToFit(tip.lines[line])   // grow the panel so a long line isn't clipped
+        resizeToFit()   // grow the panel so a long line isn't clipped
         panel.orderFrontRegardless()
         active = (tip, line + 1)
         scheduleTick(after: tip.seconds[line]) { $0.gapThenAdvance() }
@@ -210,7 +212,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     public func setFontSize(_ points: Double) {
         label.font = .systemFont(ofSize: CGFloat(points), weight: .medium)
         // Re-fit the live preview so a larger font doesn't overflow the sample mid-adjust.
-        if isPreviewing { resizeToFit(Self.previewText) }
+        if isPreviewing { resizeToFit() }
     }
 
     public func setBackgroundOpacity(_ opacity: Double) {
@@ -228,7 +230,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             reassertCaptureExclusion()
             isPreviewing = true
             label.stringValue = Self.previewText
-            resizeToFit(Self.previewText)
+            resizeToFit()
             panel.orderFrontRegardless()
         } else if isPreviewing {
             isPreviewing = false

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -105,11 +105,17 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     /// line is fully shown rather than clipped by the old fixed height. Off-screen-session-safe: if
     /// there's no main screen it keeps the current origin (only tests hit that path) and still applies
     /// the fitted height. Set `label.stringValue` before calling.
+    ///
+    /// This now runs per line (not once at init), so it prefers the panel's *current* screen over
+    /// `NSScreen.main`: `NSScreen.main` follows keyboard focus, and recomputing it every line would
+    /// relocate an in-flight tip onto another display the instant the user shifts focus mid-tip. Pinning
+    /// to `panel.screen` keeps a playing tip put; the `NSScreen.main` fallback covers the first call,
+    /// when the panel isn't on a screen yet.
     private func resizeToFit() {
         let h = fittedHeight()
         let w = Layout.width
         var origin = panel.frame.origin
-        if let screen = NSScreen.main {
+        if let screen = panel.screen ?? NSScreen.main {
             let f = screen.visibleFrame
             origin = NSPoint(x: f.midX - w / 2, y: f.minY + Layout.bottomMargin)
         }
@@ -263,4 +269,8 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
 
     /// The panel's current height in points — lets tests assert it grows to fit a long line.
     var currentPanelHeight: CGFloat { panel.frame.height }
+
+    /// The panel's bottom edge (frame.minY) — lets tests assert the panel grows *upward* (this stays
+    /// pinned) rather than downward off the screen.
+    var currentPanelBottom: CGFloat { panel.frame.minY }
 }

--- a/Sources/JarvisOverlay/OverlayPanel.swift
+++ b/Sources/JarvisOverlay/OverlayPanel.swift
@@ -31,8 +31,22 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
     /// Test hook (internal): counts how many times `show()` has re-asserted capture exclusion.
     private(set) var captureExclusionReassertCount = 0
 
+    /// Fixed panel geometry. Width and bottom margin are constant; the *height* grows to fit the
+    /// wrapped line so a long tip can't overflow the window (see `fittedHeight` / `resizeToFit`).
+    private enum Layout {
+        static let width: CGFloat = 520
+        /// Floor height — a single short line sits in a panel this tall.
+        static let minHeight: CGFloat = 80
+        /// Inset between the panel edge and the label (matches the label's leading/trailing constraints).
+        static let horizontalPadding: CGFloat = 16
+        /// Inset above and below the text, each side — the slack added to the measured text height.
+        static let verticalPadding: CGFloat = 16
+        /// Gap from the screen's bottom to the panel's bottom edge (which stays fixed as it grows up).
+        static let bottomMargin: CGFloat = 80
+    }
+
     public override init() {
-        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: 520, height: 80),
+        panel = NSPanel(contentRect: NSRect(x: 0, y: 0, width: Layout.width, height: Layout.minHeight),
                         styleMask: [.nonactivatingPanel, .borderless],
                         backing: .buffered, defer: false)
         panel.level = .floating
@@ -69,14 +83,35 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             label.centerYAnchor.constraint(equalTo: content.centerYAnchor),
         ])
         super.init()
-        positionBottomCenter()
+        resizeToFit("")   // start at the floor height, centered along the bottom
     }
 
-    private func positionBottomCenter() {
-        guard let screen = NSScreen.main else { return }
-        let f = screen.visibleFrame
-        let w: CGFloat = 520, h: CGFloat = 80
-        panel.setFrame(NSRect(x: f.midX - w / 2, y: f.minY + 80, width: w, height: h), display: true)
+    /// Height the panel needs to show `text` without clipping: the wrapped text height (measured at the
+    /// label's current font, constrained to the label's width) plus padding above and below, floored at
+    /// `minHeight`. Foundation/AppKit text measurement — no layout pass required.
+    private func fittedHeight(for text: String) -> CGFloat {
+        let font = label.font ?? .systemFont(ofSize: CGFloat(Config.overlayFontSizeDefault), weight: .medium)
+        let innerWidth = Layout.width - 2 * Layout.horizontalPadding
+        let bounding = (text as NSString).boundingRect(
+            with: NSSize(width: innerWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font])
+        return max(Layout.minHeight, ceil(bounding.height) + 2 * Layout.verticalPadding)
+    }
+
+    /// Re-center the panel along the bottom of the screen and size its height to fit `text`. The bottom
+    /// edge stays pinned at `bottomMargin`, so a taller panel grows *upward* and a long line is fully
+    /// shown rather than clipped by the old fixed height. Off-screen-session-safe: if there's no main
+    /// screen it keeps the current origin (only tests hit that path) and still applies the fitted height.
+    private func resizeToFit(_ text: String) {
+        let h = fittedHeight(for: text)
+        let w = Layout.width
+        var origin = panel.frame.origin
+        if let screen = NSScreen.main {
+            let f = screen.visibleFrame
+            origin = NSPoint(x: f.midX - w / 2, y: f.minY + Layout.bottomMargin)
+        }
+        panel.setFrame(NSRect(x: origin.x, y: origin.y, width: w, height: h), display: true)
     }
 
     /// OverlayRendering witness — nonisolated so it satisfies the protocol; hops to the main actor.
@@ -125,6 +160,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             return
         }
         label.stringValue = tip.lines[line]
+        resizeToFit(tip.lines[line])   // grow the panel so a long line isn't clipped
         panel.orderFrontRegardless()
         active = (tip, line + 1)
         scheduleTick(after: tip.seconds[line]) { $0.gapThenAdvance() }
@@ -173,6 +209,8 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
 
     public func setFontSize(_ points: Double) {
         label.font = .systemFont(ofSize: CGFloat(points), weight: .medium)
+        // Re-fit the live preview so a larger font doesn't overflow the sample mid-adjust.
+        if isPreviewing { resizeToFit(Self.previewText) }
     }
 
     public func setBackgroundOpacity(_ opacity: Double) {
@@ -190,6 +228,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
             reassertCaptureExclusion()
             isPreviewing = true
             label.stringValue = Self.previewText
+            resizeToFit(Self.previewText)
             panel.orderFrontRegardless()
         } else if isPreviewing {
             isPreviewing = false
@@ -219,4 +258,7 @@ public final class OverlayPanel: NSObject, OverlayRendering, OverlayAppearanceAp
 
     /// Whether the panel is on screen — lets tests assert the drain-then-hide transition.
     var isPanelVisible: Bool { panel.isVisible }
+
+    /// The panel's current height in points — lets tests assert it grows to fit a long line.
+    var currentPanelHeight: CGFloat { panel.frame.height }
 }

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -82,6 +82,11 @@ import AppKit
     }
 
     @Test
+    func overlayExpandsToFitLongText() async {
+        await checkPanelGrowsForLongText()
+    }
+
+    @Test
     func overlayKeepsPerLineTimesAlignedWhenDroppingEmptyLines() async {
         await checkRenderAlignsTimesWhenDroppingEmptyLines()
     }
@@ -216,6 +221,28 @@ private func checkInterLineGapBlanks() async {
 
     try? await Task.sleep(nanoseconds: 500_000_000)     // ~1.1s: past the gap, second line up
     #expect(overlay.currentText == "L2", "the next line must appear after the gap")
+}
+
+// A line too long to fit one row must not be clipped by the old fixed 80pt window: the panel grows
+// taller to fit the wrapped text, while a short line stays at the floor height. Guards the overflow fix.
+@MainActor
+private func checkPanelGrowsForLongText() async {
+    let overlay = OverlayPanel()
+    overlay.interLineGapSeconds = 0   // no gap between the two tips, so the long one plays right after
+
+    let short = "Nod."
+    // No trailing space — render() trims each line, so the stored text would otherwise differ.
+    let long = String(repeating: "This is a long coaching tip that must wrap onto several lines.", count: 6)
+
+    overlay.render([short], perLineSeconds: 0.3)
+    #expect(await waitUntil { overlay.currentText == short }, "the short line should display")
+    let shortHeight = overlay.currentPanelHeight
+    #expect(shortHeight == 80, "a short line stays at the floor height (got \(shortHeight))")
+
+    overlay.render([long], perLineSeconds: 3)   // queued; plays once the short line's 0.3s window ends
+    #expect(await waitUntil { overlay.currentText == long }, "the long line should display")
+    #expect(overlay.currentPanelHeight > shortHeight,
+            "the panel must grow taller to fit wrapped long text (got \(overlay.currentPanelHeight)pt)")
 }
 
 // render(_:perLineSeconds:[TimeInterval]) zips lines with their times, then trims and drops empties

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -224,25 +224,44 @@ private func checkInterLineGapBlanks() async {
 }
 
 // A line too long to fit one row must not be clipped by the old fixed 80pt window: the panel grows
-// taller to fit the wrapped text, while a short line stays at the floor height. Guards the overflow fix.
+// taller to fit the wrapped text, while a short line stays at the floor height. The three lengths make
+// the growth assertions *load-bearing on row count*: a regression to single-line (or wrongly-inset)
+// measurement would floor BOTH the medium and long lines at 80, so `medium > floor` proves real
+// multi-line measurement happens and `long > medium` proves the height scales with the wrapped row
+// count — exactly the cellSize(forBounds:) behavior the fix depends on. We also assert the bottom edge
+// stays pinned (the panel grows upward, not down off-screen) and that capture exclusion survives the
+// resize. No trailing whitespace in the fixtures — render() trims it, which would desync currentText.
 @MainActor
 private func checkPanelGrowsForLongText() async {
     let overlay = OverlayPanel()
-    overlay.interLineGapSeconds = 0   // no gap between the two tips, so the long one plays right after
+    overlay.interLineGapSeconds = 0   // no gap between tips, so each queued line plays right after
 
     let short = "Nod."
-    // No trailing space — render() trims each line, so the stored text would otherwise differ.
-    let long = String(repeating: "This is a long coaching tip that must wrap onto several lines.", count: 6)
+    let medium = String(repeating: "This is a coaching tip that wraps onto a few rows.", count: 4)
+    let long = String(repeating: "This is a long coaching tip that must wrap onto several lines.", count: 8)
 
     overlay.render([short], perLineSeconds: 0.3)
     #expect(await waitUntil { overlay.currentText == short }, "the short line should display")
     let shortHeight = overlay.currentPanelHeight
+    let bottomEdge = overlay.currentPanelBottom
     #expect(shortHeight == 80, "a short line stays at the floor height (got \(shortHeight))")
 
-    overlay.render([long], perLineSeconds: 3)   // queued; plays once the short line's 0.3s window ends
+    overlay.render([medium], perLineSeconds: 0.3)   // queued; plays once the short line's window ends
+    #expect(await waitUntil { overlay.currentText == medium }, "the medium line should display")
+    let mediumHeight = overlay.currentPanelHeight
+    #expect(mediumHeight > shortHeight,
+            "a multi-row line must clear the floor — proves real wrapped-height measurement (got \(mediumHeight)pt)")
+    #expect(overlay.currentPanelBottom == bottomEdge,
+            "the panel must grow upward — its bottom edge stays pinned (got \(overlay.currentPanelBottom), was \(bottomEdge))")
+
+    overlay.render([long], perLineSeconds: 3)   // queued; plays once the medium line's window ends
     #expect(await waitUntil { overlay.currentText == long }, "the long line should display")
-    #expect(overlay.currentPanelHeight > shortHeight,
-            "the panel must grow taller to fit wrapped long text (got \(overlay.currentPanelHeight)pt)")
+    #expect(overlay.currentPanelHeight > mediumHeight,
+            "a longer line wraps to more rows and must be taller still — proves height scales with row count (got \(overlay.currentPanelHeight)pt)")
+    #expect(overlay.currentPanelBottom == bottomEdge,
+            "the bottom edge must stay pinned as the panel grows taller (got \(overlay.currentPanelBottom), was \(bottomEdge))")
+    #expect(overlay.currentSharingType == .none,
+            "the panel must stay excluded from screen capture after the resize")
 }
 
 // render(_:perLineSeconds:[TimeInterval]) zips lines with their times, then trims and drops empties


### PR DESCRIPTION
## Problem

If a coaching tip is too long, the text overflows the overlay text window — the panel was hard-coded to `520×80`, so the wrapping label wrapped long text onto multiple rows that spilled past the fixed 80pt height.

## Fix

`OverlayPanel` now measures each line's wrapped height (at the label's current font, constrained to the label's width) and resizes the panel to fit, floored at 80pt. The bottom edge stays pinned at the screen's bottom margin, so a taller panel grows **upward** instead of clipping.

Applied at every display point:
- showing a line in `advance()`
- the Settings live appearance preview
- font-size changes while previewing
- init (starts at the floor height)

Geometry constants were pulled into a `Layout` enum to remove the duplicated `520`/`80`/`16` literals.

## Test

Added `overlayExpandsToFitLongText` to `JarvisOverlayTests`: a short line keeps the 80pt floor; a queued long line grows the panel taller. Plus a `currentPanelHeight` test hook.

All 122 tests pass via `./scripts/run-tests.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)