### PR TITLE
Scale max_output_tokens with reasoning effort

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -132,7 +132,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         let brain = OpenAIBrainClient(apiKey: key, model: brainPreferences.model.id,
-                                      reasoningEffort: brainPreferences.effort.rawValue)
+                                      reasoningEffort: brainPreferences.effort.rawValue,
+                                      maxOutputTokens: brainPreferences.effort.maxOutputTokens)
         // Fan each spoken tip out to both the Overlay Caption and the persistent Overlay Box.
         let overlaySink = BroadcastOverlay([overlayCaption, overlayBox])
         let driver = CoachDriver(config: config, transcript: transcript,

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -29,7 +29,7 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
                 timeout: TimeInterval = 15,
                 maxRetries: Int = 2,
                 backoffBaseSeconds: Double = 0.5,
-                maxOutputTokens: Int = 768,   // headroom so reasoning + a short tool call don't truncate
+                maxOutputTokens: Int = 2_048,   // combined reasoning+output cap; pass a per-effort budget (see ReasoningEffort.maxOutputTokens)
                 promptCacheKey: String = "jarvis-coach-v1",
                 send: Sender? = nil) {
         self.apiKey = apiKey
@@ -198,13 +198,27 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
             let arguments: String?
         }
         struct IncompleteDetails: Decodable { let reason: String? }
+        struct Usage: Decodable {
+            struct OutputDetails: Decodable { let reasoning_tokens: Int? }
+            let output_tokens: Int?
+            let output_tokens_details: OutputDetails?
+        }
         let output: [Item]
         let status: String?
         let incomplete_details: IncompleteDetails?
+        let usage: Usage?
     }
 
     private func decode(_ data: Data) throws -> BrainResponse {
         let decoded = try JSONDecoder().decode(Response.self, from: data)
+        // Log per-turn token usage so the per-effort `max_output_tokens` budgets can be tuned DOWN
+        // from real consumption (OpenAI's own advice). `reasoning` is the share spent thinking — the
+        // part that silently ate the whole cap at high effort.
+        if let usage = decoded.usage {
+            let reasoning = usage.output_tokens_details?.reasoning_tokens ?? 0
+            let truncated = decoded.status == "incomplete" ? " [incomplete]" : ""
+            jlog("Jarvis coach: tokens — reasoning \(reasoning), output \(usage.output_tokens ?? 0), cap \(maxOutputTokens)\(truncated)")
+        }
         var invocations: [ToolInvocation] = []
         var raws: [RawToolCall] = []
         for item in decoded.output where item.type == "function_call" {

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -24,12 +24,16 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
 
     public init(apiKey: String,
                 model: String,
-                reasoningEffort: String = "low",
+                reasoningEffort: String = ReasoningEffort.default.rawValue,
                 endpoint: URL = URL(string: "https://api.openai.com/v1/responses")!,
                 timeout: TimeInterval = 15,
                 maxRetries: Int = 2,
                 backoffBaseSeconds: Double = 0.5,
-                maxOutputTokens: Int = 2_048,   // combined reasoning+output cap; pass a per-effort budget (see ReasoningEffort.maxOutputTokens)
+                // The cap MUST track the effort: it's a combined reasoning+output budget, so a value
+                // too small for the effort truncates the run (the high-effort bug). Callers pass the
+                // budget for the *selected* effort (`AppDelegate` → `effort.maxOutputTokens`); this
+                // default mirrors the default effort so there's one source of truth, never a magic number.
+                maxOutputTokens: Int = ReasoningEffort.default.maxOutputTokens,
                 promptCacheKey: String = "jarvis-coach-v1",
                 send: Sender? = nil) {
         self.apiKey = apiKey

--- a/Sources/JarvisCore/Coach/ReasoningEffort.swift
+++ b/Sources/JarvisCore/Coach/ReasoningEffort.swift
@@ -22,4 +22,21 @@ public enum ReasoningEffort: String, CaseIterable, Sendable {
 
     /// `low` keeps a coaching turn fast (sub-2s target) while still allowing tool calls.
     public static let `default`: ReasoningEffort = .low
+
+    /// The combined `max_output_tokens` budget to pair with this effort. On the Responses API this
+    /// cap covers reasoning + visible output + formatting tokens *together*, so it must clear the
+    /// whole reasoning pass before any tip is emitted — otherwise the run comes back
+    /// `status:"incomplete"` with reason `max_output_tokens` and zero output (what a flat 768 did at
+    /// `high`). These are runaway guards set well above expected consumption and scaled with effort;
+    /// `high` matches OpenAI's recommended ≥25k reserve for reasoning + outputs. The visible tip
+    /// itself is only ~100–200 tokens, so the budget is almost entirely reasoning headroom. Tune
+    /// down using the per-turn reasoning-token usage the brain client logs.
+    public var maxOutputTokens: Int {
+        switch self {
+        case .none: return 1_024
+        case .low: return 2_048
+        case .medium: return 8_192
+        case .high: return 25_000
+        }
+    }
 }

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
@@ -169,6 +169,18 @@ private func speakResponseBody(arguments: String) -> Data {
         #expect(body.contains("\"max_output_tokens\":25000"))
     }
 
+    /// A default-constructed client encodes the *default effort's* budget, not a magic number — this
+    /// pins the single source of truth (`ReasoningEffort.default.maxOutputTokens`) so the client
+    /// default can't silently drift back to a hardcoded value.
+    @Test func defaultMaxOutputTokensTracksDefaultEffort() async throws {
+        let box = CapturedBody()
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+                                       send: { req in box.set(req.httpBody); return (Data(#"{"output":[]}"#.utf8), http(200)) })
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools)
+        let body = String(data: box.get() ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("\"max_output_tokens\":\(ReasoningEffort.default.maxOutputTokens)"))
+    }
+
     /// Tools are sent with `strict:true` so the model's function-call arguments are schema-guaranteed
     /// (Structured Outputs via function calling) — that's what lets `speak` return a typed `lines`
     /// array instead of a free-form string the client has to split.

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
@@ -158,6 +158,17 @@ private func speakResponseBody(arguments: String) -> Data {
         #expect(body.contains("\"name\":\"capture_screen\""))
     }
 
+    /// The caller's `max_output_tokens` budget is encoded verbatim — this is what carries the
+    /// per-effort cap (high → 25k) so high-effort reasoning isn't truncated before the tip.
+    @Test func encodesProvidedMaxOutputTokens() async throws {
+        let box = CapturedBody()
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5", maxOutputTokens: 25_000,
+                                       send: { req in box.set(req.httpBody); return (Data(#"{"output":[]}"#.utf8), http(200)) })
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools)
+        let body = String(data: box.get() ?? Data(), encoding: .utf8) ?? ""
+        #expect(body.contains("\"max_output_tokens\":25000"))
+    }
+
     /// Tools are sent with `strict:true` so the model's function-call arguments are schema-guaranteed
     /// (Structured Outputs via function calling) — that's what lets `speak` return a typed `lines`
     /// array instead of a free-form string the client has to split.

--- a/Tests/JarvisCoreTests/Coach/ReasoningEffortTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ReasoningEffortTests.swift
@@ -16,4 +16,14 @@ import Testing
     @Test func defaultIsLow() {
         #expect(ReasoningEffort.default == .low)
     }
+
+    /// The combined cap scales with effort and never sits at the old flat 768 that starved high-effort
+    /// reasoning (the truncation bug). `high` clears OpenAI's recommended ≥25k reserve.
+    @Test func maxOutputTokensScalesWithEffort() {
+        #expect(ReasoningEffort.none.maxOutputTokens < ReasoningEffort.low.maxOutputTokens)
+        #expect(ReasoningEffort.low.maxOutputTokens < ReasoningEffort.medium.maxOutputTokens)
+        #expect(ReasoningEffort.medium.maxOutputTokens < ReasoningEffort.high.maxOutputTokens)
+        #expect(ReasoningEffort.high.maxOutputTokens >= 25_000)
+        for e in ReasoningEffort.allCases { #expect(e.maxOutputTokens > 768) }
+    }
 }


### PR DESCRIPTION
## Why

Setting reasoning effort to **high** truncated every coaching turn:

```
⚠️ response truncated (max_output_tokens) — not deliberate silence
```

Per OpenAI's [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning), `max_output_tokens` is a **combined** cap over reasoning + visible output + formatting tokens — and they recommend reserving **≥25,000** for reasoning models. Our flat `768` default (tuned for `low`) meant high-effort reasoning exhausted the whole budget before the `speak` tool call was ever emitted, so the run came back `status:"incomplete"` / `reason:"max_output_tokens"` with no tip.

## What

- **Per-effort budget** (`ReasoningEffort.maxOutputTokens`) — scales with effort since the cap is almost entirely reasoning headroom (the tip itself is ~100–200 tokens):

  | Effort | Cap |
  |---|---|
  | none | 1,024 |
  | low | 2,048 |
  | medium | 8,192 |
  | high | 25,000 |

- **Wired through** `AppDelegate` so the cap tracks the effort dropdown.
- **Dropped the `768` trap default** in `OpenAIBrainClient` (now 2,048; real callers pass the per-effort value).
- **Per-turn usage logging** — `tokens — reasoning N, output M, cap C [incomplete]` — so the caps can be tuned *down* from real consumption, as the guide advises.

## Why not just remove the cap

Falling back to the context-window limit loses the safety valve against a single runaway reasoning pass spiking latency/cost on an always-on, every-turn assistant. Generous-but-bounded keeps both.

## Tests

`./scripts/run-tests.sh` → 195 pass. Added:
- `maxOutputTokensScalesWithEffort` — monotonic, high ≥ 25k, all > 768
- `encodesProvidedMaxOutputTokens` — the cap reaches the wire

Not yet verified live — needs a real run at high effort to confirm the truncation is gone (the new token logging will show actual reasoning spend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)