### PR TITLE
Store the API key in an owner-only file instead of the Keychain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ into one module, so moving a file between subfolders never changes access contro
 | `Sources/JarvisCore/Triggers/` | Turn / silence trigger detection + silence backoff |
 | `Sources/JarvisCore/Screen/` | Screen-capture tool contract |
 | `Sources/JarvisCore/Overlay/` | Overlay text model (the rendered tip; not the window) |
-| `Sources/JarvisCore/Config/` | Config + Keychain secrets |
+| `Sources/JarvisCore/Config/` | Config + secrets (owner-only file) |
 | `Sources/JarvisCore/Diagnostics/` | Logging, the dev-mode activity log, session-history store |
 | `Sources/JarvisCore/Support/` | Small primitives (`Clock`, `TurnTaskBox`) |
 | `Sources/JarvisOverlay/` | The on-screen `NSPanel` overlay (single file — no subfolders) |
@@ -100,8 +100,9 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
 
 ## Safety & secrets
 
-- **No secrets in code, ever** — not in source, tests, or examples. The API key lives in the
-  Keychain (`OPENAI_API_KEY` env var is a headless fallback only).
+- **No secrets in code, ever** — not in source, tests, or examples. The API key lives in an
+  owner-only `0600` file (`OPENAI_API_KEY` env var is a headless fallback only); see
+  [`wiki/sandbox.md`](./wiki/sandbox.md) for why not the Keychain.
 - **Nothing screen- or audio-derived is written to disk** outside dev mode. Dev-mode logs and
   screenshots go to a gitignored, owner-only `.jarvis/<session>/`. Never relax that.
 - Full security posture: [`wiki/sandbox.md`](./wiki/sandbox.md).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Full design: [`wiki/architecture.md`](./wiki/architecture.md).
 │   │   ├── Triggers/              # turn / silence detection + silence backoff
 │   │   ├── Screen/                # screen-capture tool contract
 │   │   ├── Overlay/               # overlay text model (the rendered tip)
-│   │   ├── Config/                # config + Keychain secrets
+│   │   ├── Config/                # config + secrets (owner-only file)
 │   │   ├── Diagnostics/           # logging, activity log, session-history store
 │   │   └── Support/               # small primitives (Clock, TurnTaskBox)
 │   ├── JarvisOverlay/         # the on-screen NSPanel overlay — own target so it's unit-testable
@@ -122,8 +122,10 @@ Then:
    `open`, never the bare binary, or macOS misattributes the permission grants and they look "denied".
 2. **Grant Microphone and Screen Recording** when prompted on first run (System Settings → Privacy &
    Security). They persist afterward.
-3. **Set your OpenAI API key** via the menu bar → **"Set OpenAI API Key…"** (saved to your login
-   Keychain; an `OPENAI_API_KEY` env var works as a headless fallback).
+3. **Set your OpenAI API key** via the menu bar → **"Set OpenAI API Key…"** (saved to an owner-only
+   file on this Mac; an `OPENAI_API_KEY` env var works as a headless fallback). Upgrading from an
+   older build that used the Keychain? Re-paste your key once (the file starts empty); you can delete
+   the orphaned Keychain entry with `security delete-generic-password -s com.jarvis.coach`.
 4. **Start / Stop** coaching from the menu bar. Jarvis does **not** auto-start. The icon shows the
    only two states: **⚪️ stopped** and **🟢 running**.
 

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -7,8 +7,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let clock = SystemClock()
     private let config = Config.default
     private let transcript = RollingTranscript()
-    private let keychain = KeychainSecretStore()
-    private lazy var secrets = ChainedSecretStore([keychain, EnvSecretStore()])
+    private let secretFile = FileSecretStore()
+    private lazy var secrets = ChainedSecretStore([secretFile, EnvSecretStore()])
 
     private var overlay: OverlayPanel!
     private var menuBar: MenuBarController!
@@ -55,7 +55,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // in dev mode. A pasted key is stored but does not auto-start; restart only if already
         // running, reflecting the real outcome back into the menu state.
         var sections: [SettingsSection] = [
-            APIKeySection(keychain: keychain, onKeySaved: { [weak self] _ in
+            APIKeySection(store: secretFile, onKeySaved: { [weak self] _ in
                 guard let self, self.transcriber != nil else { return }
                 // Re-saving a key while running only re-applies it to the pipeline — it is NOT a new
                 // coaching run, so keep the current session (don't rotate logs). Session rotation is

--- a/Sources/JarvisApp/Settings/APIKeySection.swift
+++ b/Sources/JarvisApp/Settings/APIKeySection.swift
@@ -1,27 +1,27 @@
 import AppKit
 import JarvisCore
 
-/// Settings panel for the OpenAI API key. Saves to the Keychain and reports back via `onKeySaved`
-/// (the app restarts the pipeline only if it was already running). Replaces the old modal dialog in
-/// MenuBarController.
+/// Settings panel for the OpenAI API key. Saves to an owner-only file and reports back via
+/// `onKeySaved` (the app restarts the pipeline only if it was already running). Replaces the old modal
+/// dialog in MenuBarController.
 @MainActor
 final class APIKeySection: NSObject, SettingsSection {
     let title = "API Key"
 
-    private let keychain: KeychainSecretStore
+    private let store: FileSecretStore
     private let onKeySaved: (String) -> Void
     private var field: NSSecureTextField?
     private var status: NSTextField?
 
-    init(keychain: KeychainSecretStore, onKeySaved: @escaping (String) -> Void) {
-        self.keychain = keychain
+    init(store: FileSecretStore, onKeySaved: @escaping (String) -> Void) {
+        self.store = store
         self.onKeySaved = onKeySaved
     }
 
     func makeView() -> NSView {
         let view = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 432))
 
-        let label = NSTextField(labelWithString: "Paste your OpenAI API key. It's stored in your Keychain.")
+        let label = NSTextField(labelWithString: "Paste your OpenAI API key. It's stored in an owner-only file on this Mac.")
         label.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
         view.addSubview(label)
 
@@ -49,7 +49,7 @@ final class APIKeySection: NSObject, SettingsSection {
     @objc private func saveTapped() {
         let token = (field?.stringValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         guard !token.isEmpty else { status?.stringValue = "Enter a key first."; return }
-        keychain.setApiKey(token)
+        guard store.setApiKey(token) else { status?.stringValue = "Couldn't save key — check disk permissions."; return }
         onKeySaved(token)
         status?.stringValue = "Key saved ✓"
         field?.stringValue = ""

--- a/Sources/JarvisCore/Config/Secrets.swift
+++ b/Sources/JarvisCore/Config/Secrets.swift
@@ -1,7 +1,6 @@
 import Foundation
-import Security
 
-/// Source of the OpenAI API key. Keychain is primary (spec §5); env is a headless fallback.
+/// Source of the OpenAI API key. An owner-only file is primary (spec §5); env is a headless fallback.
 public protocol SecretStore {
     func apiKey() -> String?
 }
@@ -18,47 +17,55 @@ public struct EnvSecretStore: SecretStore {
     }
 }
 
-/// Reads/writes the key in the macOS login Keychain as a generic password.
-public struct KeychainSecretStore: SecretStore {
-    private let service: String
-    private let account: String
-    public init(service: String = "com.jarvis.coach", account: String = "openai-api-key") {
-        self.service = service
-        self.account = account
+/// Reads/writes the key in an owner-only file under Application Support.
+///
+/// We deliberately do *not* use the login Keychain. macOS keys Keychain access to a per-build code
+/// *partition* (a cdhash, for a self-signed app with no Apple Team ID), so a fresh build is treated as
+/// a new program and re-prompts for the login password on every rebuild — unlike TCC (mic/screen),
+/// which keys to the stable signing identity and persists. A 0600 file in a 0700 directory has the
+/// same practical trust boundary as the headless `OPENAI_API_KEY` fallback (any process running as
+/// this user can read it) but never prompts and survives every rebuild.
+public struct FileSecretStore: SecretStore {
+    /// Absolute path of the credential file. Exposed so callers/tests can see where the key lives.
+    public let fileURL: URL
+
+    /// Defaults to `~/Library/Application Support/Jarvis/openai-api-key`. Pass an explicit URL in tests.
+    public init(fileURL: URL? = nil) {
+        if let fileURL {
+            self.fileURL = fileURL
+        } else {
+            let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+                ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+            self.fileURL = base.appendingPathComponent("Jarvis", isDirectory: true)
+                .appendingPathComponent("openai-api-key")
+        }
     }
 
     public func apiKey() -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var item: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess,
-              let data = item as? Data,
-              let s = String(data: data, encoding: .utf8), !s.isEmpty else { return nil }
-        return s
+        guard let data = try? Data(contentsOf: fileURL),
+              let s = String(data: data, encoding: .utf8) else { return nil }
+        let trimmed = s.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     @discardableResult
     public func setApiKey(_ key: String) -> Bool {
-        let base: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-        ]
-        SecItemDelete(base as CFDictionary)
-        var add = base
-        add[kSecValueData as String] = Data(key.utf8)
-        // Explicit: readable only while unlocked, and never synced to iCloud Keychain.
-        add[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-        return SecItemAdd(add as CFDictionary, nil) == errSecSuccess
+        let fm = FileManager.default
+        let dir = fileURL.deletingLastPathComponent()
+        // 0700 dir: a 0755 parent would leak the credential file's name/metadata to other local users
+        // (CWE-732). Mirrors how the dev-mode log directory is created.
+        do {
+            try fm.createDirectory(at: dir, withIntermediateDirectories: true,
+                                   attributes: [.posixPermissions: 0o700])
+        } catch { return false }
+        // Create the file 0600 from the start (createFile applies attributes atomically on creation),
+        // so the secret is never briefly world-readable between write and chmod.
+        return fm.createFile(atPath: fileURL.path, contents: Data(key.utf8),
+                             attributes: [.posixPermissions: 0o600])
     }
 }
 
-/// Tries each store in order; first non-nil wins. App uses [Keychain, Env].
+/// Tries each store in order; first non-nil wins. App uses [File, Env].
 public struct ChainedSecretStore: SecretStore {
     private let stores: [SecretStore]
     public init(_ stores: [SecretStore]) { self.stores = stores }

--- a/Sources/JarvisCore/Config/Secrets.swift
+++ b/Sources/JarvisCore/Config/Secrets.swift
@@ -57,6 +57,11 @@ public struct FileSecretStore: SecretStore {
         do {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true,
                                    attributes: [.posixPermissions: 0o700])
+            // createDirectory only applies the mode to directories it *creates*; a pre-existing dir
+            // (e.g. a 0755 left by a restored backup or another tool) keeps its mode. Tighten it so the
+            // owner-only guarantee holds regardless. Best-effort: a metadata-perms failure must not
+            // block saving the key, whose own bytes are still protected 0600.
+            try? fm.setAttributes([.posixPermissions: 0o700], ofItemAtPath: dir.path)
         } catch { return false }
         // Create the file 0600 from the start (createFile applies attributes atomically on creation),
         // so the secret is never briefly world-readable between write and chmod.

--- a/Tests/JarvisCoreTests/Config/FileSecretStoreTests.swift
+++ b/Tests/JarvisCoreTests/Config/FileSecretStoreTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+/// `FileSecretStore` persists the API key in an owner-only file (no Keychain), so the key survives
+/// rebuilds without a per-build authorization prompt. These tests pin the contract the app relies on:
+/// a write→read roundtrip, owner-only (0600) file + (0700) directory permissions, and the
+/// missing/empty cases that map to "no key yet".
+@Suite struct FileSecretStoreTests {
+    /// A throwaway file URL under a unique temp directory; the store creates the parent itself.
+    private func tempFileURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("jarvis-secret-\(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("openai-api-key")
+    }
+
+    @Test func writesThenReadsBack() {
+        let store = FileSecretStore(fileURL: tempFileURL())
+        #expect(store.setApiKey("sk-roundtrip"))
+        #expect(store.apiKey() == "sk-roundtrip")
+    }
+
+    @Test func missingFileReadsAsNil() {
+        let store = FileSecretStore(fileURL: tempFileURL())
+        #expect(store.apiKey() == nil)
+    }
+
+    @Test func emptyOrWhitespaceReadsAsNil() {
+        let url = tempFileURL()
+        let store = FileSecretStore(fileURL: url)
+        #expect(store.setApiKey("   \n  "))
+        // A key that is only whitespace is "no key" — same as the env store's empty handling.
+        #expect(store.apiKey() == nil)
+    }
+
+    @Test func surroundingWhitespaceIsTrimmed() {
+        let store = FileSecretStore(fileURL: tempFileURL())
+        #expect(store.setApiKey("  sk-padded\n"))
+        #expect(store.apiKey() == "sk-padded")
+    }
+
+    @Test func overwriteReplacesPreviousKey() {
+        let store = FileSecretStore(fileURL: tempFileURL())
+        #expect(store.setApiKey("sk-old"))
+        #expect(store.setApiKey("sk-new"))
+        #expect(store.apiKey() == "sk-new")
+    }
+
+    /// The whole point of the file store is to hold a secret no other local user can read.
+    @Test func fileIsOwnerOnly() throws {
+        let url = tempFileURL()
+        let store = FileSecretStore(fileURL: url)
+        #expect(store.setApiKey("sk-perms"))
+        let perms = try FileManager.default.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value == 0o600)
+    }
+
+    /// A 0755 parent would leak the credential file's existence/metadata to other local users, so the
+    /// store must create its directory owner-only too (CWE-732).
+    @Test func directoryIsOwnerOnly() throws {
+        let url = tempFileURL()
+        let store = FileSecretStore(fileURL: url)
+        #expect(store.setApiKey("sk-dir"))
+        let dir = url.deletingLastPathComponent().path
+        let perms = try FileManager.default.attributesOfItem(atPath: dir)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value == 0o700)
+    }
+
+    @Test func defaultLocationIsUnderApplicationSupport() {
+        // The no-arg init must land in the per-user Application Support tree, not /tmp or cwd.
+        let store = FileSecretStore()
+        #expect(store.fileURL.path.contains("Application Support/Jarvis"))
+    }
+}

--- a/Tests/JarvisCoreTests/Config/FileSecretStoreTests.swift
+++ b/Tests/JarvisCoreTests/Config/FileSecretStoreTests.swift
@@ -29,7 +29,8 @@ import Testing
         let url = tempFileURL()
         let store = FileSecretStore(fileURL: url)
         #expect(store.setApiKey("   \n  "))
-        // A key that is only whitespace is "no key" — same as the env store's empty handling.
+        // A key that is only whitespace is "no key": the file store trims before checking (stricter
+        // than EnvSecretStore, which doesn't trim and would return the raw whitespace).
         #expect(store.apiKey() == nil)
     }
 
@@ -64,6 +65,42 @@ import Testing
         let dir = url.deletingLastPathComponent().path
         let perms = try FileManager.default.attributesOfItem(atPath: dir)[.posixPermissions] as? NSNumber
         #expect(perms?.int16Value == 0o700)
+    }
+
+    /// `createDirectory` only applies its mode to directories it creates — a *pre-existing* loose dir
+    /// keeps its mode. The store must tighten it anyway, or the owner-only guarantee silently lapses.
+    @Test func tightensPreExistingLooseDirectory() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent("jarvis-loose-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o755])
+        let store = FileSecretStore(fileURL: dir.appendingPathComponent("openai-api-key"))
+        #expect(store.setApiKey("sk-tighten"))
+        let perms = try fm.attributesOfItem(atPath: dir.path)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value == 0o700)
+    }
+
+    /// Overwriting an already-saved key must re-assert 0600 — otherwise a file someone loosened (or a
+    /// future switch to a perms-preserving write) would silently leave the secret world-readable.
+    @Test func overwriteReassertsOwnerOnlyPermissions() throws {
+        let fm = FileManager.default
+        let url = tempFileURL()
+        let store = FileSecretStore(fileURL: url)
+        #expect(store.setApiKey("sk-first"))
+        try fm.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+        #expect(store.setApiKey("sk-second"))
+        let perms = try fm.attributesOfItem(atPath: url.path)[.posixPermissions] as? NSNumber
+        #expect(perms?.int16Value == 0o600)
+    }
+
+    /// `setApiKey` returns false (not a crash) when the file can't be written — the path the Settings
+    /// UI surfaces as "Couldn't save key". Here the intended parent is a regular file, so the store's
+    /// directory creation fails.
+    @Test func writeFailsGracefullyWhenDirectoryUnavailable() throws {
+        let fm = FileManager.default
+        let blocker = fm.temporaryDirectory.appendingPathComponent("jarvis-blocker-\(UUID().uuidString)")
+        try Data("x".utf8).write(to: blocker)   // a file where the store wants a directory
+        let store = FileSecretStore(fileURL: blocker.appendingPathComponent("sub/openai-api-key"))
+        #expect(store.setApiKey("sk-nope") == false)
     }
 
     @Test func defaultLocationIsUnderApplicationSupport() {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -92,7 +92,7 @@ path still works for testing/practice; it is simply not latency-critical there.)
 | **CoachDriver** | The event loop. On every trigger, call the brain with the transcript + timing context and tools, route tool calls. No cooldown/rate cap — restraint is the model's. | `gpt-5.5` (vision + tool-use). |
 | **ScreenTool** | Fulfill `capture_screen`: take a silent screenshot of the active display, excluding the overlay window. | macOS `screencapture` CLI. |
 | **Overlay** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. | AppKit NSPanel. |
-| **MenuBar** | Manual **Start/Stop** of the pipeline (two states: ⚪️ stopped / 🟢 running — no auto-start), status indicator, one-time API-key entry. | AppKit menu-bar item; Keychain for the key. |
+| **MenuBar** | Manual **Start/Stop** of the pipeline (two states: ⚪️ stopped / 🟢 running — no auto-start), status indicator, one-time API-key entry. | AppKit menu-bar item; owner-only file for the key. |
 
 Each component has one job and a narrow interface. The CoachDriver is the only place the
 "intelligence" lives, and even there the intelligence is the model — the driver just wires events
@@ -158,7 +158,7 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
   identity (`Jarvis Dev`, so grants persist), relying on macOS **TCC prompts** for Screen Recording
   + Microphone. It can therefore technically read the user's files;
   that tradeoff is accepted for the personal tool. See [sandbox.md](./sandbox.md).
-- **API key in the Keychain**, never plaintext on disk.
+- **API key in an owner-only file** (`0600`), not the Keychain — see [sandbox.md §3](./sandbox.md) for why.
 - **Built and run in the main `forrest` account inside a git worktree** (recoverability). The
   separate-restricted-account requirement is waived for the personal build; see [sandbox.md](./sandbox.md).
 - **Egress is narrow and explicit:** audio to `gpt-4o-transcribe`; a screenshot + transcript window

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -55,7 +55,7 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
   TCC attribute the grant to the *terminal*, so the app reports Microphone/Screen Recording as
   "denied" even when granted. Pass flags with `open ./Jarvis.app --args …`.
 - Jarvis does **not** auto-start: set the OpenAI key once via the menu bar ("Set OpenAI API Key…",
-  saved to the Keychain; `OPENAI_API_KEY` is a headless fallback), then **Start / Stop** from the
+  saved to an owner-only file; `OPENAI_API_KEY` is a headless fallback), then **Start / Stop** from the
   menu. The icon shows two states only: ⚪️ stopped, 🟢 running.
 
 ## Dev mode — the live activity viewer

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -17,7 +17,7 @@ Two layers below are **relaxed** for the personal build, by explicit decision:
   **git worktree** for recoverability, rather than a restricted `jarvisbuild` account. The former
   HARD REQUIREMENT is **waived** here. (Hardened model: §2.)
 
-Everything else (Keychain for the key, narrow egress, no recording to disk, model-governed behavioral
+Everything else (owner-only file for the key, narrow egress, no recording to disk, model-governed behavioral
 restraint) **still holds**. To re-harden for a shippable build, re-enable §1 and §2.
 
 ## Principle
@@ -64,8 +64,19 @@ Standard account cannot grant itself Screen Recording.
 
 ### 3. Secrets
 
-The OpenAI API key lives in the **macOS Keychain**, entered once through the menu bar. It is never
-written to disk in plaintext, never committed, never logged.
+The OpenAI API key lives in an **owner-only file** (`~/Library/Application Support/Jarvis/openai-api-key`,
+mode `0600` in a `0700` directory), entered once through the menu bar. It is never committed, never
+logged.
+
+We deliberately **don't** use the macOS Keychain. macOS keys Keychain access to a per-build code
+*partition* — for a self-signed app with no Apple Team ID, that partition is the binary's `cdhash`,
+which changes on every build — so each rebuild is treated as a new program and re-prompts for the
+login-keychain password. (TCC grants for Microphone/Screen Recording don't have this problem: they
+key to the stable signing identity, not the `cdhash`.) The only ways to avoid the re-prompt are an
+Apple Developer Team ID (stable `teamid:` partition) or moving off the Keychain. A `0600` file has
+the same practical trust boundary as the `OPENAI_API_KEY` headless fallback — any process running as
+this user can read it — but never prompts and survives every rebuild. If Jarvis ever ships under a
+real Developer ID, revisit this and move the key back into the Keychain.
 
 ## Data Egress
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -78,6 +78,9 @@ the same practical trust boundary as the `OPENAI_API_KEY` headless fallback — 
 this user can read it — but never prompts and survives every rebuild. If Jarvis ever ships under a
 real Developer ID, revisit this and move the key back into the Keychain.
 
+Upgrading from an older Keychain build: the key isn't migrated — re-paste it once (the file starts
+empty), and optionally delete the now-orphaned item with `security delete-generic-password -s com.jarvis.coach`.
+
 ## Data Egress
 
 Narrow and explicit. Data leaves the machine only via:

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -48,7 +48,7 @@ resizing; the API-key and overlay panels stay compact.
 
 | Section class | Tab title | Always present | Description |
 |---|---|---|---|
-| `APIKeySection` | "API Key" | yes | `NSSecureTextField` to paste the OpenAI key; saves to Keychain on "Save", restarts the pipeline if already running. |
+| `APIKeySection` | "API Key" | yes | `NSSecureTextField` to paste the OpenAI key; saves to an owner-only file on "Save", restarts the pipeline if already running. |
 | `OverlaySection` | "Overlay" | yes | Text-size and background-opacity sliders with live readouts; persists via `OverlayAppearance`; shows the sample-overlay live preview **only while the Overlay tab is selected** (`didBecomeActive`/`didResignActive`). |
 | `ActivitySection` | "Activity" | dev mode only | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `prefersResizableWindow == true` so the log gets a larger, resizable window. |
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -56,6 +56,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | ~~Two-phase build~~ → **Skip Phase 1; build native Swift directly** (2026-06-14) | this page; [fork-evaluation.md](./fork-evaluation.md) |
 | **Native Swift app** (cleanest sandbox/footprint on macOS) | [architecture.md](./architecture.md), [fork-evaluation.md](./fork-evaluation.md) |
 | **Toolchain: SwiftPM + Command Line Tools** (no full Xcode; manual bundle + stable self-signed `Jarvis Dev` identity so TCC grants persist; TCC prompts) | [build-and-run.md](./build-and-run.md) |
+| **API key in an owner-only `0600` file, not the Keychain** — a self-signed (no Team ID) app's Keychain access keys to a per-build `cdhash`, so the Keychain re-prompts every rebuild; a file doesn't (2026-06-20) | [sandbox.md §3](./sandbox.md) |
 | ~~Build in a separate restricted account (HARD)~~ → **build in main `forrest` account, in a git worktree; hard requirement waived for the personal build** (2026-06-14) | [sandbox.md](./sandbox.md) |
 | **Tuned `server_vad`+debounce (not `semantic_vad`); quiet graceful Stop** — fixes from first live smoke run (2026-06-15) | [architecture.md](./architecture.md#models-and-apis) |
 | **Dev activity viewer = in-app `WKWebView`** (live push, no meta-refresh; screenshot lightbox; persisted JSONL session history + clear-history) | [build-and-run.md](./build-and-run.md) |
@@ -89,7 +90,7 @@ The headless build is done. Remaining is the **human smoke run** — build, run,
 
 1. `./scripts/build-app.sh release` → `open ./Jarvis.app`; grant Microphone + Screen Recording
    (one-time; they persist afterward — see [build-and-run.md](./build-and-run.md)).
-2. Paste your OpenAI key via the menu bar ("Set OpenAI API Key…") — it saves to the Keychain. Jarvis
+2. Paste your OpenAI key via the menu bar ("Set OpenAI API Key…") — it saves to an owner-only file. Jarvis
    does **not** auto-start; press **Start Jarvis** in the menu to begin (⚪️ stopped → 🟢 running),
    **Stop Jarvis** to halt. Model IDs are doc-verified; no edit expected.
 3. Run the **live smoke checklist** ([README](../README.md#live-smoke-checklist)): speak →


### PR DESCRIPTION
## Why

The login Keychain re-prompts for the password on **every rebuild** of Jarvis, even though the build already uses a stable self-signed identity so Mic/Screen-Recording (TCC) grants persist.

Root cause (confirmed empirically): macOS keys Keychain access to a per-build code **partition**. For a self-signed app with **no Apple Team ID**, that partition is the binary's **cdhash**, which changes on every build — so each rebuild looks like a new program and re-prompts. TCC keys to the stable *signing identity*, not the cdhash, which is why those grants persist.

Ruled out (empirically):
- **Data-protection keychain** (the modern API that *would* key to identity): a self-signed app claiming the required `keychain-access-groups` entitlement is **SIGKILL'd**; without it, ops fail `errSecMissingEntitlement` (-34018).
- **Custom / allow-all ACLs**: securityd always re-attaches the current build's cdhash as the partition, and on the login keychain a never-authorized cdhash is denied regardless of the trusted-app rule.

With no stable partition value available to a no-Team-ID app, the only escapes are an Apple Developer Team ID (stable `teamid:` partition) or moving off the Keychain.

## What

- New `FileSecretStore` — the OpenAI key lives in an owner-only **0600** file (in a **0700** dir) at `~/Library/Application Support/Jarvis/openai-api-key`, created atomically. Foundation-only, so it's unit-tested in `JarvisCore`.
- Same practical trust boundary as the existing `OPENAI_API_KEY` headless fallback (any process running as this user can read it), but it never prompts and survives every rebuild.
- Wired `AppDelegate` + `APIKeySection`; dropped `KeychainSecretStore` and the `Security` import; updated Settings copy + save-failure handling.
- 10 new tests (roundtrip, 0600/0700 perms, missing/empty→nil, trim, overwrite, default location).
- Updated `wiki/sandbox.md` (the *why*), `architecture.md`, `settings-window.md`, `status.md` (+ key-decision entry), `build-and-run.md`, and `CLAUDE.md`.

## Migration

After this lands, paste your key once more in Settings (the file starts empty). The stale Keychain item can be removed with `security delete-generic-password -s com.jarvis.coach`.

## Test

`./scripts/run-tests.sh` → 129 tests in 21 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)