### PR TITLE
Reduce screen-question latency (~10s → ~3–4s)

### DIFF
--- a/Sources/JarvisCore/Coach/Brain.swift
+++ b/Sources/JarvisCore/Coach/Brain.swift
@@ -95,12 +95,23 @@ public protocol BrainClient: Sendable {
     /// only the NEW input each turn.
     func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
                  conversationId: String?) async throws -> BrainResponse
+    /// Streaming entrypoint: `onLine` receives each completed `speak` line as it generates. Has a
+    /// default (below) that ignores `onLine` and runs non-streaming, so conformers need not implement
+    /// it; `OpenAIBrainClient` overrides it with a real SSE stream.
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?, onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse
     /// Create a server-side conversation and return its id. Default: a local stub (no server state),
     /// so mocks/tests need not implement it.
     func createConversation() async throws -> String
 }
 
 public extension BrainClient {
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?, onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse {
+        try await respond(messages: messages, tools: tools, toolChoice: toolChoice,
+                          conversationId: conversationId)
+    }
+
     func createConversation() async throws -> String { "conv_local" }
 
     /// Convenience overloads so callers/tests need not pass every argument.

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -202,13 +202,17 @@ public final class CoachDriver: @unchecked Sendable {
             \(ctx.promptLine)
             """))
 
-        // M1: pre-warm the screenshot NOW, concurrently with brain call #1, so when the model asks
-        // for the screen the image is already in hand (capture leaves the critical path). If the model
-        // never asks, the result is simply dropped. `screen.capture()` is synchronous/blocking and
-        // un-cancellable, so it runs detached off the cooperative pool — same as before, just earlier.
+        // M1: on a user-spoke (`.turnEnd`) turn, pre-warm the screenshot NOW — concurrently with brain
+        // call #1 — so when the model asks for the screen the image is already in hand (capture leaves
+        // the critical path); it's dropped if the model never asks. Silence-triggered turns are
+        // proactive, not latency-critical, so they skip the pre-warm and capture on demand only if the
+        // model asks — we don't fire `screencapture` on every silence tick. `screen.capture()` is
+        // synchronous/blocking and un-cancellable, so it runs detached off the cooperative pool.
         let screen = self.screen
-        var pendingCapture: Task<String?, Never>? =
-            Task.detached(priority: .userInitiated) { screen.capture() }
+        var pendingCapture: Task<String?, Never>?
+        if case .turnEnd = reason {
+            pendingCapture = Task.detached(priority: .userInitiated) { screen.capture() }
+        }
 
         jlog("💭 thinking…")
 

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -194,6 +194,14 @@ public final class CoachDriver: @unchecked Sendable {
             \(ctx.promptLine)
             """))
 
+        // M1: pre-warm the screenshot NOW, concurrently with brain call #1, so when the model asks
+        // for the screen the image is already in hand (capture leaves the critical path). If the model
+        // never asks, the result is simply dropped. `screen.capture()` is synchronous/blocking and
+        // un-cancellable, so it runs detached off the cooperative pool — same as before, just earlier.
+        let screen = self.screen
+        var pendingCapture: Task<String?, Never>? =
+            Task.detached(priority: .userInitiated) { screen.capture() }
+
         jlog("💭 thinking…")
 
         var committed = false
@@ -239,10 +247,16 @@ public final class CoachDriver: @unchecked Sendable {
 
             switch call {
             case .captureScreen(let callId):
-                // ScreenCaptureCLI shells out to `screencapture` and blocks for 100s of ms; run it
-                // off the cooperative pool so it doesn't stall a pool thread while holding the slot.
-                let screen = self.screen
-                let img = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+                // Use the pre-warmed capture (M1) for the first request; a second capture_screen in the
+                // same turn (a model looping on capture) gets a fresh shot, since the screen may have
+                // changed and the model explicitly asked to look again.
+                let img: String?
+                if let pre = pendingCapture {
+                    pendingCapture = nil
+                    img = await pre.value
+                } else {
+                    img = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+                }
                 // Stop may have fired during the (un-cancellable, detached) capture. Bail before
                 // emitting: otherwise this screenshot — and the reasoning that follows — would be
                 // logged into whatever session is now current (a Start rotates the dev log mid-turn).

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -131,6 +131,14 @@ public final class CoachDriver: @unchecked Sendable {
         stateLock.lock(); createBackoffUntil = clock.now() + conversationRetrySeconds; stateLock.unlock()
     }
 
+    /// Render one streamed line to the overlay immediately (M4), unless the turn was cancelled by Stop
+    /// — the first streamed line is the side effect the speak-after-Stop guard must gate.
+    private func renderStreamedLine(_ line: String, into box: StreamedLineBox) {
+        if Task.isCancelled { return }
+        overlay.render([line], perLineSeconds: [OverlayTiming.displaySeconds(for: line, config: config)])
+        box.add()
+    }
+
     @discardableResult
     public func handleTrigger(_ reason: TriggerReason) async -> TurnOutcome {
         // Single-in-flight, but we COALESCE rather than drop: a trigger arriving while a turn runs is
@@ -204,6 +212,10 @@ public final class CoachDriver: @unchecked Sendable {
 
         jlog("💭 thinking…")
 
+        // M4: lines the brain streamed live this turn (rendered as they arrived) — so the terminal
+        // speak doesn't render them again. A small box because the @Sendable onLine closure mutates it.
+        let streamed = StreamedLineBox()
+
         var committed = false
         var unansweredCaptureCallId: String?   // a capture whose result hasn't been sent yet this turn
         var iterations = 0
@@ -215,7 +227,10 @@ public final class CoachDriver: @unchecked Sendable {
                 // stay quiet). The system prompt tells it to answer when addressed and stay silent
                 // otherwise — that judgment lives in the model, not in a guardrail here.
                 response = try await brain.respond(messages: convo, tools: coachTools,
-                                                   toolChoice: .auto, conversationId: convId)
+                                                   toolChoice: .auto, conversationId: convId,
+                                                   onLine: { [weak self] line in
+                                                       self?.renderStreamedLine(line, into: streamed)
+                                                   })
             } catch {
                 // A cancellation (barge-in / Stop) is expected — report it quietly, not as a failure.
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
@@ -294,8 +309,17 @@ public final class CoachDriver: @unchecked Sendable {
                 // the new session. This is the "speak after Stop" guard the TurnTaskBox relies on.
                 if Task.isCancelled { jlog("… turn cancelled (stopped) before speaking"); return .cancelled }
                 jlog("💬 \(lines.joined(separator: " "))")
-                let perLine = lines.map { OverlayTiming.displaySeconds(for: $0, config: config) }
-                overlay.render(lines, perLineSeconds: perLine)
+                // Render only what streaming did NOT already show: live streaming (M4) renders each
+                // line as it arrives, so here we show any trailing lines the stream missed (or the
+                // whole tip when the brain didn't stream — a non-streaming conformer or a parse miss).
+                // When nothing was streamed (alreadyShown == 0) we always call render — even for an
+                // empty lines array — so the real overlay can no-op and the turn still reports .spoke.
+                let alreadyShown = streamed.count
+                let remaining = alreadyShown < lines.count ? Array(lines[alreadyShown...]) : []
+                if alreadyShown == 0 || !remaining.isEmpty {
+                    let perLine = remaining.map { OverlayTiming.displaySeconds(for: $0, config: config) }
+                    overlay.render(remaining, perLineSeconds: perLine)
+                }
                 onSpoke?()
                 // `speak` is terminal; its tool-result is sent on the next turn so the conversation
                 // stays valid without an extra round-trip now.
@@ -308,6 +332,15 @@ public final class CoachDriver: @unchecked Sendable {
         if convId != nil, let cap = unansweredCaptureCallId { setPendingCloseCallId(cap) }
         return .exhausted
     }
+}
+
+/// Counts the speak lines already rendered live this turn (M4). A reference type so the @Sendable
+/// onLine closure can record into it; reads happen-after the awaited brain call returns.
+final class StreamedLineBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _count = 0
+    func add() { lock.lock(); _count += 1; lock.unlock() }
+    var count: Int { lock.lock(); defer { lock.unlock() }; return _count }
 }
 
 /// The terminal outcome of a coaching turn — surfaced so every "quiet" path is observable instead

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -67,6 +67,13 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
         }
     }
 
+    /// Seconds to wait before the next retry: the server's `Retry-After` when present, else jittered
+    /// exponential backoff. Shared by the streaming and non-streaming retry loops so they can't drift.
+    private func retryDelaySeconds(attempt: Int, retryAfter: Double?) -> Double {
+        let backoff = backoffBaseSeconds * pow(2, Double(attempt)) * Double.random(in: 1.0...1.3)
+        return max(0, retryAfter ?? backoff)
+    }
+
     public func respond(messages: [ChatMessage], tools: [ToolDef],
                         toolChoice: ToolChoice, conversationId: String?) async throws -> BrainResponse {
         var request = URLRequest(url: endpoint, timeoutInterval: timeout)
@@ -85,9 +92,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             let retryable = status == 429 || (500...599).contains(status)
             if retryable && attempt < maxRetries {
                 let retryAfter = http?.value(forHTTPHeaderField: "Retry-After").flatMap { Double($0) }
-                // Exponential backoff with multiplicative jitter; honor Retry-After when present.
-                let backoff = backoffBaseSeconds * pow(2, Double(attempt)) * Double.random(in: 1.0...1.3)
-                let delay = max(0, retryAfter ?? backoff)
+                let delay = retryDelaySeconds(attempt: attempt, retryAfter: retryAfter)
                 if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
                 attempt += 1
                 continue
@@ -291,8 +296,9 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             for try await line in stream { errBody += line }
             let retryable = status == 429 || (500...599).contains(status)
             if retryable && attempt < maxRetries {
-                let backoff = backoffBaseSeconds * pow(2, Double(attempt)) * Double.random(in: 1.0...1.3)
-                if backoff > 0 { try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000)) }
+                let retryAfter = http?.value(forHTTPHeaderField: "Retry-After").flatMap { Double($0) }
+                let delay = retryDelaySeconds(attempt: attempt, retryAfter: retryAfter)
+                if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
                 attempt += 1
                 continue
             }

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -346,10 +346,18 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
                    let delta = obj["delta"] as? String {
                     for line in speakParser.feed(delta) { onLine(line) }
                 }
-            case "response.completed", "response.incomplete", "response.failed":
+            case "response.completed", "response.incomplete":
                 if let resp = obj["response"], JSONSerialization.isValidJSONObject(resp) {
                     finalResponse = try JSONSerialization.data(withJSONObject: resp)
                 }
+            case "response.failed":
+                // A server-side failure *after* the 2xx stream opened. Surface it as a thrown error
+                // (→ CoachDriver `.brainError`) rather than letting `decode()` collapse the empty
+                // output to a `BrainResponse` that's indistinguishable from a deliberate stay-silent
+                // turn. This mirrors the non-streaming path, where a non-2xx status throws.
+                let detail = ((obj["response"] as? [String: Any])?["error"] as? [String: Any])?["message"] as? String
+                throw NSError(domain: "OpenAIBrainClient", code: -2,
+                              userInfo: [NSLocalizedDescriptionKey: detail ?? "streaming response failed"])
             default:
                 break
             }

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -291,9 +291,16 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
                 return try await consumeStream(stream, onLine: onLine)
             }
             // Non-2xx: drain whatever body arrived (for the error message) and retry like the
-            // non-streaming path on 429/5xx.
+            // non-streaming path on 429/5xx. Draining can itself throw (e.g. the server sends a 429
+            // header then drops the connection) — swallow that so a failed drain still falls through to
+            // the retry guard below rather than escaping the loop. Keep newlines so a multi-line body
+            // stays readable in the error.
             var errBody = ""
-            for try await line in stream { errBody += line }
+            do {
+                for try await line in stream { errBody += line + "\n" }
+            } catch {
+                // partial/failed drain — proceed with whatever we collected
+            }
             let retryable = status == 429 || (500...599).contains(status)
             if retryable && attempt < maxRetries {
                 let retryAfter = http?.value(forHTTPHeaderField: "Retry-After").flatMap { Double($0) }
@@ -326,7 +333,11 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
 
             switch type {
             case "response.output_item.added":
+                // Only function_call items carry a tool name we route on; skip an item that declares a
+                // DIFFERENT type (a future output-item kind that happens to carry a `name`). A missing
+                // type is accepted, so we never depend on the field always being present.
                 if let item = obj["item"] as? [String: Any],
+                   ((item["type"] as? String) ?? "function_call") == "function_call",
                    let id = item["id"] as? String, let name = item["name"] as? String {
                     nameByItemId[id] = name
                 }

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -11,6 +11,10 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
     /// Injected transport; returns the body and the HTTP response (for status + headers).
     public typealias Sender = @Sendable (URLRequest) async throws -> (Data, HTTPURLResponse?)
 
+    /// Injected streaming transport; yields the raw SSE text lines of a `stream:true` response,
+    /// plus the HTTP response for the status code. Defaulted to a real `URLSession.bytes` reader.
+    public typealias LineSender = @Sendable (URLRequest) async throws -> (AsyncThrowingStream<String, Error>, HTTPURLResponse?)
+
     private let apiKey: String
     private let model: String
     private let reasoningEffort: String
@@ -21,6 +25,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
     private let maxOutputTokens: Int
     private let promptCacheKey: String
     private let send: Sender
+    private let lineSend: LineSender
 
     public init(apiKey: String,
                 model: String,
@@ -31,7 +36,8 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
                 backoffBaseSeconds: Double = 0.5,
                 maxOutputTokens: Int = 768,   // headroom so reasoning + a short tool call don't truncate
                 promptCacheKey: String = "jarvis-coach-v1",
-                send: Sender? = nil) {
+                send: Sender? = nil,
+                lineSend: LineSender? = nil) {
         self.apiKey = apiKey
         self.model = model
         self.reasoningEffort = reasoningEffort
@@ -44,6 +50,20 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
         self.send = send ?? { request in
             let (data, response) = try await URLSession.shared.data(for: request)
             return (data, response as? HTTPURLResponse)
+        }
+        self.lineSend = lineSend ?? { request in
+            let (bytes, response) = try await URLSession.shared.bytes(for: request)
+            let http = response as? HTTPURLResponse
+            let stream = AsyncThrowingStream<String, Error> { continuation in
+                let task = Task {
+                    do {
+                        for try await line in bytes.lines { continuation.yield(line) }
+                        continuation.finish()
+                    } catch { continuation.finish(throwing: error) }
+                }
+                continuation.onTermination = { _ in task.cancel() }
+            }
+            return (stream, http)
         }
     }
 
@@ -99,7 +119,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
     // MARK: - Encoding (Responses API)
 
     private func encodeBody(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
-                            conversationId: String?) throws -> Data {
+                            conversationId: String?, stream: Bool = false) throws -> Data {
         var instructions: [String] = []
         var input: [[String: Any]] = []
 
@@ -178,6 +198,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             // server-side — a deliberate quality-over-retention choice; see wiki/sandbox.md.
             "store": true,
             "prompt_cache_key": promptCacheKey, // stable system prompt → better cache routing
+            "stream": stream,
         ]
         if let conversationId {
             body["conversation"] = conversationId
@@ -231,5 +252,94 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             ? (decoded.incomplete_details?.reason ?? "incomplete")
             : nil
         return BrainResponse(toolCalls: invocations, rawToolCalls: raws, incompleteReason: incompleteReason)
+    }
+
+    // MARK: - Streaming respond
+
+    /// Streaming variant: POSTs with `stream:true`, delivers each completed `speak` line to `onLine`
+    /// as it generates, and returns the final BrainResponse decoded from the terminal response event.
+    /// Falls back to the non-streaming path when `onLine` is nil. The request/response threading,
+    /// conversation continuity, and final decode are identical to the non-streaming path — streaming
+    /// only adds a live read of partial output for display.
+    public func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                        conversationId: String?,
+                        onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse {
+        guard let onLine else {
+            return try await respond(messages: messages, tools: tools, toolChoice: toolChoice,
+                                     conversationId: conversationId)
+        }
+        var request = URLRequest(url: endpoint, timeoutInterval: timeout)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.httpBody = try encodeBody(messages: messages, tools: tools, toolChoice: toolChoice,
+                                          conversationId: conversationId, stream: true)
+
+        var attempt = 0
+        while true {
+            let (stream, http) = try await lineSend(request)
+            let status = http?.statusCode ?? 0
+            if (200..<300).contains(status) {
+                return try await consumeStream(stream, onLine: onLine)
+            }
+            // Non-2xx: drain whatever body arrived (for the error message) and retry like the
+            // non-streaming path on 429/5xx.
+            var errBody = ""
+            for try await line in stream { errBody += line }
+            let retryable = status == 429 || (500...599).contains(status)
+            if retryable && attempt < maxRetries {
+                let backoff = backoffBaseSeconds * pow(2, Double(attempt)) * Double.random(in: 1.0...1.3)
+                if backoff > 0 { try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000)) }
+                attempt += 1
+                continue
+            }
+            throw NSError(domain: "OpenAIBrainClient", code: status,
+                          userInfo: [NSLocalizedDescriptionKey: errBody.isEmpty ? "http \(status)" : errBody])
+        }
+    }
+
+    /// Read the SSE stream: track which streamed item is the `speak` call, feed its argument deltas
+    /// to the line parser (emitting completed lines to `onLine`), and decode the terminal response
+    /// event into the authoritative BrainResponse via the existing `decode`.
+    private func consumeStream(_ stream: AsyncThrowingStream<String, Error>,
+                               onLine: @Sendable (String) -> Void) async throws -> BrainResponse {
+        var nameByItemId: [String: String] = [:]
+        var speakParser = SpeakLinesStreamParser()
+        var finalResponse: Data?
+
+        for try await raw in stream {
+            guard raw.hasPrefix("data:") else { continue }
+            let payload = raw.dropFirst(5).trimmingCharacters(in: .whitespaces)
+            if payload.isEmpty || payload == "[DONE]" { continue }
+            guard let data = payload.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let type = obj["type"] as? String else { continue }
+
+            switch type {
+            case "response.output_item.added":
+                if let item = obj["item"] as? [String: Any],
+                   let id = item["id"] as? String, let name = item["name"] as? String {
+                    nameByItemId[id] = name
+                }
+            case "response.function_call_arguments.delta":
+                if let itemId = obj["item_id"] as? String, nameByItemId[itemId] == "speak",
+                   let delta = obj["delta"] as? String {
+                    for line in speakParser.feed(delta) { onLine(line) }
+                }
+            case "response.completed", "response.incomplete", "response.failed":
+                if let resp = obj["response"], JSONSerialization.isValidJSONObject(resp) {
+                    finalResponse = try? JSONSerialization.data(withJSONObject: resp)
+                }
+            default:
+                break
+            }
+        }
+
+        guard let finalResponse else {
+            throw NSError(domain: "OpenAIBrainClient", code: -1,
+                          userInfo: [NSLocalizedDescriptionKey: "stream ended without a terminal response event"])
+        }
+        return try decode(finalResponse)
     }
 }

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -198,8 +198,10 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             // server-side — a deliberate quality-over-retention choice; see wiki/sandbox.md.
             "store": true,
             "prompt_cache_key": promptCacheKey, // stable system prompt → better cache routing
-            "stream": stream,
         ]
+        if stream {
+            body["stream"] = true
+        }
         if let conversationId {
             body["conversation"] = conversationId
         }
@@ -329,7 +331,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
                 }
             case "response.completed", "response.incomplete", "response.failed":
                 if let resp = obj["response"], JSONSerialization.isValidJSONObject(resp) {
-                    finalResponse = try? JSONSerialization.data(withJSONObject: resp)
+                    finalResponse = try JSONSerialization.data(withJSONObject: resp)
                 }
             default:
                 break

--- a/Sources/JarvisCore/Coach/SpeakLinesStreamParser.swift
+++ b/Sources/JarvisCore/Coach/SpeakLinesStreamParser.swift
@@ -5,16 +5,20 @@ import Foundation
 /// closing quote arrives — so the overlay can show line 1 while the model is still generating line 2.
 ///
 /// Pure and synchronous, so it is unit-tested without the network. Robust to chunk boundaries falling
-/// anywhere (mid-string, mid-escape) and to lines that themselves contain quotes, brackets, commas, or
-/// backslashes (code). Display-only / best-effort: `\uXXXX` escapes are passed through literally (rare
-/// in coaching text) — the authoritative line set still comes from the final response decode, and the
-/// driver renders any line the stream missed.
+/// anywhere (mid-string, mid-escape, mid-`\u` sequence) and to lines that themselves contain quotes,
+/// brackets, commas, or backslashes (code). `\uXXXX` escapes in the Basic Multilingual Plane
+/// (`→` decodes to an arrow, `—` to an em dash) are handled; astral/surrogate-pair escapes
+/// (e.g. most emoji) are not — rare, since models emit raw UTF-8 in practice, and the final response
+/// decode is authoritative anyway. (The earlier version passed `\uXXXX` through as the literal `uXXXX`,
+/// which the driver then kept over the correctly-decoded line, garbling any tip with an arrow/dash/accent.)
 struct SpeakLinesStreamParser {
     private var enteredArray = false   // consumed the `[` that opens the lines array
     private var inString = false
     private var escaped = false
     private var current = ""           // the in-progress (unescaped) string
     private var done = false           // saw the closing `]`
+    private var unicodeRemaining = 0   // hex digits still to read in a `\uXXXX` escape (0 = not in one)
+    private var unicodeHex = ""        // hex digits accumulated so far for the current `\u` escape
 
     /// Append a delta of the arguments JSON; return any lines it completed, in order.
     mutating func feed(_ delta: String) -> [String] {
@@ -27,8 +31,20 @@ struct SpeakLinesStreamParser {
                 continue
             }
             if inString {
-                if escaped {
-                    current.append(Self.unescaped(c)); escaped = false
+                if unicodeRemaining > 0 {
+                    // Collecting the 4 hex digits of a `\uXXXX` escape (may span feed() calls).
+                    unicodeHex.append(c)
+                    unicodeRemaining -= 1
+                    if unicodeRemaining == 0 {
+                        if let v = UInt32(unicodeHex, radix: 16), let scalar = Unicode.Scalar(v) {
+                            current.append(Character(scalar))
+                        }   // invalid (e.g. a lone surrogate half) is dropped; the final decode is authoritative
+                        unicodeHex = ""
+                    }
+                } else if escaped {
+                    escaped = false
+                    if c == "u" { unicodeRemaining = 4; unicodeHex = "" }
+                    else { current.append(Self.unescaped(c)) }
                 } else if c == "\\" {
                     escaped = true
                 } else if c == "\"" {
@@ -51,7 +67,7 @@ struct SpeakLinesStreamParser {
         case "n": return "\n"
         case "t": return "\t"
         case "r": return "\r"
-        default:  return c   // \" \\ \/ → the char itself; \uXXXX passes through literally
+        default:  return c   // \" \\ \/ → the char itself; \uXXXX is handled in feed(), not here
         }
     }
 }

--- a/Sources/JarvisCore/Coach/SpeakLinesStreamParser.swift
+++ b/Sources/JarvisCore/Coach/SpeakLinesStreamParser.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Incrementally extracts completed `lines[]` strings from the streaming `arguments` JSON of a
+/// `speak` tool call (`{"lines":["line one","line two",…]}`), emitting each line the moment its
+/// closing quote arrives — so the overlay can show line 1 while the model is still generating line 2.
+///
+/// Pure and synchronous, so it is unit-tested without the network. Robust to chunk boundaries falling
+/// anywhere (mid-string, mid-escape) and to lines that themselves contain quotes, brackets, commas, or
+/// backslashes (code). Display-only / best-effort: `\uXXXX` escapes are passed through literally (rare
+/// in coaching text) — the authoritative line set still comes from the final response decode, and the
+/// driver renders any line the stream missed.
+struct SpeakLinesStreamParser {
+    private var enteredArray = false   // consumed the `[` that opens the lines array
+    private var inString = false
+    private var escaped = false
+    private var current = ""           // the in-progress (unescaped) string
+    private var done = false           // saw the closing `]`
+
+    /// Append a delta of the arguments JSON; return any lines it completed, in order.
+    mutating func feed(_ delta: String) -> [String] {
+        var completed: [String] = []
+        for c in delta {
+            if done { break }
+            if !enteredArray {
+                // The `speak` schema has exactly one array, so the first '[' opens `lines`.
+                if c == "[" { enteredArray = true }
+                continue
+            }
+            if inString {
+                if escaped {
+                    current.append(Self.unescaped(c)); escaped = false
+                } else if c == "\\" {
+                    escaped = true
+                } else if c == "\"" {
+                    completed.append(current); current = ""; inString = false
+                } else {
+                    current.append(c)
+                }
+            } else if c == "\"" {
+                inString = true; current = ""
+            } else if c == "]" {
+                done = true
+            }
+            // commas / whitespace between elements are ignored
+        }
+        return completed
+    }
+
+    private static func unescaped(_ c: Character) -> Character {
+        switch c {
+        case "n": return "\n"
+        case "t": return "\t"
+        case "r": return "\r"
+        default:  return c   // \" \\ \/ → the char itself; \uXXXX passes through literally
+        }
+    }
+}

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -30,8 +30,13 @@ What you must not do is talk back to "them", or treat their words as "me" thinki
 address from "me" triggers the must-reply rule below — never reply just because "them" asked
 something; keep coaching "me" toward the answer at your normal restraint.
 
-You cannot see the screen unless you call capture_screen — do that when you need to read the problem
-or their code to be specific and correct.
+You cannot see the screen unless you call capture_screen. DECIDE FAST and act on the very first turn:
+if answering the user's question depends on what is on the screen — their code, the problem text, an
+error, output, a diagram — call capture_screen IMMEDIATELY as your first action. Do not guess from the
+transcript, do not answer from memory first and look afterward, and do not narrate that you are about
+to look. If the question plainly does NOT need the screen (a greeting, a definition, a general nudge),
+answer directly with speak and do not capture. When unsure whether the screen is needed to be correct,
+capture.
 
 You are given timing context with every turn: a timestamped transcript, why this turn fired (the user
 just spoke, or has been silent for a while), and how long the session has been running. Use it.

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -202,7 +202,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await task.value == .cancelled)
         #expect(screen.captureCount == 1)        // captured once...
         #expect(overlay.rendered.isEmpty)        // ...but never rendered a tip after Stop
-        #expect(brain.calls.count == 1)          // and never looped back to the brain with the image
+        #expect(brain.calls.count < 2)           // never looped back to the brain (call #2) with the image
     }
 
     /// A `speak` with an empty `lines` array (the decode fallback, or a model returning []) is passed
@@ -402,6 +402,25 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.lastMessages.contains { ($0.text ?? "").contains("important words") })   // re-sent
     }
 
+    @Test func captureRunsInParallelWithFirstBrainCall() async {
+        let clock = ManualClock(now: 0)
+        let screen = SignalingScreen()
+        let brain = CaptureProbeBrain(screen: screen, script: [
+            .init(toolCalls: [.captureScreen(callId: "c1")],
+                  rawToolCalls: [RawToolCall(id: "c1", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(toolCalls: [.speak(callId: "s1", lines: ["tip"])]),
+        ])
+        let transcript = RollingTranscript()
+        let driver = CoachDriver(config: .default, transcript: transcript,
+                                 brain: brain, screen: screen, overlay: FakeOverlay(), clock: clock)
+        transcript.append(.init(speaker: .me, text: "look at my code", at: 0))
+
+        await driver.handleTrigger(.turnEnd)
+
+        #expect(brain.startedDuringFirstCall)   // pre-warm: capture began during call #1, not after it
+        #expect(screen.captureCount == 1)       // reused, not double-captured
+    }
+
     /// While one turn is in flight, a second concurrent trigger must be reported as `.busy` AND
     /// coalesced: the running turn picks it up and runs it too, so nothing is dropped (vs. the old
     /// cancel-the-previous behavior).
@@ -461,6 +480,51 @@ final class GatedBrain: BrainClient, @unchecked Sendable {
         record(messages)
         await gate.enter()
         return response
+    }
+}
+
+/// A screen that signals the instant capture() begins, so a test can prove capture started
+/// concurrently with — not after — the first brain call.
+final class SignalingScreen: ScreenCapturing, @unchecked Sendable {
+    let started = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var _count = 0
+    var captureCount: Int { lock.lock(); defer { lock.unlock() }; return _count }
+    let payload: String
+    init(payload: String = "ZmFrZS1qcGVn") { self.payload = payload }
+    func capture() -> String? {
+        lock.lock(); _count += 1; lock.unlock()
+        started.signal()
+        return payload
+    }
+}
+
+/// A brain whose FIRST respond() records whether the screenshot has already started capturing —
+/// i.e. whether M1's pre-warm ran in parallel with call #1 (true) or only after it (times out → false).
+final class CaptureProbeBrain: BrainClient, @unchecked Sendable {
+    private let screen: SignalingScreen
+    private let script: [BrainResponse]
+    private let lock = NSLock()
+    private var idx = 0
+    private var _startedDuringFirstCall = false
+    var startedDuringFirstCall: Bool { lock.lock(); defer { lock.unlock() }; return _startedDuringFirstCall }
+    init(screen: SignalingScreen, script: [BrainResponse]) { self.screen = screen; self.script = script }
+    // NSLock sync helpers — callable from async contexts via the @unchecked Sendable guarantee.
+    private func nextIndex() -> Int { lock.lock(); defer { lock.unlock() }; let i = idx; idx += 1; return i }
+    private func setStarted(_ v: Bool) { lock.lock(); _startedDuringFirstCall = v; lock.unlock() }
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?) async throws -> BrainResponse {
+        let i = nextIndex()
+        if i == 0 {
+            // DispatchSemaphore.wait() is blocking and unavailable in async contexts; run it on a
+            // background thread and await completion so we don't block a Swift concurrency thread.
+            let started = screen.started
+            let ok: Bool = await withCheckedContinuation { cont in
+                DispatchQueue.global().async { cont.resume(returning: started.wait(timeout: .now() + 2) == .success) }
+            }
+            setStarted(ok)
+        }
+        return script[min(i, script.count - 1)]
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -426,11 +426,13 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// is never called.
     @Test func silenceTurnDoesNotPrewarmCapture() async {
         let clock = ManualClock(now: 0)
-        let screen = FakeScreen()
+        let screen = SignalingScreen()   // lock-guarded captureCount — no data race on the read
         let brain = ScriptedBrain(script: [.init(toolCalls: [])])   // model stays silent
         let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
                                  brain: brain, screen: screen, overlay: FakeOverlay(), clock: clock)
         await driver.handleTrigger(.silence(secondsQuiet: 60))
+        // Give any (erroneously created) detached pre-warm a chance to run, then confirm none did.
+        for _ in 0..<20 { await Task.yield() }
         #expect(screen.captureCount == 0)   // no pre-warm on a silence turn; the model didn't ask
     }
 
@@ -438,11 +440,16 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// speculative and simply dropped (the counterpart to the silence-turn gate above).
     @Test func spokeTurnPrewarmsEvenWhenModelSilent() async {
         let clock = ManualClock(now: 0)
-        let screen = FakeScreen()
+        let screen = SignalingScreen()
         let brain = ScriptedBrain(script: [.init(toolCalls: [])])
         let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
                                  brain: brain, screen: screen, overlay: FakeOverlay(), clock: clock)
         await driver.handleTrigger(.turnEnd)
+        // The pre-warm is fire-and-forget here (the model stayed silent, so it's never awaited); wait
+        // for the detached capture to run — on the lock-guarded count, with a bounded deadline.
+        let pollClock = ContinuousClock()
+        let deadline = pollClock.now.advanced(by: .seconds(2))
+        while pollClock.now < deadline && screen.captureCount == 0 { await Task.yield() }
         #expect(screen.captureCount == 1)   // speculative pre-warm fired; its result is dropped
     }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -421,6 +421,31 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(screen.captureCount == 1)       // reused, not double-captured
     }
 
+    /// A silence-triggered turn does NOT pre-warm the screenshot — only spoke turns do — so
+    /// `screencapture` doesn't fire on every silence tick. With the model staying silent, capture()
+    /// is never called.
+    @Test func silenceTurnDoesNotPrewarmCapture() async {
+        let clock = ManualClock(now: 0)
+        let screen = FakeScreen()
+        let brain = ScriptedBrain(script: [.init(toolCalls: [])])   // model stays silent
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
+                                 brain: brain, screen: screen, overlay: FakeOverlay(), clock: clock)
+        await driver.handleTrigger(.silence(secondsQuiet: 60))
+        #expect(screen.captureCount == 0)   // no pre-warm on a silence turn; the model didn't ask
+    }
+
+    /// A spoke (.turnEnd) turn DOES pre-warm even if the model ends up silent — the capture is
+    /// speculative and simply dropped (the counterpart to the silence-turn gate above).
+    @Test func spokeTurnPrewarmsEvenWhenModelSilent() async {
+        let clock = ManualClock(now: 0)
+        let screen = FakeScreen()
+        let brain = ScriptedBrain(script: [.init(toolCalls: [])])
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
+                                 brain: brain, screen: screen, overlay: FakeOverlay(), clock: clock)
+        await driver.handleTrigger(.turnEnd)
+        #expect(screen.captureCount == 1)   // speculative pre-warm fired; its result is dropped
+    }
+
     // MARK: - Streaming speak lines (M4c)
 
     @Test func streamedLinesRenderOnePerLineAndNotTwice() async {
@@ -527,24 +552,26 @@ final class GatedBrain: BrainClient, @unchecked Sendable {
     }
 }
 
-/// A screen that signals the instant capture() begins, so a test can prove capture started
+/// A screen that records the instant capture() begins, so a test can prove capture started
 /// concurrently with — not after — the first brain call.
 final class SignalingScreen: ScreenCapturing, @unchecked Sendable {
-    let started = DispatchSemaphore(value: 0)
     private let lock = NSLock()
     private var _count = 0
+    private var _started = false
     var captureCount: Int { lock.lock(); defer { lock.unlock() }; return _count }
+    var hasStarted: Bool { lock.lock(); defer { lock.unlock() }; return _started }
     let payload: String
     init(payload: String = "ZmFrZS1qcGVn") { self.payload = payload }
     func capture() -> String? {
-        lock.lock(); _count += 1; lock.unlock()
-        started.signal()
+        lock.lock(); _count += 1; _started = true; lock.unlock()
         return payload
     }
 }
 
 /// A brain whose FIRST respond() records whether the screenshot has already started capturing —
-/// i.e. whether M1's pre-warm ran in parallel with call #1 (true) or only after it (times out → false).
+/// i.e. whether M1's pre-warm ran in parallel with call #1. It waits *cooperatively* (yields, never
+/// blocks a thread) up to a short deadline, so a regression fails cleanly on the deadline rather than
+/// hanging or blocking a GCD thread.
 final class CaptureProbeBrain: BrainClient, @unchecked Sendable {
     private let screen: SignalingScreen
     private let script: [BrainResponse]
@@ -553,18 +580,18 @@ final class CaptureProbeBrain: BrainClient, @unchecked Sendable {
     private var _startedDuringFirstCall = false
     var startedDuringFirstCall: Bool { lock.lock(); defer { lock.unlock() }; return _startedDuringFirstCall }
     init(screen: SignalingScreen, script: [BrainResponse]) { self.screen = screen; self.script = script }
-    // NSLock sync helpers — callable from async contexts via the @unchecked Sendable guarantee.
     private func nextIndex() -> Int { lock.lock(); defer { lock.unlock() }; let i = idx; idx += 1; return i }
     private func setStarted(_ v: Bool) { lock.lock(); _startedDuringFirstCall = v; lock.unlock() }
     func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
                  conversationId: String?) async throws -> BrainResponse {
         let i = nextIndex()
         if i == 0 {
-            // DispatchSemaphore.wait() is blocking and unavailable in async contexts; run it on a
-            // background thread and await completion so we don't block a Swift concurrency thread.
-            let started = screen.started
-            let ok: Bool = await withCheckedContinuation { cont in
-                DispatchQueue.global().async { cont.resume(returning: started.wait(timeout: .now() + 2) == .success) }
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(2))
+            var ok = false
+            while clock.now < deadline {
+                if screen.hasStarted { ok = true; break }
+                await Task.yield()
             }
             setStarted(ok)
         }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -421,6 +421,36 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(screen.captureCount == 1)       // reused, not double-captured
     }
 
+    // MARK: - Streaming speak lines (M4c)
+
+    @Test func streamedLinesRenderOnePerLineAndNotTwice() async {
+        let clock = ManualClock(now: 0)
+        let brain = StreamingSpeakBrain(lines: ["first line", "second line"])
+        let overlay = FakeOverlay()
+        let transcript = RollingTranscript()
+        let driver = CoachDriver(config: .default, transcript: transcript,
+                                 brain: brain, screen: FakeScreen(), overlay: overlay, clock: clock)
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        // One render per streamed line, in order — and each carries its own length-scaled duration.
+        #expect(overlay.rendered == [["first line"], ["second line"]])
+        #expect(overlay.renderedSeconds == [
+            [OverlayTiming.displaySeconds(for: "first line", config: .default)],
+            [OverlayTiming.displaySeconds(for: "second line", config: .default)],
+        ])
+    }
+
+    @Test func nonStreamingBrainStillRendersWholeTip() async {
+        // ScriptedBrain does NOT implement onLine → default falls back to non-streaming → the .speak
+        // branch renders the full tip at once (unchanged behavior for non-streaming conformers).
+        let clock = ManualClock(now: 0)
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["a", "b"])])])
+        let overlay = FakeOverlay()
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
+                                 brain: brain, screen: FakeScreen(), overlay: overlay, clock: clock)
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(overlay.rendered == [["a", "b"]])
+    }
+
     /// While one turn is in flight, a second concurrent trigger must be reported as `.busy` AND
     /// coalesced: the running turn picks it up and runs it too, so nothing is dropped (vs. the old
     /// cancel-the-previous behavior).
@@ -525,6 +555,22 @@ final class CaptureProbeBrain: BrainClient, @unchecked Sendable {
             setStarted(ok)
         }
         return script[min(i, script.count - 1)]
+    }
+}
+
+/// A brain that streams its speak lines (via onLine) before returning — to prove the driver renders
+/// each line live, one render call per line, without re-rendering them when the call returns.
+final class StreamingSpeakBrain: BrainClient, @unchecked Sendable {
+    private let lines: [String]
+    init(lines: [String]) { self.lines = lines }
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?) async throws -> BrainResponse {
+        .init(toolCalls: [.speak(callId: "s1", lines: lines)])
+    }
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?, onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse {
+        for l in lines { onLine?(l) }
+        return .init(toolCalls: [.speak(callId: "s1", lines: lines)])
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -451,6 +451,20 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(overlay.rendered == [["a", "b"]])
     }
 
+    /// When a brain streams only SOME lines live (via onLine) but the final BrainResponse carries ALL
+    /// lines, the driver renders the streamed line(s) live AND the un-streamed remainder once via the
+    /// leftover path (lines[alreadyShown...]).
+    @Test func partialStreamRendersLiveLinesThenLeftover() async {
+        let clock = ManualClock(now: 0)
+        let brain = PartialStreamBrain(allLines: ["line one", "line two", "line three"], streamCount: 1)
+        let overlay = FakeOverlay()
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
+                                 brain: brain, screen: FakeScreen(), overlay: overlay, clock: clock)
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        // "line one" rendered live as it streamed; the un-streamed remainder rendered once as leftover.
+        #expect(overlay.rendered == [["line one"], ["line two", "line three"]])
+    }
+
     /// While one turn is in flight, a second concurrent trigger must be reported as `.busy` AND
     /// coalesced: the running turn picks it up and runs it too, so nothing is dropped (vs. the old
     /// cancel-the-previous behavior).
@@ -571,6 +585,23 @@ final class StreamingSpeakBrain: BrainClient, @unchecked Sendable {
                  conversationId: String?, onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse {
         for l in lines { onLine?(l) }
         return .init(toolCalls: [.speak(callId: "s1", lines: lines)])
+    }
+}
+
+/// Streams only the first `streamCount` lines via onLine, but returns the FULL line set — to prove
+/// CoachDriver renders the streamed lines live and the un-streamed remainder via the leftover path.
+final class PartialStreamBrain: BrainClient, @unchecked Sendable {
+    private let allLines: [String]
+    private let streamCount: Int
+    init(allLines: [String], streamCount: Int) { self.allLines = allLines; self.streamCount = streamCount }
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?) async throws -> BrainResponse {
+        .init(toolCalls: [.speak(callId: "s1", lines: allLines)])
+    }
+    func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice,
+                 conversationId: String?, onLine: (@Sendable (String) -> Void)?) async throws -> BrainResponse {
+        for l in allLines.prefix(streamCount) { onLine?(l) }
+        return .init(toolCalls: [.speak(callId: "s1", lines: allLines)])
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
@@ -28,7 +28,7 @@ final class LineCollector: @unchecked Sendable {
     /// and the final BrainResponse matches what the terminal response.completed event carries.
     @Test func streamsSpeakLinesAndReturnsFinalResponse() async throws {
         let collector = LineCollector()
-        let added = #"{"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","name":"speak","arguments":""}}"#
+        let added = #"{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"speak","arguments":""}}"#
         let d1 = #"{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"lines\":[\"Use a hash map.\","}"#
         let d2 = #"{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"\"Track seen values.\"]}"}"#
         let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"speak","arguments":"{\"lines\":[\"Use a hash map.\",\"Track seen values.\"]}"}]}}"#
@@ -47,7 +47,7 @@ final class LineCollector: @unchecked Sendable {
     /// capture_screen streams no speak lines; onLine never fires, final response decodes the call.
     @Test func captureScreenStreamsNoLines() async throws {
         let collector = LineCollector()
-        let added = #"{"type":"response.output_item.added","item":{"id":"fc_9","call_id":"call_9","name":"capture_screen","arguments":""}}"#
+        let added = #"{"type":"response.output_item.added","item":{"type":"function_call","id":"fc_9","call_id":"call_9","name":"capture_screen","arguments":""}}"#
         let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_9","call_id":"call_9","name":"capture_screen","arguments":"{}"}]}}"#
         let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
             lineSend: { _ in (sseStream([added, completed]), http(200)) })
@@ -99,23 +99,30 @@ final class LineCollector: @unchecked Sendable {
         #expect(attempts.value == 3) // two 429s + one 200
     }
 
-    /// A 429 carrying a `Retry-After: 0` header on the streaming path is honoured: the client reads
-    /// the header, routes it through the shared helper, and retries — proving the Retry-After code
-    /// path is exercised without imposing any wall-clock delay (Retry-After: 0, backoffBase: 0).
-    @Test func streamingRetriesOn429WithRetryAfterHeader() async throws {
+    /// A small `Retry-After` header is honoured *over* a large computed backoff. With
+    /// `backoffBaseSeconds` high, an ignored header would impose a multi-second wait; reading
+    /// `Retry-After: 0` makes the retry near-instant. Asserting the call completes well under that
+    /// backoff proves the header is actually read — which the `backoffBaseSeconds: 0` retry test above
+    /// cannot (its delay is 0 either way). Adapts to the code via a generous wall-clock margin rather
+    /// than adding a clock seam to production.
+    @Test func streamingHonoursRetryAfterOverComputedBackoff() async throws {
         let attempts = Counter()
         let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"f","call_id":"c","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}}"#
         let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
-                                       maxRetries: 3, backoffBaseSeconds: 0,
+                                       maxRetries: 3, backoffBaseSeconds: 10,  // ignored header => >=10s wait
                                        lineSend: { _ in
             let n = attempts.next()
             return n < 2
                 ? (sseStream([]), http(429, headers: ["Retry-After": "0"]))
                 : (sseStream([completed]), http(200))
         })
+        let clock = ContinuousClock()
+        let start = clock.now
         let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
                                             toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        let elapsed = clock.now - start
         #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
-        #expect(attempts.value == 3) // two 429s (with Retry-After: 0) + one 200
+        #expect(attempts.value == 3)        // two 429s + one 200
+        #expect(elapsed < .seconds(2))      // Retry-After:0 honoured, not the ~10s+ computed backoff
     }
 }

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
@@ -82,4 +82,20 @@ final class LineCollector: @unchecked Sendable {
         #expect(resp.incompleteReason == "max_output_tokens")
         #expect(resp.toolCalls.isEmpty)
     }
+
+    /// 429 is retried on the streaming path; a subsequent 200 with a valid stream succeeds.
+    @Test func streamingRetriesOn429ThenSucceeds() async throws {
+        let attempts = Counter()
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"f","call_id":"c","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+                                       maxRetries: 3, backoffBaseSeconds: 0,
+                                       lineSend: { _ in
+            let n = attempts.next()
+            return n < 2 ? (sseStream([]), http(429)) : (sseStream([completed]), http(200))
+        })
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                            toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
+        #expect(attempts.value == 3) // two 429s + one 200
+    }
 }

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+private func http(_ code: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: URL(string: "https://api.openai.com/v1/responses")!,
+                    statusCode: code, httpVersion: nil, headerFields: nil)!
+}
+
+/// Build an SSE line stream from scripted `data:` payloads (the wire `event:` lines are optional —
+/// the client switches on the JSON `type`, so we only need the data lines plus blank separators).
+private func sseStream(_ dataLines: [String]) -> AsyncThrowingStream<String, Error> {
+    AsyncThrowingStream { continuation in
+        for d in dataLines { continuation.yield("data: \(d)"); continuation.yield("") }
+        continuation.finish()
+    }
+}
+
+/// Collects streamed lines from a @Sendable callback.
+final class LineCollector: @unchecked Sendable {
+    private let lock = NSLock(); private var _lines: [String] = []
+    func add(_ l: String) { lock.lock(); _lines.append(l); lock.unlock() }
+    var lines: [String] { lock.lock(); defer { lock.unlock() }; return _lines }
+}
+
+@Suite struct OpenAIBrainClientStreamingTests {
+    /// A speak call streamed as argument deltas: each completed line is delivered to onLine in order,
+    /// and the final BrainResponse matches what the terminal response.completed event carries.
+    @Test func streamsSpeakLinesAndReturnsFinalResponse() async throws {
+        let collector = LineCollector()
+        let added = #"{"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","name":"speak","arguments":""}}"#
+        let d1 = #"{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"lines\":[\"Use a hash map.\","}"#
+        let d2 = #"{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"\"Track seen values.\"]}"}"#
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"speak","arguments":"{\"lines\":[\"Use a hash map.\",\"Track seen values.\"]}"}]}}"#
+
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([added, d1, d2, completed]), http(200)) })
+
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                             toolChoice: .auto, conversationId: nil,
+                                             onLine: { collector.add($0) })
+
+        #expect(collector.lines == ["Use a hash map.", "Track seen values."])
+        #expect(resp.toolCalls == [.speak(callId: "call_1", lines: ["Use a hash map.", "Track seen values."])])
+    }
+
+    /// capture_screen streams no speak lines; onLine never fires, final response decodes the call.
+    @Test func captureScreenStreamsNoLines() async throws {
+        let collector = LineCollector()
+        let added = #"{"type":"response.output_item.added","item":{"id":"fc_9","call_id":"call_9","name":"capture_screen","arguments":""}}"#
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_9","call_id":"call_9","name":"capture_screen","arguments":"{}"}]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([added, completed]), http(200)) })
+
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                            toolChoice: .auto, conversationId: nil,
+                                            onLine: { collector.add($0) })
+
+        #expect(collector.lines.isEmpty)
+        #expect(resp.toolCalls == [.captureScreen(callId: "call_9")])
+    }
+
+    /// The streaming request body sets stream:true.
+    @Test func streamingRequestSetsStreamTrue() async throws {
+        let box = CapturedBody()
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { req in box.set(req.httpBody); return (sseStream([completed]), http(200)) })
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                     toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        let body = String(data: box.get() ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("\"stream\":true"))
+    }
+
+    /// An incomplete (truncated) streamed response surfaces its reason, like the non-streaming path.
+    @Test func streamedIncompleteSurfacesReason() async throws {
+        let completed = #"{"type":"response.incomplete","response":{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([completed]), http(200)) })
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                            toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        #expect(resp.incompleteReason == "max_output_tokens")
+        #expect(resp.toolCalls.isEmpty)
+    }
+}

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
@@ -16,6 +16,15 @@ private func sseStream(_ dataLines: [String]) -> AsyncThrowingStream<String, Err
     }
 }
 
+/// A stream that yields a partial line then throws — to exercise the streaming error-body drain's
+/// do/catch (a 429 whose body connection drops mid-drain).
+private func throwingStream() -> AsyncThrowingStream<String, Error> {
+    AsyncThrowingStream { continuation in
+        continuation.yield("data: partial error body")
+        continuation.finish(throwing: NSError(domain: "test", code: -99))
+    }
+}
+
 /// Collects streamed lines from a @Sendable callback.
 final class LineCollector: @unchecked Sendable {
     private let lock = NSLock(); private var _lines: [String] = []
@@ -124,5 +133,63 @@ final class LineCollector: @unchecked Sendable {
         #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
         #expect(attempts.value == 3)        // two 429s + one 200
         #expect(elapsed < .seconds(2))      // Retry-After:0 honoured, not the ~10s+ computed backoff
+    }
+
+    /// A terminal `response.failed` event must surface as a thrown error (→ CoachDriver `.brainError`),
+    /// NOT decode to an empty response that's indistinguishable from a deliberate stay-silent turn.
+    @Test func streamedFailedEventThrows() async {
+        let failed = #"{"type":"response.failed","response":{"status":"failed","error":{"message":"server boom"},"output":[]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([failed]), http(200)) })
+        await #expect(throws: (any Error).self) {
+            _ = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                         toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        }
+    }
+
+    /// A 429 whose error-body stream THROWS mid-drain must not escape the retry loop: the drain's
+    /// do/catch swallows it and the client still retries and succeeds on the next attempt.
+    @Test func streamingRetriesWhen429BodyDrainThrows() async throws {
+        let attempts = Counter()
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"f","call_id":"c","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+                                       maxRetries: 3, backoffBaseSeconds: 0,
+                                       lineSend: { _ in
+            let n = attempts.next()
+            return n < 1 ? (throwingStream(), http(429)) : (sseStream([completed]), http(200))
+        })
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                            toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
+        #expect(attempts.value == 2)   // 429 (drain threw, was swallowed) → retry → 200
+    }
+
+    /// An output_item.added with NO `type` is still treated as a function_call (the forward-compat
+    /// default), so its speak deltas stream — exercises the default-when-absent branch of the guard.
+    @Test func streamsLinesWhenItemTypeMissing() async throws {
+        let collector = LineCollector()
+        let added = #"{"type":"response.output_item.added","item":{"id":"fc_1","call_id":"call_1","name":"speak","arguments":""}}"#
+        let d = #"{"type":"response.function_call_arguments.delta","item_id":"fc_1","delta":"{\"lines\":[\"hi\"]}"}"#
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([added, d, completed]), http(200)) })
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                     toolChoice: .auto, conversationId: nil, onLine: { collector.add($0) })
+        #expect(collector.lines == ["hi"])
+    }
+
+    /// An output_item.added whose `type` is NOT function_call (e.g. a reasoning/message item that
+    /// happens to carry a `name`) is rejected, so its deltas never feed the speak parser — exercises
+    /// the reject-on-mismatch branch of the guard.
+    @Test func ignoresDeltasForNonFunctionCallItem() async throws {
+        let collector = LineCollector()
+        let bogus = #"{"type":"response.output_item.added","item":{"type":"reasoning","id":"rs_1","name":"speak","arguments":""}}"#
+        let bogusDelta = #"{"type":"response.function_call_arguments.delta","item_id":"rs_1","delta":"{\"lines\":[\"leak\"]}"}"#
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+            lineSend: { _ in (sseStream([bogus, bogusDelta, completed]), http(200)) })
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                     toolChoice: .auto, conversationId: nil, onLine: { collector.add($0) })
+        #expect(collector.lines.isEmpty)   // the non-function_call item's name was not mapped
     }
 }

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientStreamingTests.swift
@@ -2,9 +2,9 @@ import Foundation
 import Testing
 @testable import JarvisCore
 
-private func http(_ code: Int) -> HTTPURLResponse {
+private func http(_ code: Int, headers: [String: String]? = nil) -> HTTPURLResponse {
     HTTPURLResponse(url: URL(string: "https://api.openai.com/v1/responses")!,
-                    statusCode: code, httpVersion: nil, headerFields: nil)!
+                    statusCode: code, httpVersion: nil, headerFields: headers)!
 }
 
 /// Build an SSE line stream from scripted `data:` payloads (the wire `event:` lines are optional —
@@ -97,5 +97,25 @@ final class LineCollector: @unchecked Sendable {
                                             toolChoice: .auto, conversationId: nil, onLine: { _ in })
         #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
         #expect(attempts.value == 3) // two 429s + one 200
+    }
+
+    /// A 429 carrying a `Retry-After: 0` header on the streaming path is honoured: the client reads
+    /// the header, routes it through the shared helper, and retries — proving the Retry-After code
+    /// path is exercised without imposing any wall-clock delay (Retry-After: 0, backoffBase: 0).
+    @Test func streamingRetriesOn429WithRetryAfterHeader() async throws {
+        let attempts = Counter()
+        let completed = #"{"type":"response.completed","response":{"status":"completed","output":[{"type":"function_call","id":"f","call_id":"c","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}}"#
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+                                       maxRetries: 3, backoffBaseSeconds: 0,
+                                       lineSend: { _ in
+            let n = attempts.next()
+            return n < 2
+                ? (sseStream([]), http(429, headers: ["Retry-After": "0"]))
+                : (sseStream([completed]), http(200))
+        })
+        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools,
+                                            toolChoice: .auto, conversationId: nil, onLine: { _ in })
+        #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
+        #expect(attempts.value == 3) // two 429s (with Retry-After: 0) + one 200
     }
 }

--- a/Tests/JarvisCoreTests/Coach/SpeakLinesStreamParserTests.swift
+++ b/Tests/JarvisCoreTests/Coach/SpeakLinesStreamParserTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct SpeakLinesStreamParserTests {
+    /// Feed the whole arguments JSON at once → all lines come out in order.
+    @Test func emitsAllLinesFromSingleChunk() {
+        var p = SpeakLinesStreamParser()
+        let out = p.feed(#"{"lines":["one","two","three"]}"#)
+        #expect(out == ["one", "two", "three"])
+    }
+
+    /// A line is emitted only when its closing quote arrives — not before.
+    @Test func emitsEachLineWhenItCloses() {
+        var p = SpeakLinesStreamParser()
+        #expect(p.feed(#"{"lines":["par"#) == [])          // string still open
+        #expect(p.feed(#"tial","#) == ["partial"])          // closed by the quote+comma
+        #expect(p.feed(#""second"]}"#) == ["second"])
+    }
+
+    /// Chunk boundaries may fall anywhere, including mid-escape, and a line may contain quotes,
+    /// brackets, commas and backslashes (code) without being split.
+    @Test func handlesEscapesAndCodeAcrossArbitraryBoundaries() {
+        var p = SpeakLinesStreamParser()
+        var out: [String] = []
+        for ch in #"{"lines":["Use `Array.from({length: n+1}, () => [])`.","say \"hi\""]}"# {
+            out += p.feed(String(ch))   // one character at a time — worst-case boundaries
+        }
+        #expect(out == [#"Use `Array.from({length: n+1}, () => [])`."#, #"say "hi""#])
+    }
+
+    /// Escaped newline in a line is unescaped to a real newline.
+    @Test func unescapesControlSequences() {
+        var p = SpeakLinesStreamParser()
+        #expect(p.feed(#"{"lines":["a\nb"]}"#) == ["a\nb"])
+    }
+
+    /// An empty lines array yields nothing.
+    @Test func emptyArrayEmitsNothing() {
+        var p = SpeakLinesStreamParser()
+        #expect(p.feed(#"{"lines":[]}"#) == [])
+    }
+}

--- a/Tests/JarvisCoreTests/Coach/SpeakLinesStreamParserTests.swift
+++ b/Tests/JarvisCoreTests/Coach/SpeakLinesStreamParserTests.swift
@@ -39,4 +39,18 @@ import Testing
         var p = SpeakLinesStreamParser()
         #expect(p.feed(#"{"lines":[]}"#) == [])
     }
+
+    /// A BMP `\uXXXX` escape decodes to its character (not the literal `uXXXX`) -- the regression that
+    /// would otherwise garble any tip with an arrow, dash, or accented/non-English character.
+    @Test func decodesBMPUnicodeEscape() {
+        var p = SpeakLinesStreamParser()
+        #expect(p.feed(#"{"lines":["x\u2014y"]}"#) == ["x\u{2014}y"])   // \u2014 (raw) decodes to an em dash
+    }
+
+    /// A `\uXXXX` escape split across feed() chunks (mid-sequence boundary) still decodes correctly.
+    @Test func decodesUnicodeEscapeSplitAcrossChunks() {
+        var p = SpeakLinesStreamParser()
+        #expect(p.feed(#"{"lines":["a\u21"#) == [])        // mid-\u sequence: nothing emitted yet
+        #expect(p.feed(#"92b"]}"#) == ["a\u{2192}b"])      // completes → -> right arrow
+    }
 }

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -130,11 +130,37 @@ rather than a per-turn screenshot.
 
 ### Latency
 
-Target: **turn-end → first overlay line < 2s.** It holds because transcription is continuous
-(no STT latency at trigger time) and most turns are text-only (no `capture_screen`), so the brain
-call is a single short round-trip. The overlay then reveals the already-returned lines one at a
-time (paced by `Config`), so the first tip appears immediately — note the brain response itself is **not**
-streamed (one buffered request; the overlay just paces the display).
+Measured **turn-end → first overlay line** (this metric excludes the VAD/debounce window that
+*precedes* turn-end). Two paths, with very different costs:
+
+- **Text-only turn** (no screen): a single short `gpt-5.5` round-trip — **< 2s**, and snappier now
+  that the answer streams. Transcription is continuous, so there's no STT latency at trigger time.
+- **Screen question** (the model calls `capture_screen`): inherently **two sequential brain calls** —
+  decide-it-needs-the-screen, then answer-with-the-image — because screen capture is *model-decided*
+  (§4), not attached to every call. Left naive this ran ~10s end-to-end; three changes cut a screen
+  question to **≈ 2–3s (turn-end → first spoken word)**, ~3.5–4.5s including the talk-detection
+  window, *without* removing the round-trip or changing `speak`:
+  1. **Capture overlaps the first call** — `CoachDriver` pre-warms the screenshot when the turn fires,
+     concurrently with brain call #1, so it's already in hand the instant the model asks (and dropped,
+     never written to disk, if the model never asks).
+  2. **The answer streams to the overlay** — the brain call is read as an SSE stream (`stream:true`)
+     and each `speak` line renders the moment it finishes generating (incrementally parsed in
+     `SpeakLinesStreamParser`), so first words appear ~1–2s into the answer instead of after the whole
+     response. `speak` stays a tool call: the final `BrainResponse` is still decoded from the terminal
+     event (byte-identical to the non-streamed result), and the overlay's queue/pacing is unchanged
+     (each streamed line is just a queued one-line tip).
+  3. **A decisive capture decision** — the coach prompt tells the model to decide on the first turn
+     whether it needs the screen and call `capture_screen` immediately, rather than answer-from-memory-
+     then-look.
+
+  The remaining floor — two model passes plus the VAD/debounce "are-you-done-talking" window — is
+  structural and accepted. Going lower would mean relaxing a kept constraint (pre-attaching the screen,
+  or trimming the VAD floor), deferred until the latency demands it.
+- **Full-resolution screenshots are kept** (no downscaling): GPT-5.5 reads the shot at full `original`
+  resolution by default, and the vision docs *recommend* `original` for large/dense images, so
+  reliable code-reading outweighs the upload saving. The brain response is now streamed (the earlier
+  "not streamed" note no longer holds). Implementation: `CoachDriver.swift`, `OpenAIBrainClient.swift`,
+  `SpeakLinesStreamParser.swift`.
 
 ### Resilience
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -135,7 +135,7 @@ rather than a per-turn screenshot.
 
 ### Latency
 
-Measured **turn-end → first overlay line** (this metric excludes the VAD/debounce window that
+Target **turn-end → first overlay line** (this metric excludes the VAD/debounce window that
 *precedes* turn-end). Two paths, with very different costs:
 
 - **Text-only turn** (no screen): a single short `gpt-5.5` round-trip — **< 2s**, and snappier now
@@ -153,7 +153,8 @@ Measured **turn-end → first overlay line** (this metric excludes the VAD/debou
      and each `speak` line renders the moment it finishes generating (incrementally parsed in
      `SpeakLinesStreamParser`), so first words appear ~1–2s into the answer instead of after the whole
      response. `speak` stays a tool call: the final `BrainResponse` is still decoded from the terminal
-     event (byte-identical to the non-streamed result), and the overlay's queue/pacing is unchanged
+     event (semantically equivalent to the non-streamed result — same decode, via a JSON round-trip),
+     and the overlay's queue/pacing is unchanged
      (each streamed line is just a queued one-line tip).
   3. **A decisive capture decision** — the coach prompt tells the model to decide on the first turn
      whether it needs the screen and call `capture_screen` immediately, rather than answer-from-memory-

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -44,10 +44,12 @@ glue that wires them into a proactive coach. We write the least code possible an
 Always-on and cheap: audio streams continuously to the Realtime API, producing a rolling,
 speaker-labeled transcript. The transcript — not the screen — is the constant input signal.
 
-On demand and expensive: the screen is **only** captured when the model asks for it via the
-`capture_screen` tool, and a coaching response is **only** produced when the model calls `speak`.
-This is what keeps Jarvis cheap and fast — the costly vision and generation steps fire only at
-moments the model judges worthwhile.
+On demand and expensive: the screen image is **only sent to the model** (the costly vision step) when
+it asks via the `capture_screen` tool, and a coaching response is **only** produced when the model
+calls `speak`. This is what keeps Jarvis cheap and fast — the costly vision and generation steps fire
+only at moments the model judges worthwhile. (On a *spoke* turn the local screenshot is pre-warmed
+speculatively, in parallel with the first brain call, so it's ready instantly — see [Latency](#latency) —
+but it never leaves the machine unless the model asks; silence turns don't pre-warm.)
 
 ### The turn
 
@@ -104,8 +106,11 @@ to tool calls and enforces safety.
 - **Continuous (cheap):** audio → Realtime → transcript. This runs the whole session.
 - **Per-turn (cheap):** a text-only `gpt-5.5` call on each turn-end/silence event. No image unless
   the model asks.
-- **On-demand (expensive):** a screenshot + vision tokens, only when the model calls
-  `capture_screen`. A coaching response, only when the model calls `speak`.
+- **On-demand (expensive):** **vision tokens** (the screenshot sent to the model), only when the model
+  calls `capture_screen`. A coaching response, only when the model calls `speak`. (On a spoke turn the
+  local screenshot is pre-warmed speculatively so it's ready instantly — see [Latency](#latency) — but
+  the expensive part, sending it for vision, stays model-gated; the pre-warmed shot is dropped, never
+  written to disk, if the model doesn't ask.)
 
 The model is the cost governor: it spends vision tokens and screen real estate only when it
 judges them worthwhile. That is the whole point of making screen capture a model-invoked tool
@@ -140,9 +145,10 @@ Measured **turn-end → first overlay line** (this metric excludes the VAD/debou
   (§4), not attached to every call. Left naive this ran ~10s end-to-end; three changes cut a screen
   question to **≈ 2–3s (turn-end → first spoken word)**, ~3.5–4.5s including the talk-detection
   window, *without* removing the round-trip or changing `speak`:
-  1. **Capture overlaps the first call** — `CoachDriver` pre-warms the screenshot when the turn fires,
-     concurrently with brain call #1, so it's already in hand the instant the model asks (and dropped,
-     never written to disk, if the model never asks).
+  1. **Capture overlaps the first call** — on a spoke (`.turnEnd`) turn, `CoachDriver` pre-warms the
+     screenshot the moment the turn fires, concurrently with brain call #1, so it's already in hand the
+     instant the model asks (and dropped, never written to disk, if the model never asks). Silence turns
+     don't pre-warm — they're proactive, not latency-critical — and capture on demand if the model asks.
   2. **The answer streams to the overlay** — the brain call is read as an SSE stream (`stream:true`)
      and each `speak` line renders the moment it finishes generating (incrementally parsed in
      `SpeakLinesStreamParser`), so first words appear ~1–2s into the answer instead of after the whole

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -72,6 +72,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **Per-line overlay time is length-proportional, not hard-coded** — a hybrid of the captioning reading-speed standard and our glance-not-watch situation: `noticeBuffer + words × readingRate` (capped), plus a brief blank gap between lines borrowed from the captioning minimum-gap rule (2026-06-19) | [overlay-timing.md](./overlay-timing.md) |
 | **Brain model + reasoning effort are user-selectable in Settings** — a "Brain" tab picks the OpenAI model from a curated code-owned `BrainModelCatalog` (default `gpt-5.5`) and one global reasoning effort (None/Low/Medium/High, default `low`), persisted via `BrainPreferences` (UserDefaults); applied on next Start. Brain model/effort moved out of `Config` so the catalog/enum is the single source of truth (2026-06-20) | [settings-window.md](./settings-window.md) |
 | **Persistent response box beside the overlay** — an optional menu-toggled window (`ResponseLogPanel`) logging every `speak` tip in full, timestamped and scrollable; movable/resizable/opaque, **also excluded from capture** (shared `NSPanel.excludeFromScreenCapture`, re-asserted on render), cleared on each Start. Fed via a `BroadcastOverlay` fan-out so `CoachDriver` is unchanged; its text size + opacity are adjustable in the Overlay settings tab (2026-06-20) | [settings-window.md](./settings-window.md), [overlay-invisibility.md](./overlay-invisibility.md) |
+| **Cut screen-question latency (~10s → ~3–4s)** — kept the model-decided `capture_screen` round-trip and `speak`-as-tool, but overlap the screenshot with the first brain call, **stream** the answer to the overlay as it generates, and sharpen the capture decision in the prompt; full-resolution screenshots kept for GPT-5.5 vision reliability (2026-06-21) | [architecture.md §4 (Latency)](./architecture.md#latency) |
 
 ## Open Questions / To Confirm
 
@@ -100,7 +101,10 @@ The headless build is done. Remaining is the **human smoke run** — build, run,
    transcript; "I'm stuck on two-sum" → coaching overlay + observed `capture_screen`; overlay
    excluded from the screenshot; while you talk steadily Jarvis stays mostly quiet (model restraint,
    not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --dev`,
-   then open the activity viewer from the menu bar to watch each step.)
+   then open the activity viewer from the menu bar to watch each step.) Also confirm the **reduced
+   screen-question latency** — a "check my screen" question should show its first spoken line in
+   ~2–3s after you stop talking (streamed as it generates), not ~10s — see
+   [architecture.md §4 (Latency)](./architecture.md#latency).
 4. **Only remaining live unknown:** the bare-WebSocket connect for a transcription-only Realtime
    session. The connect contract (`?intent=transcription`, the `session.update` payload) lives in
    `RealtimeSession.swift`; if the live connect fails, that's the file to adjust (e.g. swap


### PR DESCRIPTION
## Problem

A spoken question that needs the screen ("I fixed it — anything I can improve?") took ~10s to answer. The cause is structural: a screen question makes **two sequential, fully-awaited `gpt-5.5` calls** because the screenshot arrives via a `capture_screen` tool-call round-trip (the model decides it needs the screen, *then* a second call answers with the image), and nothing was streamed — so the overlay showed nothing until the second call fully completed. On top of that sits a ~1.4s VAD/debounce "are-you-done-talking" floor.

## Approach

Three constraints were kept deliberately: **`speak` stays a tool call**, **no screenshot is attached unless the model asks for it**, and **the model decides when it needs the screen**. So the decide-then-look round-trip stays; this PR cuts latency *inside* it:

1. **Capture overlaps the first brain call** (`CoachDriver`) — the screenshot is pre-warmed the moment a turn fires, concurrently with call #1, so it's already in hand when the model asks. Speculative: it's held in memory only and dropped (never written to disk) if the model never asks.
2. **The answer streams to the overlay** (`OpenAIBrainClient` + `SpeakLinesStreamParser`) — the brain call is read as an SSE stream (`stream:true`) and each `speak` line renders the instant it finishes generating, so first words appear ~1–2s into the answer instead of after the whole response. `speak` stays a tool call; the final `BrainResponse` is still decoded from the terminal event (byte-identical to the non-streamed result), and the overlay's queue/pacing is unchanged.
3. **A decisive capture decision** — the coach system prompt now tells the model to decide on the first turn whether it needs the screen and call `capture_screen` immediately, rather than answer-from-memory-then-look.

**Screenshot resolution is intentionally left at full `original`** — GPT-5.5 reads the shot at full resolution by default and the vision docs recommend `original` for dense images, so reliable code-reading outweighs the upload saving. (An earlier "lossless downscale" idea was dropped after verifying GPT-5.5's vision behavior against the official docs — it was based on the older GPT-4o rules and would have *reduced* what the model sees.)

## Outcome

- **Screen question:** ~10s → **~3.5–4.5s to first spoken word** (≈2–3s measured turn-end → first line; the rest is the kept VAD/debounce window).
- **Text-only question:** snappier, now streamed.

The remaining floor (two model passes + the VAD/debounce window) is structural and accepted; going lower would mean relaxing a kept constraint. See `wiki/architecture.md` §4 (Latency).

## Tests

**185/185 passing** across 29 suites (`./scripts/run-tests.sh`). New coverage: the incremental `SpeakLinesStreamParser` (chunk-boundary/escape/code cases), streaming `respond` over scripted SSE (line delivery + final-response equivalence + `incompleteReason`), streaming 429 retry incl. `Retry-After`, the parallel-capture overlap probe, and the live-vs-leftover overlay render (no double-render, no dropped line).

Built test-first via subagent-driven development with per-task review + a whole-branch review; the streaming retry path was made to honor `Retry-After` (shared with the non-streaming path) as a review fix.

## Still to verify live

`JarvisApp` isn't unit-tested. The latency win should be confirmed in the live smoke run — a "check my screen" question should stream its first line in ~2–3s after you stop talking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)