### PR TITLE
Filter non-speech transcription hallucinations (noise reduction + text gate)

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -131,6 +131,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                               silenceTimeout: config.silenceTimeoutSeconds,
                                               silenceMaxInterval: config.silenceMaxIntervalSeconds,
                                               silenceDurationMs: config.vadSilenceDurationMs,
+                                              noiseReduction: config.audioNoiseReduction,
                                               turnDebounce: config.turnDebounceSeconds,
                                               maxBufferedAudioSeconds: config.maxBufferedAudioSeconds)
         transcriber.onTurnEnd = { turns.run { await driver.handleTrigger(.turnEnd) } }
@@ -145,6 +146,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                   silenceTimeout: config.silenceTimeoutSeconds,
                                                   silenceMaxInterval: config.silenceMaxIntervalSeconds,
                                                   silenceDurationMs: config.vadSilenceDurationMs,
+                                                  noiseReduction: config.audioNoiseReduction,
                                                   turnDebounce: config.turnDebounceSeconds,
                                                   maxBufferedAudioSeconds: config.maxBufferedAudioSeconds)
         themTranscriber.onTurnEnd = { turns.run { await driver.handleTrigger(.turnEnd) } }

--- a/Sources/JarvisApp/Capture/InputDeviceProximity.swift
+++ b/Sources/JarvisApp/Capture/InputDeviceProximity.swift
@@ -1,0 +1,44 @@
+import CoreAudio
+import JarvisCore
+
+/// Classifies the system's current default input device into a `MicProximity` by its Core Audio
+/// transport type — the OS-bound half of `.auto` noise reduction. Thin on purpose: the policy
+/// (proximity → wire profile) lives in `JarvisCore.NoiseReduction`, which is unit-tested; this just
+/// reads a hardware property. Re-read per session so a reconnect picks up a device swap.
+enum InputDeviceProximity {
+    static func current() -> MicProximity {
+        guard let transport = defaultInputTransportType() else { return .unknown }
+        switch transport {
+        case kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE,
+             kAudioDeviceTransportTypeUSB:
+            return .near    // headset / earbuds / AirPods / USB close mic
+        case kAudioDeviceTransportTypeBuiltIn, kAudioDeviceTransportTypeHDMI,
+             kAudioDeviceTransportTypeDisplayPort, kAudioDeviceTransportTypeThunderbolt,
+             kAudioDeviceTransportTypeAirPlay:
+            return .far     // laptop / monitor / dock / remote — across the desk or further
+        default:
+            return .unknown // aggregate / virtual / PCI / genuinely unknown
+        }
+    }
+
+    /// The default input device's `kAudioDevicePropertyTransportType`, or nil if it can't be read.
+    private static func defaultInputTransportType() -> UInt32? {
+        var devID = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        var devAddr = AudioObjectPropertyAddress(mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                                                 mScope: kAudioObjectPropertyScopeGlobal,
+                                                 mElement: kAudioObjectPropertyElementMain)
+        guard AudioObjectGetPropertyData(AudioObjectID(kAudioObjectSystemObject), &devAddr, 0, nil,
+                                         &size, &devID) == noErr, devID != kAudioObjectUnknown
+        else { return nil }
+
+        var transport = UInt32(0)
+        var tSize = UInt32(MemoryLayout<UInt32>.size)
+        var tAddr = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyTransportType,
+                                               mScope: kAudioObjectPropertyScopeGlobal,
+                                               mElement: kAudioObjectPropertyElementMain)
+        guard AudioObjectGetPropertyData(devID, &tAddr, 0, nil, &tSize, &transport) == noErr
+        else { return nil }
+        return transport
+    }
+}

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -30,6 +30,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private let clock: Clock
     private let sessionStart: TimeInterval
     private let silenceDurationMs: Int
+    private let noiseReduction: String?
     private let turnDebounce: TimeInterval
 
     private let lock = NSLock()
@@ -51,7 +52,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
          silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
-         silenceDurationMs: Int = 1000,
+         silenceDurationMs: Int = 1000, noiseReduction: String? = "near_field",
          turnDebounce: TimeInterval = 0.4, maxBufferedAudioSeconds: TimeInterval = 60) {
         self.apiKey = apiKey
         self.model = model
@@ -61,6 +62,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         self.sessionStart = clock.now()
         self.silenceBackoff = SilenceBackoff(base: silenceTimeout, maxInterval: silenceMaxInterval)
         self.silenceDurationMs = silenceDurationMs
+        self.noiseReduction = noiseReduction
         self.turnDebounce = turnDebounce
         // PCM16 mono at the realtime sample rate → 2 bytes/sample.
         let bytesPerSecond = RealtimeSession.sampleRate * 2
@@ -112,7 +114,8 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     }
 
     private func configureSession() {
-        send(json: RealtimeSession.sessionUpdate(model: model, silenceDurationMs: silenceDurationMs))
+        send(json: RealtimeSession.sessionUpdate(model: model, silenceDurationMs: silenceDurationMs,
+                                                 noiseReduction: noiseReduction))
     }
 
     func sendAudio(_ pcm: Data) {

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -30,7 +30,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private let clock: Clock
     private let sessionStart: TimeInterval
     private let silenceDurationMs: Int
-    private let noiseReduction: String?
+    private let noiseReduction: NoiseReductionMode
     private let turnDebounce: TimeInterval
 
     private let lock = NSLock()
@@ -52,7 +52,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
          silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
-         silenceDurationMs: Int = 1000, noiseReduction: String? = "near_field",
+         silenceDurationMs: Int = 1000, noiseReduction: NoiseReductionMode = .auto,
          turnDebounce: TimeInterval = 0.4, maxBufferedAudioSeconds: TimeInterval = 60) {
         self.apiKey = apiKey
         self.model = model
@@ -114,8 +114,11 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     }
 
     private func configureSession() {
+        // Resolve .auto against the live default-input device each session, so a reconnect after a
+        // device swap (e.g. plugging in AirPods) picks the right profile.
+        let profile = NoiseReduction.profile(mode: noiseReduction, micProximity: InputDeviceProximity.current())
         send(json: RealtimeSession.sessionUpdate(model: model, silenceDurationMs: silenceDurationMs,
-                                                 noiseReduction: noiseReduction))
+                                                 noiseReduction: profile))
     }
 
     func sendAudio(_ pcm: Data) {

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -196,7 +196,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
             // whole), but DON'T fire the coach yet — debounce so rapid fragments of one spoken
             // sentence coalesce into a single trigger. The wire→text parse lives in RealtimeSession
             // (pure + unit-tested).
-            if let transcriptText = RealtimeSession.completedTranscript(from: obj) {
+            if let transcriptText = RealtimeSession.completedTranscript(from: obj, speaker: speaker) {
                 let at = clock.now() - sessionStart
                 transcript.append(.init(speaker: speaker, text: transcriptText, at: at))
                 jlog("🗣 heard (\(speaker.rawValue)): \"\(transcriptText)\"")   // show side + what was said

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -36,10 +36,11 @@ public struct Config: Sendable {
     /// Server-VAD silence window: how long a pause must last before the server ends the turn.
     /// Raised above the ~500 ms server default so a mid-thought pause doesn't split a sentence.
     public var vadSilenceDurationMs: Int
-    /// Input noise-reduction profile applied *before* VAD, to stop non-speech blips from firing the
-    /// VAD and producing phantom transcripts. `near_field` suits a MacBook's built-in/close mic;
-    /// `far_field` suits a room/conference mic; `nil` disables it. See `RealtimeSession.sessionUpdate`.
-    public var audioNoiseReduction: String?
+    /// Input noise-reduction policy applied *before* VAD, to stop non-speech blips from firing the VAD
+    /// and producing phantom transcripts. `.auto` (default) picks `near_field` vs `far_field` from the
+    /// active mic's Core Audio transport type each session (see `NoiseReduction` / `InputDeviceProximity`);
+    /// or pin `.nearField` / `.farField`, or `.off` to disable.
+    public var audioNoiseReduction: NoiseReductionMode
     /// Client-side coalescing window: rapid `…transcription.completed` fragments arriving within this
     /// window are merged into one coaching trigger, so even residual VAD fragmentation doesn't drive
     /// multiple brain calls for one spoken sentence.
@@ -60,7 +61,7 @@ public struct Config: Sendable {
         reasoningEffort: String = "low",
         transcriptionModel: String = "gpt-4o-transcribe",
         vadSilenceDurationMs: Int = 1000,
-        audioNoiseReduction: String? = "near_field",
+        audioNoiseReduction: NoiseReductionMode = .auto,
         turnDebounceSeconds: TimeInterval = 0.4,
         maxBufferedAudioSeconds: TimeInterval = 60
     ) {

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -36,6 +36,10 @@ public struct Config: Sendable {
     /// Server-VAD silence window: how long a pause must last before the server ends the turn.
     /// Raised above the ~500 ms server default so a mid-thought pause doesn't split a sentence.
     public var vadSilenceDurationMs: Int
+    /// Input noise-reduction profile applied *before* VAD, to stop non-speech blips from firing the
+    /// VAD and producing phantom transcripts. `near_field` suits a MacBook's built-in/close mic;
+    /// `far_field` suits a room/conference mic; `nil` disables it. See `RealtimeSession.sessionUpdate`.
+    public var audioNoiseReduction: String?
     /// Client-side coalescing window: rapid `…transcription.completed` fragments arriving within this
     /// window are merged into one coaching trigger, so even residual VAD fragmentation doesn't drive
     /// multiple brain calls for one spoken sentence.
@@ -56,6 +60,7 @@ public struct Config: Sendable {
         reasoningEffort: String = "low",
         transcriptionModel: String = "gpt-4o-transcribe",
         vadSilenceDurationMs: Int = 1000,
+        audioNoiseReduction: String? = "near_field",
         turnDebounceSeconds: TimeInterval = 0.4,
         maxBufferedAudioSeconds: TimeInterval = 60
     ) {
@@ -69,6 +74,7 @@ public struct Config: Sendable {
         self.reasoningEffort = reasoningEffort
         self.transcriptionModel = transcriptionModel
         self.vadSilenceDurationMs = vadSilenceDurationMs
+        self.audioNoiseReduction = audioNoiseReduction
         self.turnDebounceSeconds = turnDebounceSeconds
         self.maxBufferedAudioSeconds = maxBufferedAudioSeconds
     }

--- a/Sources/JarvisCore/Transcription/NoiseReduction.swift
+++ b/Sources/JarvisCore/Transcription/NoiseReduction.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// How aggressively the Realtime session should de-noise the input *before* VAD, and how that choice
+/// is made. `near_field` suits a close mic (headset/AirPods); `far_field` suits a distant mic
+/// (built-in laptop / monitor / room). `.auto` derives the profile from the detected mic — the OS
+/// classification lives in `JarvisApp` (`InputDeviceProximity`); the policy below stays Foundation-only
+/// and unit-tested. See `RealtimeSession.sessionUpdate`.
+public enum NoiseReduction {
+    /// Resolve the wire value (`"near_field"` / `"far_field"` / nil-to-omit) for a mode. `micProximity`
+    /// is consulted only for `.auto`; pinned modes ignore it. Unknown proximity falls back to
+    /// `far_field`: it is the gentler profile, so it won't over-suppress a quiet or distant voice when
+    /// we can't tell what the device is.
+    public static func profile(mode: NoiseReductionMode, micProximity: MicProximity) -> String? {
+        switch mode {
+        case .off: return nil
+        case .nearField: return "near_field"
+        case .farField: return "far_field"
+        case .auto:
+            switch micProximity {
+            case .near: return "near_field"
+            case .far, .unknown: return "far_field"
+            }
+        }
+    }
+}
+
+/// The noise-reduction policy: auto-detect from the mic, pin a profile, or disable.
+public enum NoiseReductionMode: Sendable, Equatable {
+    case auto
+    case nearField
+    case farField
+    case off
+}
+
+/// How close the active input mic sits to the speaker — the abstract signal `.auto` resolves on.
+/// `JarvisApp` maps a Core Audio transport type onto this; Core only reasons about the abstraction.
+public enum MicProximity: Sendable, Equatable {
+    case near       // headset / earbuds / AirPods / USB close mic
+    case far        // built-in laptop, monitor, room, or remote (AirPlay/HDMI) mic
+    case unknown    // aggregate / virtual / undetectable
+}

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -57,32 +57,42 @@ public enum RealtimeSession {
     /// The transcript text from a parsed realtime event, if it is a **completed** input-audio
     /// transcription carrying real speech — otherwise nil. Pure and unit-testable; the live socket
     /// is not, so this is where the wire→text parsing (and hallucination filtering) is verified.
-    public static func completedTranscript(from event: [String: Any]) -> String? {
+    ///
+    /// `speaker` scopes the phrase denylist: a bare "Thank you."/"Thanks" is a silence hallucination on
+    /// the *me* (mic) side but a real turn-ending reply on the *them* (system-audio) side, so the
+    /// denylist applies to `.me` only. The punctuation/whitespace-only drop applies to both.
+    public static func completedTranscript(from event: [String: Any], speaker: Speaker) -> String? {
         guard event["type"] as? String == completedTranscriptionType,
               let text = event["transcript"] as? String else { return nil }
-        return meaningfulTranscript(text)
+        return meaningfulTranscript(text, speaker: speaker)
     }
 
     /// Stock non-speech hallucinations gpt-4o-transcribe / Whisper emit when VAD fires on silence —
     /// mostly YouTube-caption artifacts the model absorbed in training. Lower-cased, punctuation
     /// stripped; matched only against a whole utterance (see `meaningfulTranscript`) so a real sentence
     /// containing these words survives. Conservative on purpose — add only well-attested phrases here.
+    /// Applied to the `.me` side only (see `completedTranscript`). "bye" is deliberately absent: it is a
+    /// well-formed sign-off, and the punctuation filter already catches the lone-"." artifact.
     static let hallucinationDenylist: Set<String> = [
         "you", "thank you", "thank you very much", "thanks", "thanks for watching",
-        "thank you for watching", "please subscribe", "bye",
+        "thank you for watching", "please subscribe",
     ]
 
     /// Returns the utterance trimmed if it is real speech, else nil — the Layer-3 text filter for the
     /// `"."`-on-silence problem. Drops two kinds of non-speech the model invents:
-    ///   1. punctuation/whitespace-only output (a lone "." has no letter or digit), and
-    ///   2. an utterance that, normalized, is exactly a known caption-artifact phrase.
+    ///   1. punctuation/whitespace-only output (a lone "." has no letter or digit) — both speakers, and
+    ///   2. an utterance that, normalized, is exactly a known caption-artifact phrase — `.me` only.
     /// Letting either through logs a phantom `heard` line, resets the silence timer, and fires a turn.
-    static func meaningfulTranscript(_ raw: String) -> String? {
+    static func meaningfulTranscript(_ raw: String, speaker: Speaker) -> String? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed.contains(where: { $0.isLetter || $0.isNumber }) else { return nil }
-        let normalized = trimmed.lowercased()
-            .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?…\"' "))
-        guard !hallucinationDenylist.contains(normalized) else { return nil }
+        if speaker == .me {
+            // Strip only the trailing punctuation the transcriber actually emits; no apostrophe (it
+            // belongs inside contractions, and trimming it could mangle a legitimately-quoted word).
+            let normalized = trimmed.lowercased()
+                .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?…\" "))
+            guard !hallucinationDenylist.contains(normalized) else { return nil }
+        }
         return trimmed
     }
 }

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -21,23 +21,28 @@ public enum RealtimeSession {
     /// sentence into several utterances; ~1000 ms lets a "thinking aloud" coder finish. We keep
     /// `server_vad` rather than `semantic_vad`, which is reported flaky in transcription-only mode
     /// (it can stop emitting completed events entirely). See wiki/architecture.md (Models and APIs).
+    ///
+    /// `noiseReduction` ("near_field" for a headset/close mic, "far_field" for a laptop/room mic, or
+    /// nil to disable) filters the input buffer *before* it reaches VAD and the model — OpenAI's
+    /// first-line defense against non-speech blips firing the VAD and producing phantom transcripts.
+    /// Sent as an object `{"type": …}`; a bare string is rejected by the server.
     public static func sessionUpdate(model: String, language: String = "en",
-                                     silenceDurationMs: Int = 1000) -> [String: Any] {
-        [
-            "type": "session.update",
-            "session": [
-                "type": "transcription",
-                "audio": [
-                    "input": [
-                        "format": ["type": "audio/pcm", "rate": sampleRate],
-                        "transcription": ["model": model, "language": language],
-                        "turn_detection": [
-                            "type": "server_vad",
-                            "silence_duration_ms": silenceDurationMs,
-                        ],
-                    ],
-                ],
+                                     silenceDurationMs: Int = 1000,
+                                     noiseReduction: String? = "near_field") -> [String: Any] {
+        var input: [String: Any] = [
+            "format": ["type": "audio/pcm", "rate": sampleRate],
+            "transcription": ["model": model, "language": language],
+            "turn_detection": [
+                "type": "server_vad",
+                "silence_duration_ms": silenceDurationMs,
             ],
+        ]
+        if let noiseReduction {
+            input["noise_reduction"] = ["type": noiseReduction]
+        }
+        return [
+            "type": "session.update",
+            "session": ["type": "transcription", "audio": ["input": input]],
         ]
     }
 
@@ -50,11 +55,34 @@ public enum RealtimeSession {
     public static let completedTranscriptionType = "conversation.item.input_audio_transcription.completed"
 
     /// The transcript text from a parsed realtime event, if it is a **completed** input-audio
-    /// transcription carrying non-empty text — otherwise nil. Pure and unit-testable; the live socket
-    /// is not, so this is where the wire→text parsing is verified.
+    /// transcription carrying real speech — otherwise nil. Pure and unit-testable; the live socket
+    /// is not, so this is where the wire→text parsing (and hallucination filtering) is verified.
     public static func completedTranscript(from event: [String: Any]) -> String? {
         guard event["type"] as? String == completedTranscriptionType,
-              let text = event["transcript"] as? String, !text.isEmpty else { return nil }
-        return text
+              let text = event["transcript"] as? String else { return nil }
+        return meaningfulTranscript(text)
+    }
+
+    /// Stock non-speech hallucinations gpt-4o-transcribe / Whisper emit when VAD fires on silence —
+    /// mostly YouTube-caption artifacts the model absorbed in training. Lower-cased, punctuation
+    /// stripped; matched only against a whole utterance (see `meaningfulTranscript`) so a real sentence
+    /// containing these words survives. Conservative on purpose — add only well-attested phrases here.
+    static let hallucinationDenylist: Set<String> = [
+        "you", "thank you", "thank you very much", "thanks", "thanks for watching",
+        "thank you for watching", "please subscribe", "bye",
+    ]
+
+    /// Returns the utterance trimmed if it is real speech, else nil — the Layer-3 text filter for the
+    /// `"."`-on-silence problem. Drops two kinds of non-speech the model invents:
+    ///   1. punctuation/whitespace-only output (a lone "." has no letter or digit), and
+    ///   2. an utterance that, normalized, is exactly a known caption-artifact phrase.
+    /// Letting either through logs a phantom `heard` line, resets the silence timer, and fires a turn.
+    static func meaningfulTranscript(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.contains(where: { $0.isLetter || $0.isNumber }) else { return nil }
+        let normalized = trimmed.lowercased()
+            .trimmingCharacters(in: CharacterSet(charactersIn: ".,!?…\"' "))
+        guard !hallucinationDenylist.contains(normalized) else { return nil }
+        return trimmed
     }
 }

--- a/Tests/JarvisCoreTests/Transcription/NoiseReductionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/NoiseReductionTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct NoiseReductionTests {
+    /// `.auto` picks the wire profile from the detected mic proximity: a close mic (headset/AirPods)
+    /// gets near_field, a distant mic (built-in/monitor) gets far_field, and an undetectable device
+    /// falls back to far_field (the safe, gentler default).
+    @Test func autoResolvesFromProximity() {
+        #expect(NoiseReduction.profile(mode: .auto, micProximity: .near) == "near_field")
+        #expect(NoiseReduction.profile(mode: .auto, micProximity: .far) == "far_field")
+        #expect(NoiseReduction.profile(mode: .auto, micProximity: .unknown) == "far_field")
+    }
+
+    /// An explicitly pinned mode ignores the detected proximity entirely.
+    @Test func explicitModesIgnoreProximity() {
+        for proximity in [MicProximity.near, .far, .unknown] {
+            #expect(NoiseReduction.profile(mode: .nearField, micProximity: proximity) == "near_field")
+            #expect(NoiseReduction.profile(mode: .farField, micProximity: proximity) == "far_field")
+            #expect(NoiseReduction.profile(mode: .off, micProximity: proximity) == nil)
+        }
+    }
+
+    /// `.off` disables noise reduction (the session omits the key — see RealtimeSession.sessionUpdate).
+    @Test func offIsNil() {
+        #expect(NoiseReduction.profile(mode: .off, micProximity: .near) == nil)
+    }
+}

--- a/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
@@ -21,6 +21,33 @@ import Testing
         #expect(RealtimeSession.completedTranscript(from: [:]) == nil)
     }
 
+    /// Layer 3 (text filter): the model hallucinates a lone "." (and other punctuation/whitespace) when
+    /// server VAD fires on non-speech. No real utterance is punctuation-only, so these are dropped —
+    /// otherwise each one logs a phantom `heard (me)` line, resets the silence timer, and fires a turn.
+    @Test func completedTranscriptRejectsPunctuationAndWhitespaceOnly() {
+        for junk in [".", " . ", "…", ",", ". .", "?!", "  ", "\n", "-"] {
+            #expect(RealtimeSession.meaningfulTranscript(junk) == nil, "should drop \(junk.debugDescription)")
+        }
+    }
+
+    /// Layer 3 (denylist): gpt-4o-transcribe / Whisper emit stock caption-artifact phrases on silence
+    /// ("Thank you.", "Thanks for watching"). Matched only when the *whole* utterance equals one — so a
+    /// real sentence that merely contains the words is kept.
+    @Test func completedTranscriptRejectsStockHallucinationPhrases() {
+        for junk in ["Thank you.", "thank you", "Thanks for watching!", "you", "Please subscribe."] {
+            #expect(RealtimeSession.meaningfulTranscript(junk) == nil, "should drop \(junk.debugDescription)")
+        }
+    }
+
+    /// Real speech survives, and is returned trimmed of surrounding whitespace. A sentence that merely
+    /// contains a denylisted phrase as a substring is NOT dropped.
+    @Test func completedTranscriptKeepsAndTrimsRealSpeech() {
+        #expect(RealtimeSession.meaningfulTranscript("  two pointers  ") == "two pointers")
+        #expect(RealtimeSession.meaningfulTranscript("thank you, let's use a hash map")
+                == "thank you, let's use a hash map")
+        #expect(RealtimeSession.meaningfulTranscript("3") == "3")  // a lone digit is real content
+    }
+
     /// The connect URL MUST select a transcription session via intent (not ?model=).
     @Test func connectURLUsesIntentTranscription() {
         let url = RealtimeSession.connectURL().absoluteString
@@ -51,6 +78,32 @@ import Testing
         let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
         let input = (((obj["session"] as! [String: Any])["audio"] as! [String: Any])["input"] as! [String: Any])
         #expect((((input["turn_detection"] as! [String: Any])["silence_duration_ms"]) as? Int) == 700)
+    }
+
+    /// Layer 1 (pre-VAD): noise reduction is sent as an OBJECT `{"type": "near_field"}` nested under
+    /// `audio.input` (GA shape — a string here is the documented LiveKit bug the server rejects). It
+    /// filters the buffer before VAD, cutting the non-speech blips that trigger phantom transcripts.
+    @Test func sessionUpdateIncludesNoiseReductionNearFieldByDefault() throws {
+        let payload = RealtimeSession.sessionUpdate(model: "gpt-4o-transcribe")
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let obj = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        let input = (((obj["session"] as! [String: Any])["audio"] as! [String: Any])["input"] as! [String: Any])
+        let nr = try #require(input["noise_reduction"] as? [String: Any])
+        #expect(nr["type"] as? String == "near_field")
+    }
+
+    /// The mic profile is tunable (far_field for a laptop/room mic), and nil omits the key entirely so
+    /// the server applies no filtering.
+    @Test func sessionUpdateHonorsConfiguredNoiseReduction() throws {
+        func input(_ payload: [String: Any]) throws -> [String: Any] {
+            let obj = try JSONSerialization.jsonObject(
+                with: try JSONSerialization.data(withJSONObject: payload)) as! [String: Any]
+            return (((obj["session"] as! [String: Any])["audio"] as! [String: Any])["input"] as! [String: Any])
+        }
+        let far = try input(RealtimeSession.sessionUpdate(model: "m", noiseReduction: "far_field"))
+        #expect((far["noise_reduction"] as? [String: Any])?["type"] as? String == "far_field")
+        let off = try input(RealtimeSession.sessionUpdate(model: "m", noiseReduction: nil))
+        #expect(off["noise_reduction"] == nil)
     }
 
     @Test func appendAudioShape() {

--- a/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
@@ -8,44 +8,80 @@ import Testing
     @Test func completedTranscriptParsesCompletedEvent() throws {
         let wire = "{\"type\":\"\(RealtimeSession.completedTranscriptionType)\",\"transcript\":\"two pointers\"}"
         let obj = try #require(try JSONSerialization.jsonObject(with: Data(wire.utf8)) as? [String: Any])
-        #expect(RealtimeSession.completedTranscript(from: obj) == "two pointers")
+        #expect(RealtimeSession.completedTranscript(from: obj, speaker: .me) == "two pointers")
     }
 
     /// Non-completed events, empty text, and a missing transcript field all yield nil (no line gets
     /// appended / no speaker tagged for them).
     @Test func completedTranscriptIgnoresNonCompletedAndEmpty() {
         let type = RealtimeSession.completedTranscriptionType
-        #expect(RealtimeSession.completedTranscript(from: ["type": "input_audio_buffer.speech_stopped"]) == nil)
-        #expect(RealtimeSession.completedTranscript(from: ["type": type, "transcript": ""]) == nil)
-        #expect(RealtimeSession.completedTranscript(from: ["type": type]) == nil)
-        #expect(RealtimeSession.completedTranscript(from: [:]) == nil)
+        #expect(RealtimeSession.completedTranscript(from: ["type": "input_audio_buffer.speech_stopped"], speaker: .me) == nil)
+        #expect(RealtimeSession.completedTranscript(from: ["type": type, "transcript": ""], speaker: .me) == nil)
+        #expect(RealtimeSession.completedTranscript(from: ["type": type], speaker: .me) == nil)
+        #expect(RealtimeSession.completedTranscript(from: [:], speaker: .me) == nil)
     }
 
     /// Layer 3 (text filter): the model hallucinates a lone "." (and other punctuation/whitespace) when
-    /// server VAD fires on non-speech. No real utterance is punctuation-only, so these are dropped —
-    /// otherwise each one logs a phantom `heard (me)` line, resets the silence timer, and fires a turn.
+    /// server VAD fires on non-speech. No real utterance is punctuation-only, so these are dropped for
+    /// BOTH speakers — otherwise each one logs a phantom `heard` line, resets the silence timer (me side),
+    /// and fires a turn.
     @Test func completedTranscriptRejectsPunctuationAndWhitespaceOnly() {
-        for junk in [".", " . ", "…", ",", ". .", "?!", "  ", "\n", "-"] {
-            #expect(RealtimeSession.meaningfulTranscript(junk) == nil, "should drop \(junk.debugDescription)")
+        for speaker in [Speaker.me, .them] {
+            for junk in [".", " . ", "…", ",", ". .", "?!", "  ", "\n", "-"] {
+                #expect(RealtimeSession.meaningfulTranscript(junk, speaker: speaker) == nil,
+                        "\(speaker) should drop \(junk.debugDescription)")
+            }
         }
     }
 
     /// Layer 3 (denylist): gpt-4o-transcribe / Whisper emit stock caption-artifact phrases on silence
-    /// ("Thank you.", "Thanks for watching"). Matched only when the *whole* utterance equals one — so a
-    /// real sentence that merely contains the words is kept.
-    @Test func completedTranscriptRejectsStockHallucinationPhrases() {
-        for junk in ["Thank you.", "thank you", "Thanks for watching!", "you", "Please subscribe."] {
-            #expect(RealtimeSession.meaningfulTranscript(junk) == nil, "should drop \(junk.debugDescription)")
+    /// ("Thank you.", "Thanks for watching"). On the ME side these are hallucinations and are dropped —
+    /// every entry, plus a Capitalized + trailing-punctuation variant to exercise normalization.
+    @Test func completedTranscriptRejectsEveryDenylistedPhraseOnMeSide() {
+        for phrase in RealtimeSession.hallucinationDenylist {
+            #expect(RealtimeSession.meaningfulTranscript(phrase, speaker: .me) == nil,
+                    "me should drop \(phrase.debugDescription)")
+            #expect(RealtimeSession.meaningfulTranscript(phrase.capitalized + ".", speaker: .me) == nil,
+                    "me should drop normalized \(phrase.debugDescription)")
         }
+    }
+
+    /// The denylist is a ME-side artifact filter only. On the THEM (system-audio) side a bare
+    /// "Thank you."/"Thanks" is a real conversational closer that must still fire a turn, so it is kept
+    /// (trimmed). Punctuation/whitespace-only noise is still dropped for them.
+    @Test func completedTranscriptKeepsDenylistedPhrasesOnThemSide() {
+        #expect(RealtimeSession.meaningfulTranscript("Thank you.", speaker: .them) == "Thank you.")
+        #expect(RealtimeSession.meaningfulTranscript("thanks", speaker: .them) == "thanks")
+        #expect(RealtimeSession.meaningfulTranscript(".", speaker: .them) == nil)
+    }
+
+    /// "bye" was removed from the denylist: a lone sign-off is well-formed real speech even on the me
+    /// side, and the punctuation filter already covers the lone-"." artifact.
+    @Test func byeIsNotFiltered() {
+        #expect(!RealtimeSession.hallucinationDenylist.contains("bye"))
+        #expect(RealtimeSession.meaningfulTranscript("Bye.", speaker: .me) == "Bye.")
     }
 
     /// Real speech survives, and is returned trimmed of surrounding whitespace. A sentence that merely
     /// contains a denylisted phrase as a substring is NOT dropped.
     @Test func completedTranscriptKeepsAndTrimsRealSpeech() {
-        #expect(RealtimeSession.meaningfulTranscript("  two pointers  ") == "two pointers")
-        #expect(RealtimeSession.meaningfulTranscript("thank you, let's use a hash map")
+        #expect(RealtimeSession.meaningfulTranscript("  two pointers  ", speaker: .me) == "two pointers")
+        #expect(RealtimeSession.meaningfulTranscript("thank you, let's use a hash map", speaker: .me)
                 == "thank you, let's use a hash map")
-        #expect(RealtimeSession.meaningfulTranscript("3") == "3")  // a lone digit is real content
+        #expect(RealtimeSession.meaningfulTranscript("3", speaker: .me) == "3")  // a lone digit is real
+    }
+
+    /// The filtering must take effect through the PUBLIC entry point the app actually calls
+    /// (`completedTranscript(from:speaker:)`), not only the internal helper — so a regression of the
+    /// one-line delegation can't slip through green tests.
+    @Test func completedTranscriptFiltersThroughPublicEntryPoint() {
+        let type = RealtimeSession.completedTranscriptionType
+        func event(_ t: String) -> [String: Any] { ["type": type, "transcript": t] }
+        #expect(RealtimeSession.completedTranscript(from: event("."), speaker: .me) == nil)
+        #expect(RealtimeSession.completedTranscript(from: event("."), speaker: .them) == nil)
+        #expect(RealtimeSession.completedTranscript(from: event("Thank you."), speaker: .me) == nil)
+        #expect(RealtimeSession.completedTranscript(from: event("Thank you."), speaker: .them) == "Thank you.")
+        #expect(RealtimeSession.completedTranscript(from: event("  two pointers "), speaker: .me) == "two pointers")
     }
 
     /// The connect URL MUST select a transcription session via intent (not ?model=).


### PR DESCRIPTION
## Problem

Server VAD was firing on non-speech (breaths, keyboard clicks, fan, room tone). When it commits one of those slices, `gpt-4o-transcribe` hallucinates a minimal token — most often a lone `"."`. The only validation in the pipeline was `!text.isEmpty`, so a `"."` flowed straight through and:

- logged a phantom `🗣 heard (me): "."` line,
- reset the silence timer (so the user looked "not silent" while saying nothing — masking the real "are you stuck?" check),
- fired a `turnEnd` coach trigger, waking the brain on noise.

This is the well-studied Whisper-family "hallucination on silence" problem. Fix follows the industry-standard layered approach.

## Changes

**Layer 1 — noise reduction before VAD**
- `RealtimeSession.sessionUpdate` now emits `session.audio.input.noise_reduction = {"type": "near_field"}` — the GA **object** shape (a bare string is the documented LiveKit bug the server rejects). Per OpenAI's docs this filters the input buffer *before* it reaches VAD, reducing false triggers at the source.
- Tunable via new `Config.audioNoiseReduction` (`near_field` / `far_field` / `nil`), plumbed through `RealtimeTranscriber` to both the mic and system-audio sides.

**Layer 3 — text gate at the chokepoint**
- `completedTranscript` now routes through `meaningfulTranscript(_:)`, which drops (1) punctuation/whitespace-only output (a lone `"."` has no letter or digit) and (2) a conservative *whole-utterance* denylist of stock caption-artifact hallucinations (`"thank you"`, `"thanks for watching"`, `"you"`, …). A real sentence merely *containing* those words survives. Real speech is returned trimmed.
- Because the phantom log line, silence-timer reset, and turn trigger all flow from this one return value, filtering here kills all three at once.

**Deferred — Layer 2** (`server_vad.threshold` / semantic VAD): needs live tuning against the actual mic/room, so it's a follow-up. `Config` is structured to add it next to `vadSilenceDurationMs`.

## Testing
- TDD: tests written first, watched fail (`has no member 'meaningfulTranscript'`), then implemented to green.
- 6 new tests in `RealtimeSessionTests` covering the noise-reduction payload (default/far_field/nil) and the text gate (punctuation-only, denylist, real-speech-survives + trim).
- Full suite: **126 tests pass**; app target builds clean.

## Note for reviewers
The denylist is the one judgment call: a bare `"thank you"` or `"you"` as a *complete* utterance is dropped. In a coding-coach context that's almost always a hallucination, but it's a deliberate tradeoff — easy to empty the list and rely solely on the punctuation filter + noise reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)