### PR TITLE
Tighten the coach prompt into an ordered decision list

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -192,12 +192,12 @@ public final class CoachDriver: @unchecked Sendable {
         if let priorClose {
             convo.append(.init(role: .tool, text: "shown to the user", toolCallId: priorClose))
         }
-        convo.append(.user("""
-            New since last turn (timestamped):
-            \(newSpeech.isEmpty ? "(nothing new)" : newSpeech)
-
-            \(ctx.promptLine)
-            """))
+        // Lead with the trigger line; prepend new speech only when there is any (a manual hint often
+        // has none, and an empty "New since last turn" block just buries the real signal).
+        let userText = newSpeech.isEmpty
+            ? ctx.promptLine
+            : "New since last turn:\n\(newSpeech)\n\n\(ctx.promptLine)"
+        convo.append(.user(userText))
 
         // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and
         // inject it into THIS first request — no waiting for the model to call capture_screen.

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -11,7 +11,7 @@ public let captureScreenTool = ToolDef(
 
 public let speakTool = ToolDef(
     name: "speak",
-    description: "Say a short coaching tip to the user via the on-screen overlay. `lines` is the tip split into short standalone lines, shown one at a time — at most 3, one idea per line; keep any code snippet on a single line. Only call this when you have something genuinely useful to add; otherwise do not call any tool (stay silent).",
+    description: "Say a short coaching tip to the user via the on-screen overlay. `lines` is the tip split into short standalone lines, shown one at a time — at most 3, one idea per line, each line short (aim under ~12 words); keep any code snippet on a single line. Only call this when you have something genuinely useful to add; otherwise do not call any tool (stay silent).",
     parametersJSON: #"{"type":"object","properties":{"lines":{"type":"array","items":{"type":"string"}}},"required":["lines"],"additionalProperties":false}"#
 )
 
@@ -22,51 +22,40 @@ public let coachSystemPrompt = """
 You are Jarvis, a calm, sharp LeetCode coach sitting beside the user while they solve a problem.
 
 The transcript is labeled by speaker. Lines marked "me:" are the user you coach, thinking aloud
-("the user" everywhere below means "me" — never "them").
-Lines marked "them:" are the other person in the room or on the call — an interviewer or caller,
-picked up from system audio. Coach ONLY "me", but DO read "them:" lines as context: an interviewer's
-question or clarification is the very problem "me" is working on, so fold it into your hints to "me".
-What you must not do is talk back to "them", or treat their words as "me" thinking aloud. And only an
-address from "me" triggers the must-reply rule below — never reply just because "them" asked
-something; keep coaching "me" toward the answer at your normal restraint.
+("the user" below always means "me"). Lines marked "them:" are the other person in the room or on the
+call — an interviewer or caller, picked up from system audio. You coach ONLY "me". Read "them:" lines
+as context — an interviewer's question or clarification is the very problem "me" is working on, so fold
+it into your hints — but never talk back to "them", never treat their words as "me" thinking aloud, and
+never let a "them:" line trigger a reply. Only "me" can trigger the must-reply rule below.
 
-You cannot see the screen unless you call capture_screen — do that when you need to read the problem
-or their code to be specific and correct.
+You cannot see the screen unless you call capture_screen — do that when you need to read the problem or
+their code to be specific and correct.
 
-You are given timing context with every turn: a timestamped transcript, why this turn fired (the user
-just spoke, or has been silent for a while), and how long the session has been running. Use it.
+Each turn you get timing context: a transcript (each line stamped [mm:ss]), why the turn fired (the
+user spoke, a silence, or a manual hint), and how long the session has run. Use it: early in a session
+the problem may not be on screen yet, so capture before assuming they're stuck; the longer the silence,
+the more likely they are stuck rather than thinking.
 
-WHEN "ME" ADDRESSES YOU DIRECTLY (says your name "Jarvis", asks you a question, or tells you to
-do something), you MUST reply — call the speak tool with a brief, helpful answer. Never ignore a
-direct address; even a simple greeting deserves a short spoken reply. This overrides the
-stay-quiet-by-default behavior below.
+Decide what to do each turn, in this order:
+1. Did "me" address you (says "Jarvis", asks you something, tells you to do something) or ask you to
+   look at the screen ("check my screen", "look at this", "can you see my code")? You MUST reply — call
+   speak. If they asked you to look, call capture_screen first, then answer from what you see. Even a
+   simple greeting deserves a short spoken reply. This overrides the stay-quiet default below.
+2. Is "me" making steady progress or thinking productively? Stay silent — call no tool.
+3. Can't tell, or the turn fired on a silence? Prefer capture_screen to read their current problem and
+   code, then decide: nudge only if they actually seem stuck; if the screen shows progress, leave them
+   alone.
+4. Stuck — and already nudged once? Escalate to a more concrete next step rather than restating the
+   same hint. Never dump the full solution unless they are truly stuck and ask for it.
 
-OTHERWISE, when the user is just thinking aloud, be a restrained, proactive coach. Nudge them toward
-the solution with short, encouraging, specific hints. Never dump the full solution unless they are
-truly stuck and ask for it. Prefer a pointed question or the next small step (e.g. "What's the time
-complexity of that nested loop?"). If they are making good progress, stay silent — call no tool.
-Don't repeat a hint they have already heard; if they are still stuck after an earlier nudge, escalate
-to a more concrete next step rather than restating the same one.
+When you do nudge, keep it short, encouraging, and specific — a pointed question or the next small step
+("What's the time complexity of that nested loop?"), not the whole answer.
 
-IF "ME" ASKS YOU TO LOOK AT OR CHECK THE SCREEN (e.g. "can you check my screen?", "look at this",
-"can you see my code?"), call capture_screen right away — even without your name — then answer based on
-what you see. A "them:" line is never this request.
-
-WHEN THE USER HAS BEEN SILENT FOR A WHILE, you usually cannot tell whether they are stuck or thinking
-productively without seeing what they are doing — so prefer to call capture_screen to read their
-current problem and code before deciding whether a nudge would help. A long silence often means they
-are stuck; but if the screen shows steady progress, stay silent and leave them alone.
-
-KEEP IT EASY TO READ. The user is often under interview pressure, where reading and processing text
-is hard. Write the way you would speak to a stressed friend:
-- Use plain, everyday words. Avoid jargon, abbreviations, and academic phrasing. If a simpler word
-  works, use it (say "loop inside a loop" before "nested iteration", "runs slower as the list grows"
-  before "quadratic time complexity").
-- One idea per line. Keep each line short — aim for under ~12 words.
-- Be concrete and direct. Point at the next small action, not an abstract concept
-  (e.g. "Try a hash map to remember what you've seen" beats "Consider an auxiliary data structure").
+KEEP IT EASY TO READ. The user is often under interview pressure, where reading is hard. Write the way
+you would speak to a stressed friend:
+- Use plain, everyday words. Avoid jargon and abbreviations (say "loop inside a loop" before "nested
+  iteration", "runs slower as the list grows" before "quadratic time complexity").
+- Be concrete and direct — point at the next small action ("Try a hash map to remember what you've
+  seen"), not an abstract concept ("Consider an auxiliary data structure").
 - Lead with the most useful thing first, in case they only read one line.
-
-When you do speak, call the speak tool with at most 3 short lines — one idea per line, since each line
-is shown on the overlay on its own. Keep any code snippet within a single line.
 """

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -24,7 +24,7 @@ public struct TriggerContext: Sendable {
         let elapsed = Int(sessionElapsedSeconds)
         switch reason {
         case .turnEnd:
-            return "Trigger: a turn just ended — check the transcript labels for who spoke (\"me\" or \"them\"). The session has been running for \(elapsed)s."
+            return "Trigger: a turn just ended. The session has been running for \(elapsed)s."
         case .silence(let secs):
             return "Trigger: the user has been silent for \(Int(secs))s. The session has been running for \(elapsed)s."
         case .manualHint:

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+/// How the per-turn user message is assembled (CoachDriver.runTurn): new speech is wrapped in a
+/// "New since last turn:" block ONLY when there is any, and the turn always ends with the trigger
+/// line. A turn with no new speech (a silence wake-up, or a manual hint with nothing said since)
+/// must lead with the trigger line alone — no empty wrapper, no "(nothing new)" filler.
+@Suite struct CoachDriverContextMessageTests {
+    private func makeDriver(brain: BrainClient, clock: Clock) -> (CoachDriver, RollingTranscript) {
+        let transcript = RollingTranscript()
+        let driver = CoachDriver(
+            config: .default, transcript: transcript,
+            brain: brain, screen: FakeScreen(), overlay: FakeOverlay(), clock: clock
+        )
+        return (driver, transcript)
+    }
+
+    /// The first user-role message the brain saw on the latest call.
+    private func lastUserMessage(_ brain: ScriptedBrain) -> String? {
+        brain.calls.last?.first { $0.role == .user }?.text
+    }
+
+    /// New speech is wrapped in the "New since last turn:" block, the trigger line follows it, and the
+    /// stale "(timestamped)" header is gone (lines already carry their own [mm:ss] stamps).
+    @Test func newSpeechIsWrappedAndFollowedByTheTriggerLine() async {
+        let brain = ScriptedBrain(script: [.init(toolCalls: [])])   // stay silent → one call
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "brute force two-sum", at: 0))
+
+        await driver.handleTrigger(.turnEnd)
+
+        let msg = lastUserMessage(brain)
+        #expect(msg?.hasPrefix("New since last turn:\n") == true)
+        #expect(msg?.contains("brute force two-sum") == true)
+        #expect(msg?.contains("a turn just ended") == true)   // trigger line rides along
+        #expect(msg?.contains("(timestamped)") == false)      // dropped header
+    }
+
+    /// No new speech (a silence wake-up with nothing said): the message is the bare trigger line —
+    /// no "New since last turn" wrapper and no "(nothing new)" filler burying the real signal.
+    @Test func emptySpeechSendsOnlyTheTriggerLine() async {
+        let brain = ScriptedBrain(script: [.init(toolCalls: [])])
+        let (driver, _) = makeDriver(brain: brain, clock: ManualClock(now: 0))   // empty transcript
+
+        await driver.handleTrigger(.silence(secondsQuiet: 30))
+
+        let expected = TriggerContext(reason: .silence(secondsQuiet: 30),
+                                      secondsSinceLastSpeech: 0, sessionElapsedSeconds: 0).promptLine
+        let msg = lastUserMessage(brain)
+        #expect(msg == expected)
+        #expect(msg?.contains("New since last turn") == false)
+        #expect(msg?.contains("nothing new") == false)
+    }
+}

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -4,7 +4,7 @@ import Testing
 @Suite struct TriggerContextTests {
     @Test func turnEndPromptLineIsSpeakerNeutralAndDescribesSessionElapsed() {
         let ctx = TriggerContext(reason: .turnEnd, secondsSinceLastSpeech: 0, sessionElapsedSeconds: 95)
-        #expect(ctx.promptLine == "Trigger: a turn just ended — check the transcript labels for who spoke (\"me\" or \"them\"). The session has been running for 95s.")
+        #expect(ctx.promptLine == "Trigger: a turn just ended. The session has been running for 95s.")
     }
 
     @Test func silencePromptLineDescribesQuietDurationAndSessionElapsed() {


### PR DESCRIPTION
Cleans up the coach system prompt and per-turn context based on a prompt-engineering pass — no behavior the model relies on is removed.

## Changes

**System prompt (`ToolDefs.swift`)**
- Replace the four scattered `WHEN…`/`IF…` blocks with one ordered, top-down decision procedure (direct-address/look-at-screen → steady progress → can't-tell/silence → escalation), so rule precedence is explicit instead of implied. The me/them distinction is stated once up front.
- Give the timing context teeth: instead of a bare "Use it.", spell out the heuristic (early session → problem may not be on screen yet, capture before assuming stuck; longer silence → more likely stuck).
- Consolidate the line-format contract (≤3 lines / one idea per line / short lines / code on one line) into the `speak` tool description; the prompt keeps only voice/tone guidance. Removes the triple-stated format rules.

**Per-turn context (`Trigger.swift`, `CoachDriver.swift`)**
- Trim the now-redundant `— check the transcript labels for who spoke ("me" or "them")` clause from the turn-end trigger.
- Drop `(timestamped)` from the per-turn header — lines are self-evidently `[mm:ss]`-stamped and the system prompt says so.
- When a turn has no new speech (common on a manual hint), lead with the trigger line instead of an empty `New since last turn: (nothing new)` block.

## Testing
- Updated the turn-end assertion in `TriggerContextTests`.
- `./scripts/run-tests.sh` — all 182 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)