### PR TITLE
Show an Edit button for an existing API key and fix paste in Settings

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -35,6 +35,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
+        MainMenu.install() // an Edit menu so ⌘X/⌘C/⌘V/⌘A work in the Settings text fields
 
         if devMode {
             // The activity viewer lives for the whole dev run, but a *session* is one coaching run:

--- a/Sources/JarvisApp/App/MainMenu.swift
+++ b/Sources/JarvisApp/App/MainMenu.swift
@@ -1,0 +1,34 @@
+import AppKit
+
+/// The app's main menu bar. A menu-bar (`LSUIElement`) app installs no main menu by default, which
+/// means the standard editing shortcuts (⌘X / ⌘C / ⌘V / ⌘A) have no menu items to dispatch them — so
+/// they silently do nothing in the Settings text fields (paste fails). Installing a minimal menu with
+/// an Edit submenu restores them: AppKit resolves the shortcuts against the main menu and routes the
+/// responder-chain selectors to whatever field editor is first responder.
+enum MainMenu {
+    @MainActor
+    static func install() {
+        let mainMenu = NSMenu()
+
+        // First slot is always the application menu (system shows it titled with the app name). Holds
+        // Quit so ⌘Q works while the Settings window is focused.
+        let appItem = NSMenuItem()
+        mainMenu.addItem(appItem)
+        let appMenu = NSMenu()
+        appItem.submenu = appMenu
+        appMenu.addItem(withTitle: "Quit Jarvis", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+
+        // The reason this menu exists: standard editing commands, targeting the first responder via the
+        // responder chain (nil target).
+        let editItem = NSMenuItem()
+        mainMenu.addItem(editItem)
+        let editMenu = NSMenu(title: "Edit")
+        editItem.submenu = editMenu
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+
+        NSApp.mainMenu = mainMenu
+    }
+}

--- a/Sources/JarvisApp/Settings/APIKeySection.swift
+++ b/Sources/JarvisApp/Settings/APIKeySection.swift
@@ -4,14 +4,27 @@ import JarvisCore
 /// Settings panel for the OpenAI API key. Saves to an owner-only file and reports back via
 /// `onKeySaved` (the app restarts the pipeline only if it was already running). Replaces the old modal
 /// dialog in MenuBarController.
+///
+/// Two states: when no key is stored yet it shows the entry field + Save; when one already exists it
+/// shows a "key is saved" summary + an Edit button (we never display the stored key — it's write-only,
+/// matching the owner-only-file posture). Edit reveals an empty field to paste a replacement.
 @MainActor
 final class APIKeySection: NSObject, SettingsSection {
     let title = "API Key"
 
     private let store: FileSecretStore
     private let onKeySaved: (String) -> Void
+
+    private var prompt: NSTextField?           // entry instructions
     private var field: NSSecureTextField?
+    private var saveButton: NSButton?
+    private var savedLabel: NSTextField?       // "a key is saved" summary
+    private var editButton: NSButton?
     private var status: NSTextField?
+
+    /// When true the entry field is shown; when false the saved summary is. Starts in entry mode only
+    /// if no key exists yet.
+    private var editing = true
 
     init(store: FileSecretStore, onKeySaved: @escaping (String) -> Void) {
         self.store = store
@@ -21,9 +34,10 @@ final class APIKeySection: NSObject, SettingsSection {
     func makeView() -> NSView {
         let view = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 432))
 
-        let label = NSTextField(labelWithString: "Paste your OpenAI API key. It's stored in an owner-only file on this Mac.")
-        label.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
-        view.addSubview(label)
+        let prompt = NSTextField(labelWithString: "Paste your OpenAI API key. It's stored in an owner-only file on this Mac.")
+        prompt.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
+        view.addSubview(prompt)
+        self.prompt = prompt
 
         let field = NSSecureTextField(frame: NSRect(x: 24, y: 322, width: 512, height: 26))
         field.placeholderString = "sk-…"
@@ -36,6 +50,18 @@ final class APIKeySection: NSObject, SettingsSection {
         save.bezelStyle = .rounded
         save.keyEquivalent = "\r"
         view.addSubview(save)
+        self.saveButton = save
+
+        let savedLabel = NSTextField(labelWithString: "An OpenAI API key is saved on this Mac.")
+        savedLabel.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
+        view.addSubview(savedLabel)
+        self.savedLabel = savedLabel
+
+        let edit = NSButton(title: "Edit", target: self, action: #selector(editTapped))
+        edit.frame = NSRect(x: 24, y: 318, width: 92, height: 32)
+        edit.bezelStyle = .rounded
+        view.addSubview(edit)
+        self.editButton = edit
 
         let status = NSTextField(labelWithString: "")
         status.frame = NSRect(x: 24, y: 288, width: 400, height: 20)
@@ -43,7 +69,26 @@ final class APIKeySection: NSObject, SettingsSection {
         view.addSubview(status)
         self.status = status
 
+        editing = store.apiKey() == nil
+        applyState()
         return view
+    }
+
+    /// Show the entry field + Save, or the saved summary + Edit, per `editing`.
+    private func applyState() {
+        prompt?.isHidden = !editing
+        field?.isHidden = !editing
+        saveButton?.isHidden = !editing
+        savedLabel?.isHidden = editing
+        editButton?.isHidden = editing
+    }
+
+    @objc private func editTapped() {
+        editing = true
+        status?.stringValue = ""
+        field?.stringValue = ""
+        applyState()
+        field?.window?.makeFirstResponder(field)
     }
 
     @objc private func saveTapped() {
@@ -53,5 +98,7 @@ final class APIKeySection: NSObject, SettingsSection {
         onKeySaved(token)
         status?.stringValue = "Key saved ✓"
         field?.stringValue = ""
+        editing = false
+        applyState()
     }
 }

--- a/Sources/JarvisApp/Settings/APIKeySection.swift
+++ b/Sources/JarvisApp/Settings/APIKeySection.swift
@@ -18,6 +18,7 @@ final class APIKeySection: NSObject, SettingsSection {
     private var prompt: NSTextField?           // entry instructions
     private var field: NSSecureTextField?
     private var saveButton: NSButton?
+    private var cancelButton: NSButton?        // shown only when editing an existing key
     private var savedLabel: NSTextField?       // "a key is saved" summary
     private var editButton: NSButton?
     private var status: NSTextField?
@@ -34,7 +35,7 @@ final class APIKeySection: NSObject, SettingsSection {
     func makeView() -> NSView {
         let view = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 432))
 
-        let prompt = NSTextField(labelWithString: "Paste your OpenAI API key. It's stored in an owner-only file on this Mac.")
+        let prompt = NSTextField(labelWithString: "Paste your OpenAI API key to unlock OpenAI model.")
         prompt.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
         view.addSubview(prompt)
         self.prompt = prompt
@@ -52,6 +53,15 @@ final class APIKeySection: NSObject, SettingsSection {
         view.addSubview(save)
         self.saveButton = save
 
+        // Sits just left of Save; only meaningful when a key already exists, so canceling has a saved
+        // state to return to (a first-time entry has nothing to cancel back to).
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancel.frame = NSRect(x: 344, y: 282, width: 92, height: 32)
+        cancel.bezelStyle = .rounded
+        cancel.keyEquivalent = "\u{1b}" // Esc
+        view.addSubview(cancel)
+        self.cancelButton = cancel
+
         let savedLabel = NSTextField(labelWithString: "An OpenAI API key is saved on this Mac.")
         savedLabel.frame = NSRect(x: 24, y: 360, width: 512, height: 20)
         view.addSubview(savedLabel)
@@ -63,8 +73,10 @@ final class APIKeySection: NSObject, SettingsSection {
         view.addSubview(edit)
         self.editButton = edit
 
+        // Below the Save/Cancel row — at the buttons' own height its frame would overlap (and, being
+        // a later subview, swallow clicks on) the Cancel button.
         let status = NSTextField(labelWithString: "")
-        status.frame = NSRect(x: 24, y: 288, width: 400, height: 20)
+        status.frame = NSRect(x: 24, y: 248, width: 512, height: 20)
         status.textColor = .secondaryLabelColor
         view.addSubview(status)
         self.status = status
@@ -74,11 +86,13 @@ final class APIKeySection: NSObject, SettingsSection {
         return view
     }
 
-    /// Show the entry field + Save, or the saved summary + Edit, per `editing`.
+    /// Show the entry field + Save, or the saved summary + Edit, per `editing`. Cancel appears only
+    /// while editing a key that's already stored — a first-time entry has no saved state to revert to.
     private func applyState() {
         prompt?.isHidden = !editing
         field?.isHidden = !editing
         saveButton?.isHidden = !editing
+        cancelButton?.isHidden = !(editing && store.apiKey() != nil)
         savedLabel?.isHidden = editing
         editButton?.isHidden = editing
     }
@@ -89,6 +103,13 @@ final class APIKeySection: NSObject, SettingsSection {
         field?.stringValue = ""
         applyState()
         field?.window?.makeFirstResponder(field)
+    }
+
+    @objc private func cancelTapped() {
+        editing = false
+        status?.stringValue = ""
+        field?.stringValue = ""
+        applyState()
     }
 
     @objc private func saveTapped() {


### PR DESCRIPTION
## What

Two related fixes to the **Settings → API Key** tab.

### Edit / Cancel for an existing key
The tab always rendered an empty field, with no sign a key was already stored. Now:
- **No key stored** → entry field + Save (unchanged); the prompt reads "Paste your OpenAI API key to unlock OpenAI model."
- **Key already stored** → "An OpenAI API key is saved on this Mac." + an **Edit** button. Edit reveals an empty field (focused) to paste a replacement, with **Save** and **Cancel**. Cancel (Esc) discards the field and returns to the saved state without writing; it's shown only when a key already exists, since a first-time entry has nothing to revert to. Saving returns to the saved state.

The stored key is never shown — it stays write-only, consistent with the owner-only-file posture (`FileSecretStore` exposes the key only to the pipeline, never the UI).

### ⌘C/⌘V/⌘X/⌘A in the Settings text fields
Paste silently did nothing in the API key field. Root cause: as an `LSUIElement` menu-bar app, Jarvis installed **no main menu at all**, so the standard editing shortcuts had no menu items to dispatch them to the focused field editor. Added a minimal main menu (`MainMenu.swift`) with an Edit submenu (Cut/Copy/Paste/Select All) plus Quit, installed at launch.

## Testing
- `swift build` clean.
- The original Edit-button / paste flow was built + launched via `./scripts/build-app.sh --run` (JarvisApp is verified by live run, not unit tests, per `CLAUDE.md`).
- The Cancel button and prompt-text changes have been compile-verified (`swift build`) but not yet re-run live — recommend a quick `--run` of the Edit → Cancel flow before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)