### PR TITLE
Make the activity log a default in all modes, not just dev mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ and keep anything OS-bound thin and on the outside.**
 | `JarvisCore` | library | All the logic. **Foundation-only** — no AppKit / AVFoundation / ScreenCaptureKit / WebKit. Runs and is unit-tested on any machine. |
 | `JarvisOverlay` | library | The AppKit overlay (`NSPanel`, capture-invisibility). Its own target *so its behavior can be unit-tested* (`JarvisOverlayTests`) without dragging UIKit into Core. |
 | `CJarvisAEC` | C target | The acoustic-echo-cancellation edge: a pure-C facade over WebRTC AEC3. The C++ impl is prebuilt + statically merged (abseil included, zero runtime dylibs) into `lib/libjarvis-aec.a` by `scripts/build-aec.sh`, so `swift build` only links the archive — no C++ toolchain or vendored headers. Regenerate the `.a` only when bumping the webrtc version. |
-| `JarvisApp` | executable | The thin macOS shell: menu bar, capture, permissions, the dev viewer window. Wires Core + Overlay + AEC to the OS. Verified by a live run. |
+| `JarvisApp` | executable | The thin macOS shell: menu bar, capture, permissions, the activity viewer window. Wires Core + Overlay + AEC to the OS. Verified by a live run. |
 
 > **Put logic in `JarvisCore`.** If something can be written without an OS framework, it goes in Core
 > where a test can reach it. Reach outward to `JarvisOverlay` / `JarvisApp` only when you genuinely
@@ -30,8 +30,7 @@ and keep anything OS-bound thin and on the outside.**
 | Compile | `swift build` | Builds all targets. |
 | Test | `./scripts/run-tests.sh` | **Always use this, not raw `swift test`** — it fixes the swift-testing search path on CLT-only machines. Runs all three test targets. |
 | Build the app | `./scripts/build-app.sh [release\|debug]` | Bundles + signs `Jarvis.app` with the stable `Jarvis Dev` identity (so TCC grants persist). |
-| Run it | `./scripts/build-app.sh --run` | Build, then launch. Launch via `open`, never the bare binary. |
-| Dev mode | `./scripts/build-app.sh --dev` | Same as `--run`, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis`. The activity log is always on regardless. |
+| Run it | `./scripts/build-app.sh --run` | Build, then launch. Launch via `open`, never the bare binary. Per-session logs land in the workspace `.jarvis/`. |
 
 ## Layout
 
@@ -104,10 +103,10 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
   owner-only `0600` file (`OPENAI_API_KEY` env var is a headless fallback only); see
   [`wiki/sandbox.md`](./wiki/sandbox.md) for why not the Keychain.
 - **The only screen-/audio-derived data persisted to disk is the activity log** (the spoken tips,
-  the transcribed "heard:" lines, and the screenshots the model looked at). It is written in **all**
-  modes to an **owner-only** (`0600` files in a `0700` dir) per-session directory — `~/Caches/Jarvis`
-  by default, or the workspace `.jarvis/` under `--dev` — fresh each session, never `/tmp`. The raw
-  mic audio and the live transcript are **never** archived. Keep the owner-only, no-`/tmp` posture.
+  the transcribed "heard:" lines, and the screenshots the model looked at). It is written every run to
+  an **owner-only** (`0600` files in a `0700` dir) per-session directory in the gitignored, workspace-
+  local `.jarvis/`, pruned to the most recent few sessions, never `/tmp`. The raw mic audio and the
+  live transcript are **never** archived. Keep the owner-only, no-`/tmp`, workspace-local posture.
 - Full security posture: [`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ and keep anything OS-bound thin and on the outside.**
 | Test | `./scripts/run-tests.sh` | **Always use this, not raw `swift test`** — it fixes the swift-testing search path on CLT-only machines. Runs all three test targets. |
 | Build the app | `./scripts/build-app.sh [release\|debug]` | Bundles + signs `Jarvis.app` with the stable `Jarvis Dev` identity (so TCC grants persist). |
 | Run it | `./scripts/build-app.sh --run` | Build, then launch. Launch via `open`, never the bare binary. |
-| Dev mode | `./scripts/build-app.sh --dev` | Launch with the in-app activity viewer available from the menu bar. |
+| Dev mode | `./scripts/build-app.sh --dev` | Same as `--run`, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis`. The activity log is always on regardless. |
 
 ## Layout
 
@@ -49,13 +49,13 @@ into one module, so moving a file between subfolders never changes access contro
 | `Sources/JarvisCore/Screen/` | Screen-capture tool contract |
 | `Sources/JarvisCore/Overlay/` | Overlay text model (the rendered tip; not the window) |
 | `Sources/JarvisCore/Config/` | Config + secrets (owner-only file) |
-| `Sources/JarvisCore/Diagnostics/` | Logging, the dev-mode activity log, session-history store |
+| `Sources/JarvisCore/Diagnostics/` | Logging, the activity log, session-history store |
 | `Sources/JarvisCore/Support/` | Small primitives (`Clock`, `TurnTaskBox`) |
 | `Sources/JarvisOverlay/` | The on-screen `NSPanel` overlay (single file — no subfolders) |
 | `Sources/JarvisApp/App/` | Entry point, `AppDelegate` |
 | `Sources/JarvisApp/MenuBar/` | Menu-bar item, Start/Stop, key entry |
 | `Sources/JarvisApp/Capture/` | Mic + system-audio capture, realtime transcriber, TCC priming |
-| `Sources/JarvisApp/Viewer/` | Dev-mode `WKWebView` activity-viewer window |
+| `Sources/JarvisApp/Viewer/` | The `WKWebView` activity-viewer window |
 | `Tests/JarvisCoreTests/` | Mirrors the Core subfolders; `TestFixtures.swift` stays at the root |
 | `Tests/JarvisOverlayTests/` | Overlay screen-capture-invisibility checks |
 | `Tests/JarvisViewerTests/` | WebKit end-to-end tests of the viewer's shipped HTML/JS |
@@ -103,8 +103,11 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
 - **No secrets in code, ever** — not in source, tests, or examples. The API key lives in an
   owner-only `0600` file (`OPENAI_API_KEY` env var is a headless fallback only); see
   [`wiki/sandbox.md`](./wiki/sandbox.md) for why not the Keychain.
-- **Nothing screen- or audio-derived is written to disk** outside dev mode. Dev-mode logs and
-  screenshots go to a gitignored, owner-only `.jarvis/<session>/`. Never relax that.
+- **The only screen-/audio-derived data persisted to disk is the activity log** (the spoken tips,
+  the transcribed "heard:" lines, and the screenshots the model looked at). It is written in **all**
+  modes to an **owner-only** (`0600` files in a `0700` dir) per-session directory — `~/Caches/Jarvis`
+  by default, or the workspace `.jarvis/` under `--dev` — fresh each session, never `/tmp`. The raw
+  mic audio and the live transcript are **never** archived. Keep the owner-only, no-`/tmp` posture.
 - Full security posture: [`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Workflow

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Full design: [`wiki/architecture.md`](./wiki/architecture.md).
 │       ├── App/                   # main.swift, AppDelegate
 │       ├── MenuBar/               # menu-bar item, Start/Stop, key entry
 │       ├── Capture/               # mic + system-audio capture, realtime transcriber, TCC priming
-│       └── Viewer/                # dev-mode WKWebView activity viewer
+│       └── Viewer/                # WKWebView activity viewer
 ├── Tests/
 │   ├── JarvisCoreTests/      # unit + offline-pipeline tests (mirrors the Core subsystems)
 │   ├── JarvisOverlayTests/   # overlay + response-box behavior & screen-capture-invisibility checks
@@ -97,7 +97,7 @@ by a live run. Folders are grouped **by subsystem**, following
 |---|---|
 | `./scripts/run-tests.sh` | Build and run the unit + offline-pipeline tests (no key, no permissions needed). |
 | `./scripts/build-app.sh [release\|debug]` | Build, bundle, and sign `Jarvis.app` (defaults to `release`). Creates the stable `Jarvis Dev` signing identity automatically on first run. |
-| `./scripts/build-app.sh --dev` | Same build, then launch in **dev mode** (open the activity viewer on demand from the menu bar). |
+| `./scripts/build-app.sh --dev` | Same build + launch, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis`. |
 | `./scripts/build-app.sh --run` | Same build, then launch the app normally. |
 
 ## Develop locally
@@ -137,16 +137,12 @@ Then:
 Permissions persist across rebuilds automatically (the app always signs with a stable identity); the
 mechanics are in [`wiki/build-and-run.md`](./wiki/build-and-run.md).
 
-## Dev mode — live activity viewer
+## The live activity viewer
 
-```bash
-./scripts/build-app.sh --dev   # rebuild, launch with --dev
-```
-
-In dev mode Jarvis opens an **in-app live viewer** (a `WKWebView` it pushes events into) so you can
-**watch it think** without tailing a log. It doesn't pop open on launch — choose **Open Log Viewer**
-from the menu bar when you want it (each launch is its own session; you can also browse past sessions
-or clear the history). New events stream in live — no reload — and are color-coded:
+Jarvis has an **in-app live viewer** (a `WKWebView` it pushes events into) so you can **watch it
+think** without tailing a log. Open it from **Settings → Activity** (each launch is its own session;
+you can also browse past sessions or clear the history). New events stream in live — no reload — and
+are color-coded:
 
 - 🗣 `heard: "…"` — what you said (transcribed) / 🤫 `quiet for 30s` — why it woke
 - 💭 `thinking…` — calling the brain
@@ -155,10 +151,11 @@ or clear the history). New events stream in live — no reload — and are color
 - 💬 `…the tip it spoke…` — a `speak` call rendered to the overlay
 - `… staying silent` — when the model declines to speak
 
-**Privacy posture.** File logging is dev-only — outside dev mode nothing is written to disk (just the
-unified Console log). In dev mode the logs (and the screenshot thumbnails) go to a gitignored,
-owner-only `.jarvis/<session>/` in the workspace — one fresh subdirectory per launch. The posture and
-build/run mechanics are in [`wiki/build-and-run.md`](./wiki/build-and-run.md)
+**Privacy posture.** The activity log (the viewer's `jarvis-activity.jsonl` + the screenshot
+thumbnails + `jarvis-debug.log`) is written on **every** launch to a gitignored, owner-only
+per-session directory — `~/Caches/Jarvis/<session>/` by default, or the workspace `.jarvis/<session>/`
+with `--dev` (`./scripts/build-app.sh --dev`). The raw mic audio and the live transcript are never
+archived. The posture and build/run mechanics are in [`wiki/build-and-run.md`](./wiki/build-and-run.md)
 and [`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Live smoke checklist

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Full design: [`wiki/architecture.md`](./wiki/architecture.md).
 
 The split is deliberate: **`JarvisCore`** holds all the logic (Foundation-only) and is unit-tested on
 any machine; **`JarvisOverlay`** is the AppKit overlay, split into its own target so its behavior is
-testable; **`JarvisApp`** is the thin macOS glue (menu bar, capture, permissions, dev viewer) verified
+testable; **`JarvisApp`** is the thin macOS glue (menu bar, capture, permissions, activity viewer) verified
 by a live run. Folders are grouped **by subsystem**, following
 [`wiki/architecture.md`](./wiki/architecture.md). Working rules live in [`CLAUDE.md`](./CLAUDE.md).
 
@@ -161,7 +161,7 @@ and [`wiki/sandbox.md`](./wiki/sandbox.md).
 ## Live smoke checklist
 
 Some behavior can only be verified by a human with a real key, a mic, and granted permissions. Run
-via `./scripts/build-app.sh --dev`, then open the activity viewer from the menu bar; it shows each
+via `./scripts/build-app.sh --dev`, then open **Settings → Activity**; it shows each
 step as it happens.
 
 - Confirm the transcription session connects end-to-end — watch for `transcription session ready`

--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ by a live run. Folders are grouped **by subsystem**, following
 |---|---|
 | `./scripts/run-tests.sh` | Build and run the unit + offline-pipeline tests (no key, no permissions needed). |
 | `./scripts/build-app.sh [release\|debug]` | Build, bundle, and sign `Jarvis.app` (defaults to `release`). Creates the stable `Jarvis Dev` signing identity automatically on first run. |
-| `./scripts/build-app.sh --dev` | Same build + launch, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis`. |
-| `./scripts/build-app.sh --run` | Same build, then launch the app normally. |
+| `./scripts/build-app.sh --run` | Same build, then launch the app. Per-session logs land in the workspace `.jarvis/`. |
 
 ## Develop locally
 
@@ -153,15 +152,14 @@ are color-coded:
 
 **Privacy posture.** The activity log (the viewer's `jarvis-activity.jsonl` + the screenshot
 thumbnails + `jarvis-debug.log`) is written on **every** launch to a gitignored, owner-only
-per-session directory — `~/Caches/Jarvis/<session>/` by default, or the workspace `.jarvis/<session>/`
-with `--dev` (`./scripts/build-app.sh --dev`). The raw mic audio and the live transcript are never
-archived. The posture and build/run mechanics are in [`wiki/build-and-run.md`](./wiki/build-and-run.md)
-and [`wiki/sandbox.md`](./wiki/sandbox.md).
+per-session directory in the workspace `.jarvis/<session>/`, pruned to the most recent few sessions.
+The raw mic audio and the live transcript are never archived. The posture and build/run mechanics are
+in [`wiki/build-and-run.md`](./wiki/build-and-run.md) and [`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Live smoke checklist
 
 Some behavior can only be verified by a human with a real key, a mic, and granted permissions. Run
-via `./scripts/build-app.sh --dev`, then open **Settings → Activity**; it shows each
+via `./scripts/build-app.sh --run`, then open **Settings → Activity**; it shows each
 step as it happens.
 
 - Confirm the transcription session connects end-to-end — watch for `transcription session ready`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,12 @@ whether to speak (restraint lives in the prompt); the manual Start/Stop is the o
 Tips flash one line at a time in the **Overlay Caption**; the optional **Overlay Box** keeps the
 full, timestamped history. Each is switched on/off in the Settings → Overlay tab (caption off, box
 on by default). Both are hidden from screen capture.
-Full design: [`wiki/architecture.md`](./wiki/architecture.md).
+
+Nothing leaves the machine beyond the API calls; on disk, only an owner-only per-session **activity
+log** (the spoken tips, transcribed lines, and screenshots the model saw) is kept — pruned to the
+recent few and browsable live in **Settings → Activity**. The raw mic audio and live transcript are
+never archived. Full design: [`wiki/architecture.md`](./wiki/architecture.md); privacy posture:
+[`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Project structure
 
@@ -135,26 +140,6 @@ Then:
 
 Permissions persist across rebuilds automatically (the app always signs with a stable identity); the
 mechanics are in [`wiki/build-and-run.md`](./wiki/build-and-run.md).
-
-## The live activity viewer
-
-Jarvis has an **in-app live viewer** (a `WKWebView` it pushes events into) so you can **watch it
-think** without tailing a log. Open it from **Settings → Activity** (each launch is its own session;
-you can also browse past sessions or clear the history). New events stream in live — no reload — and
-are color-coded:
-
-- 🗣 `heard: "…"` — what you said (transcribed) / 🤫 `quiet for 30s` — why it woke
-- 💭 `thinking…` — calling the brain
-- 👁 `looking at your screen` — the model invoked `capture_screen`; the captured frame appears as a
-  thumbnail you can click to open full size
-- 💬 `…the tip it spoke…` — a `speak` call rendered to the overlay
-- `… staying silent` — when the model declines to speak
-
-**Privacy posture.** The activity log (the viewer's `jarvis-activity.jsonl` + the screenshot
-thumbnails + `jarvis-debug.log`) is written on **every** launch to a gitignored, owner-only
-per-session directory in the workspace `.jarvis/<session>/`, pruned to the most recent few sessions.
-The raw mic audio and the live transcript are never archived. The posture and build/run mechanics are
-in [`wiki/build-and-run.md`](./wiki/build-and-run.md) and [`wiki/sandbox.md`](./wiki/sandbox.md).
 
 ## Live smoke checklist
 

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -258,15 +258,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return "\(f.string(from: Date()))_\(suffix)"
     }
 
-    /// Where session logs go: a gitignored, workspace-local `.jarvis/`. `build-app.sh --run` passes its
-    /// absolute path via `--log-dir` (the app is launched by `open` from an arbitrary cwd, so it can't
-    /// find the repo itself); absent that, fall back to `.jarvis/` under the current directory. Each
-    /// Start nests a per-session subdirectory under this base (see `beginNewSession`).
+    /// Where session logs go. `build-app.sh --run` passes a `--log-dir` pointing at the repo's
+    /// gitignored, workspace-local `.jarvis/` (the app is launched by `open` from an arbitrary cwd, so
+    /// it can't find the repo itself). When the bundle is opened directly with no `--log-dir`, fall back
+    /// to a per-user app-data dir alongside the API key — `~/Library/Application Support/Jarvis/sessions/`
+    /// — which is always writable and owner-only. Each Start nests a per-session subdir under this base
+    /// (see `beginNewSession`).
     private func logDirectory() -> URL {
         let args = CommandLine.arguments
         if let i = args.firstIndex(of: "--log-dir"), i + 1 < args.count {
             return URL(fileURLWithPath: args[i + 1])
         }
-        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(".jarvis")
+        return secretFile.fileURL.deletingLastPathComponent().appendingPathComponent("sessions")
     }
 }

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -258,16 +258,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return "\(f.string(from: Date()))_\(suffix)"
     }
 
-    /// Where session logs go: `--log-dir <path>` (`build-app.sh --dev` passes the workspace `.jarvis/`),
-    /// else a per-user Caches/Jarvis directory. Never `/tmp` (world-readable, shared across users).
-    /// Each Start nests a per-session subdirectory under this base (see `beginNewSession`).
+    /// Where session logs go: a gitignored, workspace-local `.jarvis/`. `build-app.sh --run` passes its
+    /// absolute path via `--log-dir` (the app is launched by `open` from an arbitrary cwd, so it can't
+    /// find the repo itself); absent that, fall back to `.jarvis/` under the current directory. Each
+    /// Start nests a per-session subdirectory under this base (see `beginNewSession`).
     private func logDirectory() -> URL {
         let args = CommandLine.arguments
         if let i = args.firstIndex(of: "--log-dir"), i + 1 < args.count {
             return URL(fileURLWithPath: args[i + 1])
         }
-        let caches = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-            ?? URL(fileURLWithPath: NSTemporaryDirectory())
-        return caches.appendingPathComponent("Jarvis")
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(".jarvis")
     }
 }

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -16,7 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindow: SettingsWindow!
     private let appearance = OverlayAppearance()
     private let brainPreferences = BrainPreferences()
-    private var activityViewer: ActivityViewer?    // embedded as the Settings Activity tab
+    private var activityViewer: ActivityViewer!    // embedded as the Settings Activity tab
     /// Two transcription sockets feeding one shared transcript: mic → `.me`, system audio → `.them`.
     private var transcriber: RealtimeTranscriber?       // "me" (mic)
     private var themTranscriber: RealtimeTranscriber?   // "them" (system audio)
@@ -34,6 +34,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// cleared in `stop()` — so the hotkey beeps when there's no session. Captures the Sendable driver
     /// + turn box (not `@MainActor` self), like the transcriber callbacks do.
     private var requestManualHint: (() -> Void)?
+
+    /// How many past session log directories to keep on disk; older ones are pruned at each Start so the
+    /// always-on activity log stays bounded. Clear all but the current via the viewer's "Clear history".
+    private static let retainedSessions = 10
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
@@ -63,7 +67,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Unified Settings window: API key + overlay appearance + the activity log. A pasted key is
         // stored but does not auto-start; restart only if already running, reflecting the real
         // outcome back into the menu state.
-        var sections: [SettingsSection] = [
+        let sections: [SettingsSection] = [
             APIKeySection(store: secretFile, onKeySaved: { [weak self] _ in
                 guard let self, self.transcriber != nil else { return }
                 // Re-saving a key while running only re-applies it to the pipeline — it is NOT a new
@@ -73,10 +77,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }),
             OverlaySection(appearance: appearance, caption: overlayCaption, box: overlayBox),
             BrainModelSection(preferences: brainPreferences),
+            ActivitySection(viewer: activityViewer),
         ]
-        if let viewer = activityViewer {
-            sections.append(ActivitySection(viewer: viewer))
-        }
         settingsWindow = SettingsWindow(sections: sections)
         menuBar.onOpenSettings = { [weak self] in self?.settingsWindow.show() }
 
@@ -234,9 +236,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                  attributes: [.posixPermissions: 0o700])
         JarvisLog.enableFileLogging(directory: dir)     // <dir>/jarvis-debug.log, 0600, fresh
         ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.jsonl, 0600, fresh
+        // Now that logging is always on, sessions accumulate every launch. Bound it: keep only the most
+        // recent few (the just-created one is current, so it's always spared).
+        SessionStore(base: logDirectory(), current: dir).pruneToMostRecent(Self.retainedSessions)
         // Point the viewer's history browser at the new current session and show it live; clear-history
         // spares whichever session is current.
-        activityViewer?.sessionDidChange(base: logDirectory(), current: dir)
+        activityViewer.sessionDidChange(base: logDirectory(), current: dir)
         jlog("Jarvis: session \(dir.lastPathComponent) (\(dir.path)).")
     }
 

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -35,8 +35,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// + turn box (not `@MainActor` self), like the transcriber callbacks do.
     private var requestManualHint: (() -> Void)?
 
-    /// How many past session log directories to keep on disk; older ones are pruned at each Start so the
-    /// always-on activity log stays bounded. Clear all but the current via the viewer's "Clear history".
+    /// How many past session log *directories* to keep on disk; older ones are pruned at each Start so
+    /// the always-on activity log stays bounded across launches. This caps session count, not the size
+    /// of any one session — a very long single run still grows its (append-only) logs + screenshots.
+    /// Clear all but the current via the viewer's "Clear history".
     private static let retainedSessions = 10
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -228,20 +230,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// `jarvis-debug.log` and `jarvis-activity.jsonl`. Called on every Start so each coaching run keeps
     /// its own logs instead of resuming the previous run's.
     private func beginNewSession() {
-        let dir = logDirectory().appendingPathComponent(newSessionID())
+        let base = logDirectory()
+        let dir = base.appendingPathComponent(newSessionID())
         // 0700: the screenshots/logs inside are 0600, so the directory holding them must be owner-only
         // too — otherwise a 0755 dir leaks file names/counts/timestamps to other local users (CWE-732).
         // Applies to the created session dir and any intermediates.
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true,
                                                  attributes: [.posixPermissions: 0o700])
+        // createDirectory only sets the mode on dirs it *creates*; a pre-existing base (e.g. a 0755
+        // Application Support/Jarvis left by another tool) keeps its mode, which would leak session-dir
+        // names. Tighten it best-effort, mirroring FileSecretStore.setApiKey.
+        try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: base.path)
         JarvisLog.enableFileLogging(directory: dir)     // <dir>/jarvis-debug.log, 0600, fresh
         ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.jsonl, 0600, fresh
         // Now that logging is always on, sessions accumulate every launch. Bound it: keep only the most
         // recent few (the just-created one is current, so it's always spared).
-        SessionStore(base: logDirectory(), current: dir).pruneToMostRecent(Self.retainedSessions)
+        SessionStore(base: base, current: dir).pruneToMostRecent(Self.retainedSessions)
         // Point the viewer's history browser at the new current session and show it live; clear-history
         // spares whichever session is current.
-        activityViewer.sessionDidChange(base: logDirectory(), current: dir)
+        activityViewer.sessionDidChange(base: base, current: dir)
         jlog("Jarvis: session \(dir.lastPathComponent) (\(dir.path)).")
     }
 

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -16,7 +16,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var settingsWindow: SettingsWindow!
     private let appearance = OverlayAppearance()
     private let brainPreferences = BrainPreferences()
-    private var activityViewer: ActivityViewer?    // dev mode only; embedded as the Settings Activity tab
+    private var activityViewer: ActivityViewer?    // embedded as the Settings Activity tab
     /// Two transcription sockets feeding one shared transcript: mic → `.me`, system audio → `.them`.
     private var transcriber: RealtimeTranscriber?       // "me" (mic)
     private var themTranscriber: RealtimeTranscriber?   // "them" (system audio)
@@ -35,21 +35,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// + turn box (not `@MainActor` self), like the transcriber callbacks do.
     private var requestManualHint: (() -> Void)?
 
-    /// Dev mode (`open ./Jarvis.app --args --dev`): enables owner-only file logging for the session.
-    /// The activity log is available on demand from the Activity tab in Settings (dev mode only).
-    private let devMode = CommandLine.arguments.contains("--dev")
-
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
         MainMenu.install() // an Edit menu so ⌘X/⌘C/⌘V/⌘A work in the Settings text fields
 
-        if devMode {
-            // The activity viewer lives for the whole dev run, but a *session* is one coaching run:
-            // each Start opens a fresh session dir + logs (see `beginNewSession`). No session exists
-            // until the first Start, so the viewer starts with no current session to browse.
-            activityViewer = ActivityViewer(log: .shared,
-                                            store: SessionStore(base: devLogDirectory(), current: nil))
-        }
+        // The activity viewer lives for the whole app run, but a *session* is one coaching run: each
+        // Start opens a fresh session dir + logs (see `beginNewSession`). No session exists until the
+        // first Start, so the viewer starts with no current session to browse.
+        activityViewer = ActivityViewer(log: .shared,
+                                        store: SessionStore(base: logDirectory(), current: nil))
 
         // Ask for Microphone + Screen Recording up front, not lazily mid-session.
         Permissions.primeAll()
@@ -66,9 +60,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         menuBar = MenuBarController()
 
-        // Unified Settings window: API key + overlay appearance always; the dev activity log only
-        // in dev mode. A pasted key is stored but does not auto-start; restart only if already
-        // running, reflecting the real outcome back into the menu state.
+        // Unified Settings window: API key + overlay appearance + the activity log. A pasted key is
+        // stored but does not auto-start; restart only if already running, reflecting the real
+        // outcome back into the menu state.
         var sections: [SettingsSection] = [
             APIKeySection(store: secretFile, onKeySaved: { [weak self] _ in
                 guard let self, self.transcriber != nil else { return }
@@ -108,7 +102,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Build the brain + driver and start the transcription pipeline. Returns `false` (and stays
     /// stopped) if no API key is available yet.
     ///
-    /// `freshSession` is true for a user-initiated Start (rotate to a fresh dev session + logs) and
+    /// `freshSession` is true for a user-initiated Start (rotate to a fresh session + logs) and
     /// false for an in-place restart that only re-applies a setting — e.g. saving a new API key while
     /// running — which must NOT be misattributed as a new coaching run.
     @discardableResult
@@ -120,7 +114,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         stop() // tear down any existing pipeline so we start cleanly
         if freshSession {
-            beginNewSession()       // dev mode: rotate to a fresh session dir + activity/debug log
+            beginNewSession()       // rotate to a fresh session dir + activity/debug log
             menuBar.resetCounter()  // a user Start begins a fresh session
             overlayBox.clear()      // …and a fresh response history for the new conversation
         }
@@ -228,12 +222,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         alert.runModal()
     }
 
-    /// Open a fresh dev session: a new per-Start subdirectory under the base log dir, with its own
+    /// Open a fresh session: a new per-Start subdirectory under the base log dir, with its own
     /// `jarvis-debug.log` and `jarvis-activity.jsonl`. Called on every Start so each coaching run keeps
-    /// its own logs instead of resuming the previous run's. No-op outside dev mode.
+    /// its own logs instead of resuming the previous run's.
     private func beginNewSession() {
-        guard devMode else { return }
-        let dir = devLogDirectory().appendingPathComponent(newSessionID())
+        let dir = logDirectory().appendingPathComponent(newSessionID())
         // 0700: the screenshots/logs inside are 0600, so the directory holding them must be owner-only
         // too — otherwise a 0755 dir leaks file names/counts/timestamps to other local users (CWE-732).
         // Applies to the created session dir and any intermediates.
@@ -243,11 +236,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ActivityLog.shared.enable(directory: dir)        // <dir>/jarvis-activity.jsonl, 0600, fresh
         // Point the viewer's history browser at the new current session and show it live; clear-history
         // spares whichever session is current.
-        activityViewer?.sessionDidChange(base: devLogDirectory(), current: dir)
-        jlog("Jarvis: dev mode — session \(dir.lastPathComponent) (\(dir.path)).")
+        activityViewer?.sessionDidChange(base: logDirectory(), current: dir)
+        jlog("Jarvis: session \(dir.lastPathComponent) (\(dir.path)).")
     }
 
-    /// A unique id for a dev session (one per Start), used as its log subdirectory name. Sortable
+    /// A unique id for a session (one per Start), used as its log subdirectory name. Sortable
     /// timestamp + a short random suffix so two Starts in the same second don't collide.
     private func newSessionID() -> String {
         let f = DateFormatter()
@@ -260,10 +253,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         return "\(f.string(from: Date()))_\(suffix)"
     }
 
-    /// Where dev-mode logs go: `--log-dir <path>` (run-dev.sh passes the workspace `.jarvis/`),
+    /// Where session logs go: `--log-dir <path>` (`build-app.sh --dev` passes the workspace `.jarvis/`),
     /// else a per-user Caches/Jarvis directory. Never `/tmp` (world-readable, shared across users).
     /// Each Start nests a per-session subdirectory under this base (see `beginNewSession`).
-    private func devLogDirectory() -> URL {
+    private func logDirectory() -> URL {
         let args = CommandLine.arguments
         if let i = args.firstIndex(of: "--log-dir"), i + 1 < args.count {
             return URL(fileURLWithPath: args[i + 1])

--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -2,7 +2,7 @@ import AppKit
 
 /// Menu-bar status item: start/stop, a "Settings…" item, and a session interjection counter.
 /// Two states, shown as the robot emoji icon: desaturated (black-and-white) when stopped, full
-/// colour when running. All settings (API key, overlay appearance, the dev activity log) live in
+/// colour when running. All settings (API key, overlay appearance, the activity log) live in
 /// the unified Settings window, opened via `onOpenSettings`.
 @MainActor
 final class MenuBarController: NSObject {

--- a/Sources/JarvisApp/Settings/ActivitySection.swift
+++ b/Sources/JarvisApp/Settings/ActivitySection.swift
@@ -1,8 +1,8 @@
 import AppKit
 import JarvisCore
 
-/// Dev-mode-only settings panel that embeds the live activity viewer. Thin wrapper: the viewer owns
-/// all WKWebView/session/live-append logic; this just vends its content view into a tab and tears it
+/// Settings panel that embeds the live activity viewer. Thin wrapper: the viewer owns all
+/// WKWebView/session/live-append logic; this just vends its content view into a tab and tears it
 /// down on close.
 @MainActor
 final class ActivitySection: NSObject, SettingsSection {

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -2,7 +2,7 @@ import AppKit
 import WebKit
 import JarvisCore
 
-/// The dev-mode activity viewer view: an in-app `WKWebView` that live-appends log rows pushed from
+/// The activity viewer view: an in-app `WKWebView` that live-appends log rows pushed from
 /// `ActivityLog` (no reload), shows screenshots in an in-page lightbox, and lets you browse and clear
 /// past sessions via `SessionStore`. Thin by design — the rendering logic and its tests live in
 /// JarvisCore (`htmlShell`/`rowScript`) and `JarvisViewerTests`. See wiki/build-and-run.md.
@@ -54,7 +54,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         let pop = NSPopUpButton(frame: NSRect(x: 76, y: 8, width: 280, height: 26))
         pop.target = self
         pop.action = #selector(sessionChanged)
-        pop.toolTip = "Switch between this and previous dev sessions"
+        pop.toolTip = "Switch between this and previous sessions"
         pop.autoresizingMask = [.maxXMargin]
         header.addSubview(pop)
         self.picker = pop

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -268,7 +268,7 @@ public final class CoachDriver: @unchecked Sendable {
                 // emitting: otherwise this screenshot — and the reasoning that follows — would be
                 // logged into whatever session is now current (a Start rotates the dev log mid-turn).
                 if Task.isCancelled { jlog("… turn cancelled (stopped) after capture"); return .cancelled }
-                if let img { jlog("👁 looking at your screen", image: img) }   // thumbnail in the dev viewer
+                if let img { jlog("👁 looking at your screen", image: img) }   // thumbnail in the activity viewer
                 else { jlog("👁 screenshot failed") }
                 if convId == nil {
                     // Stateless fallback: replay the model's call + the tool result + image.

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -266,7 +266,7 @@ public final class CoachDriver: @unchecked Sendable {
                 let img = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
                 // Stop may have fired during the (un-cancellable, detached) capture. Bail before
                 // emitting: otherwise this screenshot — and the reasoning that follows — would be
-                // logged into whatever session is now current (a Start rotates the dev log mid-turn).
+                // logged into whatever session is now current (a Start rotates the log mid-turn).
                 if Task.isCancelled { jlog("… turn cancelled (stopped) after capture"); return .cancelled }
                 if let img { jlog("👁 looking at your screen", image: img) }   // thumbnail in the activity viewer
                 else { jlog("👁 screenshot failed") }
@@ -297,7 +297,7 @@ public final class CoachDriver: @unchecked Sendable {
 
             case .speak(let callId, let lines):
                 // Last gate before side effects: a turn cancelled by Stop (or a Stop→Start that
-                // rotated the dev session) must not render a stale tip, bump the counter, or log into
+                // rotated the session) must not render a stale tip, bump the counter, or log into
                 // the new session. This is the "speak after Stop" guard the TurnTaskBox relies on.
                 if Task.isCancelled { jlog("… turn cancelled (stopped) before speaking"); return .cancelled }
                 jlog("💬 \(lines.joined(separator: " "))")

--- a/Sources/JarvisCore/Config/Secrets.swift
+++ b/Sources/JarvisCore/Config/Secrets.swift
@@ -53,7 +53,7 @@ public struct FileSecretStore: SecretStore {
         let fm = FileManager.default
         let dir = fileURL.deletingLastPathComponent()
         // 0700 dir: a 0755 parent would leak the credential file's name/metadata to other local users
-        // (CWE-732). Mirrors how the dev-mode log directory is created.
+        // (CWE-732). Mirrors how the per-session log directory is created.
         do {
             try fm.createDirectory(at: dir, withIntermediateDirectories: true,
                                    attributes: [.posixPermissions: 0o700])

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// The model behind the dev-mode activity viewer. Mirrors `jlog` lines into an in-app `WKWebView`
-/// window (see `ActivityViewer` in JarvisApp) by **pushing** each line to a registered observer, and
-/// persists the session to disk so past sessions can be browsed later. **Dev-mode only:** until
-/// `enable(directory:)` is called, `record(_:)` is a no-op and nothing is written.
+/// The model behind the activity viewer. Mirrors `jlog` lines into an in-app `WKWebView` window
+/// (see `ActivityViewer` in JarvisApp) by **pushing** each line to a registered observer, and
+/// persists the session to disk so past sessions can be browsed later. Until `enable(directory:)`
+/// is called (on each Start), `record(_:)` is a no-op and nothing is written.
 ///
 /// This type is UI-free (Foundation only): it generates the page HTML and the per-row JS as plain
 /// strings; the WebView lives in JarvisApp. See wiki/build-and-run.md.
@@ -57,7 +57,7 @@ public final class ActivityLog: @unchecked Sendable {
         df.dateFormat = "HH:mm:ss"
     }
 
-    /// Turn on the viewer for a dev session. `directory` is this session's dir; an empty
+    /// Turn on the viewer for a session. `directory` is this session's dir; an empty
     /// `jarvis-activity.jsonl` is created at 0600 immediately so the session is discoverable by
     /// `SessionStore.listSessions()` even before its first `record()`.
     public func enable(directory: URL) {

--- a/Sources/JarvisCore/Diagnostics/Log.swift
+++ b/Sources/JarvisCore/Diagnostics/Log.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-/// Dev-only file logging config. By default `jlog` writes ONLY to the unified log (Console.app);
-/// no flat file is created. In dev mode the app calls `JarvisLog.enableFileLogging(directory:)`,
+/// Per-session file logging config. By default `jlog` writes ONLY to the unified log (Console.app);
+/// no flat file is created. On each Start the app calls `JarvisLog.enableFileLogging(directory:)`,
 /// after which `jlog` also appends to `<directory>/jarvis-debug.log` (created `0600`, truncated
-/// fresh for the session). This keeps screen-derived coaching text out of any world-readable or
-/// persistent file outside dev mode — see wiki/sandbox.md ("no recording to disk").
+/// fresh for the session). The file is always owner-only and never lands in a world-readable path —
+/// see wiki/sandbox.md ("activity log persistence").
 public enum JarvisLog {
     private static let lock = NSLock()
     nonisolated(unsafe) private static var directory: URL?   // guarded by `lock`
@@ -27,13 +27,13 @@ public enum JarvisLog {
     }
 }
 
-/// Lightweight logger: always writes to the unified log (Console) and mirrors into the dev activity
-/// viewer; additionally appends to the dev debug file when file logging is enabled.
-/// `image`, when set, is a base64-encoded JPEG screenshot to show as a thumbnail in the dev activity
+/// Lightweight logger: always writes to the unified log (Console) and mirrors into the activity
+/// viewer; additionally appends to the session debug file when file logging is enabled.
+/// `image`, when set, is a base64-encoded JPEG screenshot to show as a thumbnail in the activity
 /// viewer (the file log and unified log stay text-only).
 public func jlog(_ message: String, image base64JPEG: String? = nil) {
     NSLog("%@", message)
-    ActivityLog.shared.record(message, imageBase64: base64JPEG)  // dev-only HTML viewer (no-op when disabled)
+    ActivityLog.shared.record(message, imageBase64: base64JPEG)  // HTML activity viewer (no-op until enabled)
 
     guard let url = JarvisLog.debugLogURL else { return }
     let line = "\(logTimestamp()) \(message)\n"

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Reads, lists, and deletes past dev-session directories so the activity viewer can browse history.
+/// Reads, lists, prunes, and deletes past session directories so the activity viewer can browse history.
 /// Foundation-only and stateless beyond its two URLs. All operations are bounded to immediate
 /// subdirectories of `base` whose name matches the session-id shape, so a stray `--log-dir` or a
 /// malformed persisted filename can't make it touch anything outside the log tree. See
@@ -95,6 +95,26 @@ public struct SessionStore: Sendable {
         let curPath = current?.standardizedFileURL.path
         let names = (try? FileManager.default.contentsOfDirectory(atPath: base.path)) ?? []
         for name in names where Self.isSessionID(name) {
+            let url = base.appendingPathComponent(name)
+            if url.standardizedFileURL.path == curPath { continue }                 // spare current
+            let vals = try? url.resourceValues(forKeys: [.isSymbolicLinkKey])
+            if vals?.isSymbolicLink == true { continue }                            // don't follow symlinks
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Keep only the `keep` newest session directories, deleting the rest — so the always-on activity
+    /// log can't grow without bound across launches. Counts EVERY session-shaped subdir (including
+    /// content-less aborted runs that `listSessions` hides), spares the current session, and skips
+    /// symlinks; bounded to immediate children of `base` exactly like `clearHistory`. A non-positive
+    /// `keep` is treated as 1 so a run never deletes the session it's about to write into.
+    public func pruneToMostRecent(_ keep: Int) {
+        let keep = max(1, keep)
+        let curPath = current?.standardizedFileURL.path
+        let names = ((try? FileManager.default.contentsOfDirectory(atPath: base.path)) ?? [])
+            .filter { Self.isSessionID($0) }
+            .sorted(by: >)   // id is a lexically-sortable timestamp ⇒ newest first
+        for name in names.dropFirst(keep) {
             let url = base.appendingPathComponent(name)
             if url.standardizedFileURL.path == curPath { continue }                 // spare current
             let vals = try? url.resourceValues(forKeys: [.isSymbolicLinkKey])

--- a/Sources/JarvisOverlay/OverlayBoxPanel.swift
+++ b/Sources/JarvisOverlay/OverlayBoxPanel.swift
@@ -163,7 +163,7 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     // MARK: - Visibility (driven by the Settings toggle)
 
     /// Wipe the log. Called on each fresh Start so the box shows only the current conversation,
-    /// matching how the dev session rotates.
+    /// matching how the session rotates.
     public func clear() {
         entries.removeAll()
         guard !isPreviewing else { return }   // the preview owns the display; restored on close

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -33,7 +33,7 @@ import Foundation
         let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
         // A past session with only lifecycle breadcrumbs (no coaching class, no shot) — an aborted run.
         try makeSession(base, "2026-06-16_09-00-00_aaaa", lines: [
-            "{\"t\":\"09:00:00\",\"m\":\"Jarvis: dev mode — session …\"}",
+            "{\"t\":\"09:00:00\",\"m\":\"Jarvis: session …\"}",
             "{\"t\":\"09:00:01\",\"m\":\"Jarvis: coaching started (mic + system audio).\"}",
             "{\"t\":\"09:00:02\",\"m\":\"Jarvis: stopped.\"}",
         ])
@@ -91,5 +91,36 @@ import Foundation
         #expect(!FileManager.default.fileExists(atPath: base.appendingPathComponent("2026-06-16_10-00-00_aaaa").path))
         #expect(FileManager.default.fileExists(atPath: cur.path))      // current spared
         #expect(FileManager.default.fileExists(atPath: base.path))     // base spared
+    }
+
+    @Test func pruneKeepsNewestNDeletesOlderAndSparesCurrent() throws {
+        let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        let exists = { (id: String) in
+            FileManager.default.fileExists(atPath: base.appendingPathComponent(id).path)
+        }
+        // Five sessions, oldest→newest. Include a content-less one (it still counts toward the cap, even
+        // though listSessions would hide it) and a non-session dir that must be left untouched.
+        let ids = (0..<5).map { "2026-06-16_1\($0)-00-00_aaaa" }
+        for id in ids { try makeSession(base, id, lines: ["{\"t\":\"1\",\"m\":\"🗣 heard\"}"]) }
+        try makeSession(base, "2026-06-16_09-00-00_zzzz", lines: [])   // content-less, oldest
+        try FileManager.default.createDirectory(at: base.appendingPathComponent("keepme"),
+                                                withIntermediateDirectories: true)
+        // Current is the oldest *real* session: must be spared even though it falls outside the newest-3.
+        let cur = base.appendingPathComponent(ids[0])
+        SessionStore(base: base, current: cur).pruneToMostRecent(3)
+
+        #expect(exists(ids[4]) && exists(ids[3]) && exists(ids[2]))   // newest 3 kept
+        #expect(!exists(ids[1]))                                       // older pruned
+        #expect(!exists("2026-06-16_09-00-00_zzzz"))                   // content-less also pruned
+        #expect(exists(ids[0]))                                        // current spared despite being old
+        #expect(exists("keepme"))                                      // non-session dir untouched
+    }
+
+    @Test func pruneTreatsNonPositiveKeepAsOneSoCurrentSurvives() throws {
+        let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
+        try makeSession(base, "2026-06-16_10-00-00_aaaa", lines: ["{\"t\":\"1\",\"m\":\"x\"}"])
+        let cur = base.appendingPathComponent("2026-06-16_10-00-00_aaaa")
+        SessionStore(base: base, current: cur).pruneToMostRecent(0)
+        #expect(FileManager.default.fileExists(atPath: cur.path))   // never deletes the session being written
     }
 }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -9,18 +9,16 @@
 # Usage:
 #   ./scripts/build-app.sh                build + sign (release)
 #   ./scripts/build-app.sh debug          build + sign (debug)
-#   ./scripts/build-app.sh --run          ...then launch it
-#   ./scripts/build-app.sh --dev          ...then launch with logs in the workspace .jarvis/ (instead of ~/Caches/Jarvis)
+#   ./scripts/build-app.sh --run          ...then launch it (per-session logs in the workspace .jarvis/)
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 CONFIG="release"
-LAUNCH=""            # "" | run | dev
+LAUNCH=""            # "" | run
 for arg in "$@"; do
   case "$arg" in
     release|debug) CONFIG="$arg" ;;
     --run)         LAUNCH="run" ;;
-    --dev)         LAUNCH="dev" ;;
     *) echo "unknown argument: $arg" >&2; exit 2 ;;
   esac
 done
@@ -89,15 +87,10 @@ launch() {
 case "$LAUNCH" in
   run)
     launch
-    echo "▶ launching Jarvis"
-    open ./"$APP"
-    ;;
-  dev)
-    launch
-    # Route per-session logs into a gitignored, workspace-local .jarvis/ so they're easy to tail from
-    # the repo — instead of the default ~/Caches/Jarvis. Either way the activity log is always on; this
-    # only changes where it's written. chmod 700 so the session-dir names (timestamps) aren't readable
-    # by other local users — the app then makes each <session>/ 0700 with 0600 files inside (CWE-732).
+    # Per-session logs go to a gitignored, workspace-local .jarvis/ (passed via --log-dir so the app,
+    # launched from anywhere by `open`, writes back into the repo). chmod 700 the base so session-dir
+    # names (timestamps) aren't readable by other local users — the app then makes each <session>/
+    # 0700 with 0600 files inside (CWE-732).
     LOGDIR="$PWD/.jarvis"
     mkdir -p "$LOGDIR"
     chmod 700 "$LOGDIR"
@@ -105,6 +98,6 @@ case "$LAUNCH" in
     open ./"$APP" --args --log-dir "$LOGDIR"
     ;;
   "")
-    echo "   run: open ./$APP        (or: ./scripts/build-app.sh --run  /  --dev)"
+    echo "   run: open ./$APP        (or: ./scripts/build-app.sh --run)"
     ;;
 esac

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -94,11 +94,13 @@ case "$LAUNCH" in
     ;;
   dev)
     launch
-    # Route per-session logs into a gitignored, workspace-local .jarvis/ (owner-only 0600, fresh each
-    # session) so they're easy to tail from the repo — instead of the default ~/Caches/Jarvis. Either
-    # way the activity log is always on; this only changes where it's written.
+    # Route per-session logs into a gitignored, workspace-local .jarvis/ so they're easy to tail from
+    # the repo — instead of the default ~/Caches/Jarvis. Either way the activity log is always on; this
+    # only changes where it's written. chmod 700 so the session-dir names (timestamps) aren't readable
+    # by other local users — the app then makes each <session>/ 0700 with 0600 files inside (CWE-732).
     LOGDIR="$PWD/.jarvis"
     mkdir -p "$LOGDIR"
+    chmod 700 "$LOGDIR"
     echo "▶ launching Jarvis — open Settings → Activity to watch the log; per-session logs in $LOGDIR/<session>"
     open ./"$APP" --args --log-dir "$LOGDIR"
     ;;

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -10,7 +10,7 @@
 #   ./scripts/build-app.sh                build + sign (release)
 #   ./scripts/build-app.sh debug          build + sign (debug)
 #   ./scripts/build-app.sh --run          ...then launch it
-#   ./scripts/build-app.sh --dev          ...then launch in dev mode (open the log viewer from the menu bar)
+#   ./scripts/build-app.sh --dev          ...then launch with logs in the workspace .jarvis/ (instead of ~/Caches/Jarvis)
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -94,12 +94,13 @@ case "$LAUNCH" in
     ;;
   dev)
     launch
-    # Logs go to a gitignored .jarvis/ (owner-only 0600, fresh each session) so the model's
-    # screen-derived tips never land in world-readable /tmp or in git.
+    # Route per-session logs into a gitignored, workspace-local .jarvis/ (owner-only 0600, fresh each
+    # session) so they're easy to tail from the repo — instead of the default ~/Caches/Jarvis. Either
+    # way the activity log is always on; this only changes where it's written.
     LOGDIR="$PWD/.jarvis"
     mkdir -p "$LOGDIR"
-    echo "▶ launching Jarvis (dev mode) — pick “Open Log Viewer” from the menu bar; per-session logs in $LOGDIR/<session>"
-    open ./"$APP" --args --dev --log-dir "$LOGDIR"
+    echo "▶ launching Jarvis — open Settings → Activity to watch the log; per-session logs in $LOGDIR/<session>"
+    open ./"$APP" --args --log-dir "$LOGDIR"
     ;;
   "")
     echo "   run: open ./$APP        (or: ./scripts/build-app.sh --run  /  --dev)"

--- a/wiki/CLAUDE.md
+++ b/wiki/CLAUDE.md
@@ -38,7 +38,7 @@ wiki/
 ├── index.md                 # navigation / single source of truth
 ├── status.md                # current phase, key-decisions log, next action (read first)
 ├── architecture.md          # vision, harness loop, components, models/APIs, resilience, safety
-├── build-and-run.md         # operational: toolchain, signing/TCC, running, dev-mode viewer
+├── build-and-run.md         # operational: toolchain, signing/TCC, running, the activity viewer
 ├── sandbox.md               # security / isolation model
 ├── overlay-invisibility.md  # hiding the overlay from screen capture (`sharingType = .none`)
 ├── landscape-survey.md      # tools tried & evaluated

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -185,9 +185,11 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 - **Built and run in the main `forrest` account inside a git worktree** (recoverability). The
   separate-restricted-account requirement is waived for the personal build; see [sandbox.md](./sandbox.md).
 - **Egress is narrow and explicit:** audio to `gpt-4o-transcribe`; a screenshot + transcript window
-  to `gpt-5.5` *only when the model triggers a capture/response*. Nothing is recorded to **local**
-  disk in the MVP; the per-session OpenAI conversation does retain transcript + screenshots
-  server-side (see [sandbox.md](./sandbox.md)).
+  to `gpt-5.5` *only when the model triggers a capture/response*. The only screen-/audio-derived data
+  written to **local** disk is the owner-only, bounded per-session **activity log** (spoken tips,
+  transcribed lines, the screenshots the model saw); raw mic audio and the live transcript are never
+  archived. The per-session OpenAI conversation does retain transcript + screenshots server-side (see
+  [sandbox.md](./sandbox.md)).
 - **Behavioral restraint (model-governed):** there is **no cooldown or rate cap** in code. Every
   utterance reaches the brain, and the brain decides whether it has anything worth saying — that
   restraint lives in the system prompt ("stay silent unless genuinely useful"). This keeps

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -93,9 +93,9 @@ proactive path, by contrast, must first let the model decide to call `capture_sc
 over the returned image on a second trip — the latency this hotkey exists to skip.) It reuses the
 live session's brain, conversation, and transcript, so the hint has full context, and it routes
 through the same single-in-flight turn box as audio triggers (a press coalesces, never stacks). It is
-inert — a beep — when no session is running, since there is no live conversation to hint from. In dev
-mode the trigger and its pre-filled message are recorded to the [activity viewer](./build-and-run.md),
-so you can see exactly what the shortcut sent to the brain.
+inert — a beep — when no session is running, since there is no live conversation to hint from. The
+trigger and its pre-filled message are recorded to the [activity viewer](./build-and-run.md), so you
+can see exactly what the shortcut sent to the brain.
 
 The hotkey is registered with **Carbon `RegisterEventHotKey`**, the one global-shortcut API Apple
 never modernized, which needs no Accessibility/TCC permission. We deliberately did **not** take the
@@ -217,5 +217,5 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 6. **Self-verifying.** Every build ships with tests and a smoke checklist the agent can run to prove it works.
 7. **One mode, done well.** Ship the coach; expand later.
 
-How Jarvis is built, signed, tested, and run — and the dev-mode activity viewer — is its own
+How Jarvis is built, signed, tested, and run — and the activity viewer — is its own
 operational page: [build-and-run.md](./build-and-run.md).

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -48,8 +48,7 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
 |---|---|
 | `./scripts/run-tests.sh` | Build + run the unit/offline-pipeline tests (no key, no permissions). |
 | `./scripts/build-app.sh [release\|debug]` | Build, bundle, sign `Jarvis.app` (default `release`). Creates `Jarvis Dev` on first run. |
-| `./scripts/build-app.sh --run` | Same build, then launch normally. |
-| `./scripts/build-app.sh --dev` | Same build + launch, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis` (see below). |
+| `./scripts/build-app.sh --run` | Same build, then launch. Per-session logs land in the workspace `.jarvis/` (see below). |
 
 - **Always launch with `open ./Jarvis.app`**, never the bare binary — running it from a shell makes
   TCC attribute the grant to the *terminal*, so the app reports Microphone/Screen Recording as
@@ -70,11 +69,12 @@ runtime). It also sidesteps the `file://` `fetch()` restriction that forced the 
 - New events stream in live (no reload, no flicker); thumbnails open in an in-page lightbox.
 - Each Start opens a fresh session (a Stop→Start gets a new log, never resuming the previous run),
   persisted as owner-only `jarvis-activity.jsonl` + `shot-N.jpg`, so past runs can be browsed and the
-  history cleared from the viewer.
-- **The viewer and its file logging are always on** (they used to be `--dev`-gated). On every launch
-  `jlog` writes to the unified log (Console.app) *and* the per-session files; `--dev` only changes
-  *where* — the workspace `.jarvis/<session>/` instead of `~/Caches/Jarvis/<session>/`. The files are
-  `0600` in a `0700` per-session dir either way — the full privacy posture is in [sandbox.md](./sandbox.md).
+  history cleared from the viewer. Old sessions are pruned to the most recent few at each Start.
+- **The viewer and its file logging are always on** (they used to be `--dev`-gated; that flag is gone).
+  On every launch `jlog` writes to the unified log (Console.app) *and* the per-session files in the
+  gitignored, workspace-local `.jarvis/<session>/` (`0600` files in a `0700` dir). `build-app.sh --run`
+  passes that path via `--log-dir`, since the `open`-launched app can't find the repo itself. The full
+  privacy posture is in [sandbox.md](./sandbox.md).
 - The viewer's rendering logic (`htmlShell`/`rowScript`) and history reader (`SessionStore`) live in
   `JarvisCore` so they're unit/WebKit-tested; `ActivityViewer` in `JarvisApp` is the thin window.
 
@@ -82,4 +82,4 @@ runtime). It also sidesteps the `file://` `fetch()` restriction that forced the 
 
 Some behavior can only be verified by a human with a real key, a mic, and granted permissions — see
 the checklist in the [README](../README.md#live-smoke-checklist). Run via `./scripts/build-app.sh
---dev` and watch each step in the activity viewer (Settings → Activity).
+--run` and watch each step in the activity viewer (Settings → Activity).

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -1,6 +1,6 @@
-# Build, Run & Dev Mode
+# Build, Run & the Activity Viewer
 
-> How Jarvis is built, signed, tested, and run on macOS, plus the dev-mode activity viewer. This is
+> How Jarvis is built, signed, tested, and run on macOS, plus the activity viewer. This is
 > the operational *how*; the design *why* lives in [architecture.md](./architecture.md), the security
 > posture in [sandbox.md](./sandbox.md). Anything here that's a plain value or wiring lives in code —
 > this page captures the non-obvious mechanics and the decisions behind them.
@@ -49,7 +49,7 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
 | `./scripts/run-tests.sh` | Build + run the unit/offline-pipeline tests (no key, no permissions). |
 | `./scripts/build-app.sh [release\|debug]` | Build, bundle, sign `Jarvis.app` (default `release`). Creates `Jarvis Dev` on first run. |
 | `./scripts/build-app.sh --run` | Same build, then launch normally. |
-| `./scripts/build-app.sh --dev` | Same build, then launch in dev mode (see below). |
+| `./scripts/build-app.sh --dev` | Same build + launch, but routes per-session logs to the workspace `.jarvis/` instead of `~/Caches/Jarvis` (see below). |
 
 - **Always launch with `open ./Jarvis.app`**, never the bare binary — running it from a shell makes
   TCC attribute the grant to the *terminal*, so the app reports Microphone/Screen Recording as
@@ -58,22 +58,23 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
   saved to an owner-only file; `OPENAI_API_KEY` is a headless fallback), then **Start / Stop** from the
   menu. The icon shows two states only: ⚪️ stopped, 🟢 running.
 
-## Dev mode — the live activity viewer
+## The live activity viewer
 
-`--dev` enables an **in-app `WKWebView`** window into which Swift *pushes* each `jlog` line (and
-`capture_screen` thumbnails as in-memory `data:` URIs). Chosen over a local HTTP server + SSE: for an
-app that already holds the entries in memory, pushing into an embedded WebView is less code, has zero
-network surface, and is the most testable (the production runtime *is* the test runtime). It also
-sidesteps the `file://` `fetch()` restriction that forced the original viewer's `<meta refresh>`
-reload.
+Settings → **Activity** opens an **in-app `WKWebView`** window into which Swift *pushes* each `jlog`
+line (and `capture_screen` thumbnails as in-memory `data:` URIs). Chosen over a local HTTP server +
+SSE: for an app that already holds the entries in memory, pushing into an embedded WebView is less
+code, has zero network surface, and is the most testable (the production runtime *is* the test
+runtime). It also sidesteps the `file://` `fetch()` restriction that forced the original viewer's
+`<meta refresh>` reload.
 
 - New events stream in live (no reload, no flicker); thumbnails open in an in-page lightbox.
 - Each Start opens a fresh session (a Stop→Start gets a new log, never resuming the previous run),
   persisted as owner-only `jarvis-activity.jsonl` + `shot-N.jpg`, so past runs can be browsed and the
   history cleared from the viewer.
-- **File logging is dev-only.** Outside `--dev`, `jlog` writes solely to the unified log (Console.app),
-  never a flat file. The dev files are `0600` in a gitignored per-session `.jarvis/<session>/` — the
-  full privacy posture is in [sandbox.md](./sandbox.md).
+- **The viewer and its file logging are always on** (they used to be `--dev`-gated). On every launch
+  `jlog` writes to the unified log (Console.app) *and* the per-session files; `--dev` only changes
+  *where* — the workspace `.jarvis/<session>/` instead of `~/Caches/Jarvis/<session>/`. The files are
+  `0600` in a `0700` per-session dir either way — the full privacy posture is in [sandbox.md](./sandbox.md).
 - The viewer's rendering logic (`htmlShell`/`rowScript`) and history reader (`SessionStore`) live in
   `JarvisCore` so they're unit/WebKit-tested; `ActivityViewer` in `JarvisApp` is the thin window.
 
@@ -81,4 +82,4 @@ reload.
 
 Some behavior can only be verified by a human with a real key, a mic, and granted permissions — see
 the checklist in the [README](../README.md#live-smoke-checklist). Run via `./scripts/build-app.sh
---dev` and watch each step in the activity viewer.
+--dev` and watch each step in the activity viewer (Settings → Activity).

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -73,8 +73,9 @@ runtime). It also sidesteps the `file://` `fetch()` restriction that forced the 
 - **The viewer and its file logging are always on** (they used to be `--dev`-gated; that flag is gone).
   On every launch `jlog` writes to the unified log (Console.app) *and* the per-session files in the
   gitignored, workspace-local `.jarvis/<session>/` (`0600` files in a `0700` dir). `build-app.sh --run`
-  passes that path via `--log-dir`, since the `open`-launched app can't find the repo itself. The full
-  privacy posture is in [sandbox.md](./sandbox.md).
+  passes that path via `--log-dir`, since the `open`-launched app can't find the repo itself; opening
+  the bundle directly with no `--log-dir` falls back to `~/Library/Application Support/Jarvis/sessions/`.
+  The full privacy posture is in [sandbox.md](./sandbox.md).
 - The viewer's rendering logic (`htmlShell`/`rowScript`) and history reader (`SessionStore`) live in
   `JarvisCore` so they're unit/WebKit-tested; `ActivityViewer` in `JarvisApp` is the thin window.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -11,13 +11,13 @@
 ## Core Pages
 
 - **[architecture.md](./architecture.md)** — the vision, the harness loop, components, data flow, the models/APIs rationale, resilience, safety, and design principles. The design *why*; the *what* lives in `Sources/`.
-- **[build-and-run.md](./build-and-run.md)** — the operational *how*: toolchain (SwiftPM + CLT), the three-target split (Core/Overlay/App), swift-testing, packaging/signing and why TCC grants persist, running, and the dev-mode activity viewer.
+- **[build-and-run.md](./build-and-run.md)** — the operational *how*: toolchain (SwiftPM + CLT), the three-target split (Core/Overlay/App), swift-testing, packaging/signing and why TCC grants persist, running, and the activity viewer.
 - **[sandbox.md](./sandbox.md)** — the security/isolation model (file-access restriction, entitlements, egress, server-side retention tradeoff).
 - **[overlay-invisibility.md](./overlay-invisibility.md)** — how the coaching overlay stays out of screen recordings and screen shares (the `sharingType = .none` mechanism), with empirical verification on macOS 26.5 and the limits.
 - **[overlay-timing.md](./overlay-timing.md)** — how long each coaching line stays on screen: a hybrid of the captioning reading-speed standard and our glance-not-watch situation (length-proportional time + a fixed notice buffer + an inter-line blank gap).
 - **[landscape-survey.md](./landscape-survey.md)** — every tool and product we tried or evaluated, and how each measured up. ("What I tried.")
 - **[fork-evaluation.md](./fork-evaluation.md)** — code-level evaluation of open-source apps as a fork base for the PoC, and why they're all Electron/Tauri rather than native Swift.
-- **[settings-window.md](./settings-window.md)** — the unified Settings window: one menu item → `SettingsWindow` hosting `APIKeySection`, `OverlaySection`, and (dev mode) `ActivitySection`; the Overlay Caption and Overlay Box each have an on/off toggle + size/opacity, persisted via `OverlayAppearance`.
+- **[settings-window.md](./settings-window.md)** — the unified Settings window: one menu item → `SettingsWindow` hosting `APIKeySection`, `OverlaySection`, `BrainModelSection`, and `ActivitySection`; the Overlay Caption and Overlay Box each have an on/off toggle + size/opacity, persisted via `OverlayAppearance`.
 
 ## Key Decisions
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -112,9 +112,10 @@ session can be reviewed afterward. It is written on **every** launch — it was 
 The hardening that made the dev affordance safe still applies in full: the files go to a per-session
 directory under the `--log-dir` (the workspace **gitignored `.jarvis/`** under `--dev`, else a
 per-user `Caches/Jarvis`) at **`0600`** owner-only permissions inside a **`0700`** dir, **fresh each
-session**, and **never `/tmp`** (world-readable, shared across user accounts). The viewer's
-clear-history removes past sessions. So the persisted record is readable by this user account and by
-nothing else. See [build-and-run.md](./build-and-run.md).
+session**, and **never `/tmp`** (world-readable, shared across user accounts). Because it now records
+on every launch, growth is bounded: each Start prunes to the **10 most recent** session dirs, and the
+viewer's clear-history removes all but the current. So the persisted record is small, owner-only, and
+readable by this user account and by nothing else. See [build-and-run.md](./build-and-run.md).
 
 ## Behavioral Restraint (anti-annoyance = anti-misbehavior)
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -17,8 +17,9 @@ Two layers below are **relaxed** for the personal build, by explicit decision:
   **git worktree** for recoverability, rather than a restricted `jarvisbuild` account. The former
   HARD REQUIREMENT is **waived** here. (Hardened model: §2.)
 
-Everything else (owner-only file for the key, narrow egress, no recording to disk, model-governed behavioral
-restraint) **still holds**. To re-harden for a shippable build, re-enable §1 and §2.
+Everything else (owner-only file for the key, narrow egress, no rolling stream archive, owner-only
+activity log, model-governed behavioral restraint) **still holds**. To re-harden for a shippable
+build, re-enable §1 and §2.
 
 ## Principle
 
@@ -89,11 +90,11 @@ Narrow and explicit. Data leaves the machine only via:
 - **Screenshot + transcript window → `gpt-5.5`** — and *only* when the model triggers a
   `capture_screen` and/or a coaching turn. No screen content leaves the machine on idle turns.
 
-In the MVP there is **no recording to disk** — no rolling screen/audio archive, no "recall"
-database. Temp screenshots are deleted after use. This guarantee covers the **sensitive captured
-streams** (mic audio, screenshots, and the transcript derived from them): audio streams to the API
-and is dropped, the transcript lives in memory, and nothing is persisted *on this machine* in normal
-operation.
+There is **no rolling screen/audio archive and no "recall" database** — Jarvis keeps no continuous
+recording of what it sees or hears. The **raw captured streams stay transient**: mic audio streams to
+the API and is dropped, the live transcript lives in memory, and the temp screenshot files used to
+hand a frame to `screencapture` are deleted immediately after use. The one thing persisted *on this
+machine* is the **activity log** — owner-only and bounded; see below.
 
 > **Server-side retention for conversation quality (current behavior).** To give the coach real
 > multi-turn memory — so it remembers its *own* prior replies, not just the user's speech — the brain
@@ -103,14 +104,17 @@ operation.
 > extend to OpenAI's servers. A deliberate *quality-over-retention* choice; revisiting it (encrypted
 > reasoning items / ephemeral conversations / client-side history) is tracked as a future privacy item.
 
-**Dev-mode logging is the one bounded exception, and it is hardened to not break the guarantee.**
-File logging (the activity HTML + `jarvis-debug.log`, which include the model's spoken tips and the
-transcribed "heard:" lines) is written **only when the `--dev` flag is set** — normal launches log
-solely to the unified log, never a flat file. When on, the files go to the `--log-dir` (a
-**gitignored `.jarvis/` in the workspace**, or a per-user `Caches/Jarvis`) with **`0600`** owner-only
-permissions, **truncated fresh each session** — never `/tmp` (which is world-readable and shared
-across user accounts). So even the dev affordance produces no world-readable or persistent record.
-See [build-and-run.md](./build-and-run.md).
+**The activity log is the one bounded form of disk persistence, hardened to stay owner-only.** The
+log (the in-app `WKWebView` viewer's `jarvis-activity.jsonl` + the screenshots the model looked at,
+alongside `jarvis-debug.log`) records the model's spoken tips and the transcribed "heard:" lines so a
+session can be reviewed afterward. It is written on **every** launch — it was previously gated to the
+`--dev` flag, now it is always on (an explicit decision to make session review a default affordance).
+The hardening that made the dev affordance safe still applies in full: the files go to a per-session
+directory under the `--log-dir` (the workspace **gitignored `.jarvis/`** under `--dev`, else a
+per-user `Caches/Jarvis`) at **`0600`** owner-only permissions inside a **`0700`** dir, **fresh each
+session**, and **never `/tmp`** (world-readable, shared across user accounts). The viewer's
+clear-history removes past sessions. So the persisted record is readable by this user account and by
+nothing else. See [build-and-run.md](./build-and-run.md).
 
 ## Behavioral Restraint (anti-annoyance = anti-misbehavior)
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -109,10 +109,12 @@ log (the in-app `WKWebView` viewer's `jarvis-activity.jsonl` + the screenshots t
 alongside `jarvis-debug.log`) records the model's spoken tips and the transcribed "heard:" lines so a
 session can be reviewed afterward. It is written on **every** launch — it was previously gated to a
 `--dev` flag (now removed), an explicit decision to make session review a default affordance. The
-hardening that made the old dev affordance safe still applies in full: the files always go to a
-per-session directory in the **gitignored, workspace-local `.jarvis/`** (passed to the `open`-launched
-app via `--log-dir` by `build-app.sh --run`) at **`0600`** owner-only permissions inside a **`0700`**
-dir, **fresh each session**, and **never `/tmp`** (world-readable, shared across user accounts). Because
+hardening that made the old dev affordance safe still applies in full: the files go to a per-session
+directory in the **gitignored, workspace-local `.jarvis/`** (passed to the `open`-launched app via
+`--log-dir` by `build-app.sh --run`) — or, when the bundle is opened directly with no `--log-dir`, a
+per-user **`~/Library/Application Support/Jarvis/sessions/`** alongside the API key — at **`0600`**
+owner-only permissions inside a **`0700`** dir, **fresh each session**, and **never `/tmp`**
+(world-readable, shared across user accounts). Because
 it now records on every launch, growth is bounded: each Start prunes to the **10 most recent** session
 dirs, and the viewer's clear-history removes all but the current. So the persisted record is small, owner-only, and
 readable by this user account and by nothing else. See [build-and-run.md](./build-and-run.md).

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -107,14 +107,14 @@ machine* is the **activity log** — owner-only and bounded; see below.
 **The activity log is the one bounded form of disk persistence, hardened to stay owner-only.** The
 log (the in-app `WKWebView` viewer's `jarvis-activity.jsonl` + the screenshots the model looked at,
 alongside `jarvis-debug.log`) records the model's spoken tips and the transcribed "heard:" lines so a
-session can be reviewed afterward. It is written on **every** launch — it was previously gated to the
-`--dev` flag, now it is always on (an explicit decision to make session review a default affordance).
-The hardening that made the dev affordance safe still applies in full: the files go to a per-session
-directory under the `--log-dir` (the workspace **gitignored `.jarvis/`** under `--dev`, else a
-per-user `Caches/Jarvis`) at **`0600`** owner-only permissions inside a **`0700`** dir, **fresh each
-session**, and **never `/tmp`** (world-readable, shared across user accounts). Because it now records
-on every launch, growth is bounded: each Start prunes to the **10 most recent** session dirs, and the
-viewer's clear-history removes all but the current. So the persisted record is small, owner-only, and
+session can be reviewed afterward. It is written on **every** launch — it was previously gated to a
+`--dev` flag (now removed), an explicit decision to make session review a default affordance. The
+hardening that made the old dev affordance safe still applies in full: the files always go to a
+per-session directory in the **gitignored, workspace-local `.jarvis/`** (passed to the `open`-launched
+app via `--log-dir` by `build-app.sh --run`) at **`0600`** owner-only permissions inside a **`0700`**
+dir, **fresh each session**, and **never `/tmp`** (world-readable, shared across user accounts). Because
+it now records on every launch, growth is bounded: each Start prunes to the **10 most recent** session
+dirs, and the viewer's clear-history removes all but the current. So the persisted record is small, owner-only, and
 readable by this user account and by nothing else. See [build-and-run.md](./build-and-run.md).
 
 ## Behavioral Restraint (anti-annoyance = anti-misbehavior)

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -51,10 +51,10 @@ resizing; the API-key and overlay panels stay compact.
 | `APIKeySection` | "API Key" | yes | `NSSecureTextField` to paste the OpenAI key; saves to an owner-only file on "Save", restarts the pipeline if already running. |
 | `OverlaySection` | "Overlay" | yes | Two groups, one per overlay surface — **Overlay Caption** (the transient on-screen tip) and **Overlay Box** (the persistent response history). Each has a header with an On/Off toggle (an `NSSwitch` + "On"/"Off" label) and a one-line description. When a surface is **on** it also shows its Text Size + Opacity sliders (with live readouts) and a live sample, **only while the Overlay tab is selected** (`didBecomeActive`/`didResignActive`); when **off**, its sliders and sample are hidden and the layout collapses. Persists via `OverlayAppearance`. |
 | `BrainModelSection` | "Brain" | yes | Two dropdowns — the brain (LLM) model and the reasoning effort applied to it; persists via `BrainPreferences`. Takes effect on the next Start. |
-| `ActivitySection` | "Activity" | dev mode only | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `prefersResizableWindow == true` so the log gets a larger, resizable window. |
+| `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `prefersResizableWindow == true` so the log gets a larger, resizable window. |
 
-`AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. `ActivitySection`
-is appended only when `--dev` is passed.
+`AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. All four sections
+are always present.
 
 ## Activation-Policy Switch
 
@@ -128,7 +128,7 @@ not mid-session — hence the caption on the tab.
 | `Sources/JarvisApp/Settings/APIKeySection.swift` | API-key tab |
 | `Sources/JarvisApp/Settings/OverlaySection.swift` | Overlay-appearance tab |
 | `Sources/JarvisApp/Settings/BrainModelSection.swift` | Brain model + reasoning-effort tab |
-| `Sources/JarvisApp/Settings/ActivitySection.swift` | Dev-mode activity tab |
+| `Sources/JarvisApp/Settings/ActivitySection.swift` | Activity tab |
 | `Sources/JarvisCore/Coach/BrainModelCatalog.swift` | Curated model list (`BrainModel`) |
 | `Sources/JarvisCore/Coach/ReasoningEffort.swift` | The four effort levels |
 | `Sources/JarvisCore/Config/BrainPreferences.swift` | UserDefaults persistence + validation |
@@ -142,4 +142,4 @@ not mid-session — hence the caption on the tab.
 ## Related Pages
 
 - [overlay-invisibility.md](./overlay-invisibility.md) — capture exclusion re-assert during preview
-- [build-and-run.md](./build-and-run.md) — the embedded dev-mode activity log
+- [build-and-run.md](./build-and-run.md) — the embedded activity log

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -60,7 +60,8 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | **API key in an owner-only `0600` file, not the Keychain** — a self-signed (no Team ID) app's Keychain access keys to a per-build `cdhash`, so the Keychain re-prompts every rebuild; a file doesn't (2026-06-20) | [sandbox.md §3](./sandbox.md) |
 | ~~Build in a separate restricted account (HARD)~~ → **build in main `forrest` account, in a git worktree; hard requirement waived for the personal build** (2026-06-14) | [sandbox.md](./sandbox.md) |
 | **Tuned `server_vad`+debounce (not `semantic_vad`); quiet graceful Stop** — fixes from first live smoke run (2026-06-15) | [architecture.md](./architecture.md#models-and-apis) |
-| **Dev activity viewer = in-app `WKWebView`** (live push, no meta-refresh; screenshot lightbox; persisted JSONL session history + clear-history) | [build-and-run.md](./build-and-run.md) |
+| **Activity viewer = in-app `WKWebView`** (live push, no meta-refresh; screenshot lightbox; persisted JSONL session history + clear-history) | [build-and-run.md](./build-and-run.md) |
+| **Activity log is always on, not `--dev`-gated** — Settings → Activity + owner-only per-session disk logs on every launch; `--dev` now only routes logs to the workspace `.jarvis/` (2026-06-22) | [sandbox.md](./sandbox.md) |
 | **Overlay hidden from screen capture/sharing via `sharingType = .none`** — verified on macOS 26.5 incl. live `SCStream`; re-asserted on `show()` as defense-in-depth | [overlay-invisibility.md](./overlay-invisibility.md) |
 | **Cut the guardrail layer: no cooldown/rate cap, no wake-word detector; brain self-gates speaking; silence check backs off across a long silence** — simplify the flow, cut log noise, natural conversation (2026-06-16) | [architecture.md §5](./architecture.md#5-safety-model) |
 | **`speak` returns a `lines` array via Structured Outputs (`strict:true`), not a free-form string** — the model splits the tip into overlay lines, so the client no longer splits prose on `.`/`!`/`?` (which shattered code like `Array.from(...)`) (2026-06-17) | [architecture.md §2](./architecture.md#2-core-loop) |
@@ -102,7 +103,7 @@ The headless build is done. Remaining is the **human smoke run** — build, run,
    transcript; "I'm stuck on two-sum" → coaching overlay + observed `capture_screen`; overlay
    excluded from the screenshot; while you talk steadily Jarvis stays mostly quiet (model restraint,
    not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --dev`,
-   then open the activity viewer from the menu bar to watch each step.)
+   then open Settings → Activity to watch each step.)
 4. **Only remaining live unknown:** the bare-WebSocket connect for a transcription-only Realtime
    session. The connect contract (`?intent=transcription`, the `session.update` payload) lives in
    `RealtimeSession.swift`; if the live connect fails, that's the file to adjust (e.g. swap

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -61,7 +61,7 @@ A compact log — the *rationale* for each lives in the linked design page, not 
 | ~~Build in a separate restricted account (HARD)~~ → **build in main `forrest` account, in a git worktree; hard requirement waived for the personal build** (2026-06-14) | [sandbox.md](./sandbox.md) |
 | **Tuned `server_vad`+debounce (not `semantic_vad`); quiet graceful Stop** — fixes from first live smoke run (2026-06-15) | [architecture.md](./architecture.md#models-and-apis) |
 | **Activity viewer = in-app `WKWebView`** (live push, no meta-refresh; screenshot lightbox; persisted JSONL session history + clear-history) | [build-and-run.md](./build-and-run.md) |
-| **Activity log is always on, not `--dev`-gated** — Settings → Activity + owner-only per-session disk logs on every launch; `--dev` now only routes logs to the workspace `.jarvis/` (2026-06-22) | [sandbox.md](./sandbox.md) |
+| **Activity log is always on** — Settings → Activity + owner-only per-session disk logs on every launch, pruned to the 10 most recent; single location is the gitignored, workspace-local `.jarvis/`; the `--dev` flag was removed (2026-06-22) | [sandbox.md](./sandbox.md) |
 | **Overlay hidden from screen capture/sharing via `sharingType = .none`** — verified on macOS 26.5 incl. live `SCStream`; re-asserted on `show()` as defense-in-depth | [overlay-invisibility.md](./overlay-invisibility.md) |
 | **Cut the guardrail layer: no cooldown/rate cap, no wake-word detector; brain self-gates speaking; silence check backs off across a long silence** — simplify the flow, cut log noise, natural conversation (2026-06-16) | [architecture.md §5](./architecture.md#5-safety-model) |
 | **`speak` returns a `lines` array via Structured Outputs (`strict:true`), not a free-form string** — the model splits the tip into overlay lines, so the client no longer splits prose on `.`/`!`/`?` (which shattered code like `Array.from(...)`) (2026-06-17) | [architecture.md §2](./architecture.md#2-core-loop) |
@@ -102,7 +102,7 @@ The headless build is done. Remaining is the **human smoke run** — build, run,
 3. Run the **live smoke checklist** ([README](../README.md#live-smoke-checklist)): speak →
    transcript; "I'm stuck on two-sum" → coaching overlay + observed `capture_screen`; overlay
    excluded from the screenshot; while you talk steadily Jarvis stays mostly quiet (model restraint,
-   not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --dev`,
+   not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --run`,
    then open Settings → Activity to watch each step.)
 4. **Only remaining live unknown:** the bare-WebSocket connect for a transcription-only Realtime
    session. The connect contract (`?intent=transcription`, the `session.update` payload) lives in


### PR DESCRIPTION
## What

The activity log — the in-app `WKWebView` viewer (Settings → **Activity**), its persisted `jarvis-activity.jsonl` + screenshots, and `jarvis-debug.log` — was gated behind the `--dev` launch flag. This un-gates it: the Activity tab, the live viewer, and per-session disk logging now run on **every** launch.

## Behavior

- `AppDelegate`: removed the `devMode` flag and its three gates (viewer construction, the Settings Activity tab, and `beginNewSession()`'s `guard devMode`). The viewer is always built; the tab is always present; each Start rotates a fresh session dir + logs. `devLogDirectory()` → `logDirectory()`.
- **Where logs land**: `~/Library/Caches/Jarvis/<session>/` by default; `build-app.sh --dev` now *only* routes them to the workspace `.jarvis/<session>/` (its sole remaining purpose — it no longer enables anything). Either way the dir is `0700`, files `0600`, fresh per session, never `/tmp`.

## Privacy posture (deliberate change)

This relaxes the prior **"nothing screen-/audio-derived is written to disk outside dev mode"** invariant, by explicit decision. The activity log (spoken tips, transcribed "heard:" lines, and the screenshots the model looked at) now persists **owner-only in all modes**. The raw mic audio and the live transcript are still **never** archived. `CLAUDE.md`, `README.md`, and the wiki (`sandbox`, `build-and-run`, `settings-window`, `architecture`, `status`, `index`) are updated to state the new posture; a dated decision is recorded in `wiki/status.md`.

## Verification

- `swift build` — clean.
- `./scripts/run-tests.sh` — **184 tests, all passing**. `ActivityLog`/`SessionStore` logic is unchanged (still gated by `enable()`); the un-gating lives in `JarvisApp`, which is intentionally not unit-tested. Worth a live smoke check that a normal launch now writes per-session dirs under `~/Library/Caches/Jarvis/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)