### PR TITLE
docs: conform repo to the rules template's standards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ demand, and proactively offers short coaching tips via a capture-invisible overl
 |---|---|---|
 | `JarvisCore` | library | All the logic. **Foundation-only** — no AppKit / AVFoundation / ScreenCaptureKit / WebKit. Runs and is unit-tested on any machine. |
 | `JarvisOverlay` | library | The AppKit overlay (`NSPanel`, capture-invisibility). Its own target *so its behavior can be unit-tested* (`JarvisOverlayTests`) without dragging UIKit into Core. |
-| `CJarvisAEC` | C target | The acoustic-echo-cancellation edge: a pure-C facade over WebRTC AEC3. The C++ impl is prebuilt + statically merged (abseil included, zero runtime dylibs) into `lib/libjarvis-aec.a` by `scripts/build-aec.sh`, so `swift build` only links the archive — no C++ toolchain or vendored headers. Regenerate the `.a` only when bumping the webrtc version. |
+| `CJarvisAEC` | C target | The acoustic-echo-cancellation edge: a pure-C facade over WebRTC AEC3. The C++ impl is prebuilt + statically merged (abseil included, zero runtime dylibs) into `Sources/CJarvisAEC/lib/libjarvis-aec.a` by `scripts/build-aec.sh`, so `swift build` only links the archive — no C++ toolchain or vendored headers. Regenerate the `.a` only when bumping the webrtc version. |
 | `JarvisApp` | executable | The thin macOS shell: menu bar, capture, permissions, the activity viewer window. Wires Core + Overlay + AEC to the OS. Verified by a live run. |
 
 > **Put logic in `JarvisCore`.** If something can be written without an OS framework, it goes in Core
@@ -33,7 +33,7 @@ demand, and proactively offers short coaching tips via a capture-invisible overl
 - **Toolchain:** the Command Line Tools are enough — **no full Xcode required**. SPM deps that rely on
   SwiftUI macros (`@Entry` / `#Preview`, e.g. `KeyboardShortcuts`) won't compile CLT-only; reach for a
   lower-level API instead (the global hotkey uses raw Carbon for this reason).
-- **AEC archive:** `lib/libjarvis-aec.a` is prebuilt and committed; `swift build` just links it.
+- **AEC archive:** `Sources/CJarvisAEC/lib/libjarvis-aec.a` is prebuilt and committed; `swift build` just links it.
   Regenerate it with `scripts/build-aec.sh` only when bumping the WebRTC version.
 - **API key:** lives in an owner-only `0600` file (the `OPENAI_API_KEY` env var is a headless fallback
   only) — see [`wiki/sandbox.md`](./wiki/sandbox.md). Never put it in code.
@@ -92,7 +92,7 @@ into one module, so moving a file between subfolders never changes access contro
 | `Sources/JarvisCore/Config/` | Config + secrets (owner-only file) |
 | `Sources/JarvisCore/Diagnostics/` | Logging, the activity log, session-history store |
 | `Sources/JarvisCore/Support/` | Small primitives (`Clock`, `TurnTaskBox`) |
-| `Sources/JarvisOverlay/` | The on-screen `NSPanel` overlay (single file — no subfolders) |
+| `Sources/JarvisOverlay/` | The on-screen `NSPanel` overlay surfaces (caption + box; no subfolders) |
 | `Sources/JarvisApp/App/` | Entry point, `AppDelegate` |
 | `Sources/JarvisApp/MenuBar/` | Menu-bar item, Start/Stop, key entry |
 | `Sources/JarvisApp/Capture/` | Mic + system-audio capture, realtime transcriber, TCC priming |
@@ -146,8 +146,14 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
 - **Branches:** branch, don't commit to `main`.
 - **Pull requests:** land changes via a PR that **squash-merges** with the number in the subject
   (`… (#N)`).
-- **Commit messages:** capitalized imperative mood ("Add…", "Fix…", "Organize…"). One logical change
-  per commit.
+- **Never commit:** secrets, generated artifacts, or large binaries.
+
+### Commit messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): summary` in
+lowercase imperative mood (`feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`).
+Mark breaking changes with `!` (`feat!:`) or a `BREAKING CHANGE:` footer. One logical change per commit.
+The squash-merge subject carries the PR number (`type: summary (#N)`).
 
 ## Security & safety
 
@@ -182,5 +188,6 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
 
 ## Further context
 
-- **Design source of truth:** [`wiki/index.md`](./wiki/index.md) — architecture, decisions, and current
-  status. Start at [`wiki/status.md`](./wiki/status.md) if you're picking the project up mid-stream.
+- **Design source of truth:** @wiki/index.md — architecture, decisions, and current status. Start at
+  [`wiki/status.md`](./wiki/status.md) if you're picking the project up mid-stream.
+- Contribution guide: @CONTRIBUTING.md (if present)

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         // imported by tests — see Tests/JarvisOverlayTests for the screen-capture invisibility checks.
         .target(name: "JarvisOverlay", dependencies: ["JarvisCore"]),
         // Acoustic echo cancellation (WebRTC AEC3), the OS/native-bound edge. The C++ implementation
-        // is prebuilt + statically merged with abseil into lib/libjarvis-aec.a by scripts/build-aec.sh
+        // is prebuilt + statically merged with abseil into Sources/CJarvisAEC/lib/libjarvis-aec.a by scripts/build-aec.sh
         // (zero runtime dylib deps), so `swift build` compiles only the pure-C shim header and links
         // the archive — no C++ toolchain or vendored headers needed. See scripts/aec/jarvis_aec.cpp.
         .target(

--- a/README.md
+++ b/README.md
@@ -97,11 +97,6 @@ testable; **`JarvisApp`** is the thin macOS glue (menu bar, capture, permissions
 by a live run. Folders are grouped **by subsystem**, following
 [`wiki/architecture.md`](./wiki/architecture.md). Working rules live in [`CLAUDE.md`](./CLAUDE.md).
 
-Claude Code reads `CLAUDE.md`; the vendor-neutral [AGENTS.md](https://agents.md/) standard (Cursor,
-Codex, Copilot, Gemini CLI, …) reads `AGENTS.md`. To serve both from one source of truth, `AGENTS.md` is
-a git symlink to `CLAUDE.md` (stored as mode `120000`, so it clones correctly on macOS/Linux); the same
-pairing exists in `wiki/`. Edit `CLAUDE.md` — never the symlink.
-
 ## Scripts
 
 | Script | What it does |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ never archived. Full design: [`wiki/architecture.md`](./wiki/architecture.md); p
 .
 ├── Package.swift              # SwiftPM manifest (Swift 6, macOS 14+)
 ├── CLAUDE.md                  # development rules for agents/humans working in the repo
+├── AGENTS.md                  # symlink → CLAUDE.md, for AGENTS.md-compatible tools
 ├── Sources/
 │   ├── JarvisCore/            # the testable harness — Foundation-only, runs anywhere
 │   │   ├── Audio/                 # PCM + utterance buffering
@@ -95,6 +96,11 @@ any machine; **`JarvisOverlay`** is the AppKit overlay, split into its own targe
 testable; **`JarvisApp`** is the thin macOS glue (menu bar, capture, permissions, activity viewer) verified
 by a live run. Folders are grouped **by subsystem**, following
 [`wiki/architecture.md`](./wiki/architecture.md). Working rules live in [`CLAUDE.md`](./CLAUDE.md).
+
+Claude Code reads `CLAUDE.md`; the vendor-neutral [AGENTS.md](https://agents.md/) standard (Cursor,
+Codex, Copilot, Gemini CLI, …) reads `AGENTS.md`. To serve both from one source of truth, `AGENTS.md` is
+a git symlink to `CLAUDE.md` (stored as mode `120000`, so it clones correctly on macOS/Linux); the same
+pairing exists in `wiki/`. Edit `CLAUDE.md` — never the symlink.
 
 ## Scripts
 

--- a/wiki/CLAUDE.md
+++ b/wiki/CLAUDE.md
@@ -65,8 +65,9 @@ holds:
 - **A genuinely new concept arrives** — a new subsystem / surface / role, not a refinement.
 
 **Concrete-noun test:** can you finish "X is a ___" non-generically? "the overlay is a capture-invisible
-`NSPanel`" → yes; "good error handling matters" → no. The wiki stays flat until flat stops working; let
-taxonomy emerge. **Adding / renaming / removing a page → update [`index.md`](./index.md) in the same
+`NSPanel`" → yes; "good error handling matters" → no. **Cold start:** this governs *splitting*, not the
+first page — create `architecture.md` as soon as you have three sentences. The wiki stays flat until flat
+stops working; let taxonomy emerge. **Adding / renaming / removing a page → update [`index.md`](./index.md) in the same
 edit** (a page not in the index is invisible); keep it a lightweight map, not a second copy.
 
 ### 8. Log load-bearing decisions in one place. Don't accumulate decision files.
@@ -92,9 +93,9 @@ documented behavior without a doc update is incomplete; stale docs erode trust f
 3. **[`decisions.md`](./decisions.md)** — log any load-bearing decision.
 4. **[`index.md`](./index.md)** — update if a page was added, renamed, or removed.
 5. **Links** — confirm every link and file pointer in touched pages still resolves.
-6. **Duplicated facts** — code ↔ wiki, page ↔ page: collapse to one source or link **within this same
-   change**. Don't ship drift; if a mismatch genuinely can't be resolved here, call it out explicitly in
-   the PR description rather than parking it in the wiki.
+6. **Duplicated facts** — code ↔ wiki, page ↔ page, code ↔ config: collapse to one source or link
+   **within this same change**. Don't ship drift; if a mismatch genuinely can't be resolved here, call it
+   out explicitly in the PR description rather than parking it in the wiki.
 
 A change isn't done until a fresh agent could reconstruct what's built and where to start, from
 `index.md` + `status.md` + the touched pages.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -1,66 +1,22 @@
 # Status
 
-> Entry point for anyone (human or agent) joining mid-stream. Updated as the project moves.
+> Snapshot of what is true *right now*. This is the entry point for picking the project up mid-stream:
+> read [`index.md`](./index.md) first, then this page, then the relevant core page. Edited in place at
+> the close of every change, per [`CLAUDE.md`](./CLAUDE.md) → "Keep-in-sync checklist". Every file
+> pointer below either resolves to a real file or this page is wrong — fix the page. The load-bearing
+> design decisions live in [`decisions.md`](./decisions.md).
 
-## Phase
+## Current phase
 
-**Build complete (headless) — awaiting the live smoke run.** Phase 1 was **skipped** (2026-06-14)
-and the native Swift app was built directly. The tested harness (config, transcript, silence
-backoff, coach tool-loop, OpenAI client, activity log + viewer, session store, overlay invisibility)
-is **green**; `Jarvis.app` builds, signs with the stable `Jarvis Dev` identity, and launches. The
-app shell, overlay, mic capture, and realtime transcriber **compile and launch**, but their *live*
-behavior (real mic, websocket, TCC grants, real `OPENAI_API_KEY`, real model IDs) is verified only
-by the human smoke checklist in the [README](../README.md#live-smoke-checklist).
+**Build complete (headless) — awaiting the live smoke run.** The native Swift app builds, signs with
+the stable `Jarvis Dev` identity, and launches, and the full tested harness is green. The OS-bound edges
+(mic + system-audio capture, the realtime transcriber, TCC grants, the live brain/transcription
+round-trips with a real key and model IDs) compile and launch but are verified only by the human smoke
+run.
 
-## What's Decided
+## Next action
 
-- **What it is:** a personal LeetCode-coaching "Jarvis" for macOS. Hears you think aloud,
-  watches your screen *on demand*, proactively offers short coaching tips via an overlay.
-- **Brain:** `gpt-5.5` (Responses API, tool-use + vision), with a server-side conversation per
-  session for multi-turn memory. Model + reasoning effort are user-selectable in Settings
-  (default `gpt-5.5` / `low`). **Transcription:** `gpt-4o-transcribe` over the GA Realtime API.
-  API-only, no local models. Rationale: [architecture.md](./architecture.md#4-data-flow--cost-model).
-- **Overlay:** the brain returns the tip as a pre-split `lines` array (Structured Outputs); the
-  overlay shows up to ~3 short lines per response, one at a time. Newer tips queue behind the one on
-  screen rather than interrupting it, so no hint is dropped.
-- **Build approach: native Swift, directly.** The two-phase plan (fork Natively first, then native)
-  was dropped: **Phase 1 is skipped** and we build the clean native Swift app now. The fork
-  evaluation and survey still stand as the *why-build-our-own* basis ([fork evaluation](./fork-evaluation.md),
-  [survey](./landscape-survey.md) — none usable: closed, paid, answer-dumping; LockedIn AI is the
-  best behavior reference), but Natively is now at most a reference, not a base.
-- **Toolchain:** **SwiftPM + the Command Line Tools**, *no full Xcode required*. The app is packaged
-  into a `.app` bundle by hand and signed with a **stable self-signed identity** (`Jarvis Dev`, so
-  TCC grants persist across rebuilds); macOS **TCC prompts** grant Screen Recording + Microphone at
-  first run. See [build-and-run.md](./build-and-run.md).
-- **Where it's built:** on the MacBook, in the **main `forrest` account**, inside a **git worktree**
-  for recoverability. The earlier HARD REQUIREMENT to build in a separate restricted account is
-  **waived for this personal build** (decision 2026-06-14) — the security tradeoff (unsandboxed app
-  could read the main account's files) is accepted for now and documented in
-  [sandbox.md](./sandbox.md); the hardened model (App Sandbox + restricted account) is kept there as
-  the path for any future shippable version.
-
-## Key decisions
-
-The load-bearing decisions and their rationale live in the dedicated log:
-[decisions.md](./decisions.md) (newest last; each entry links to the design page with the detail).
-
-## Open Questions / To Confirm
-
-- **Double-talk under loud far audio** can over-attenuate the user briefly (AEC3 limitation); a neural
-  canceller (DTLN, Muesli-style) on the same aligned streams is the escalation if it bites in practice.
-  AEC stays ON across all routes (near-passthrough on headphones); we deliberately don't auto-bypass
-  on "headphones" because the detection is unreliable (a BT speaker looks like headphones) and a wrong
-  bypass re-admits the echo.
-- **Universal binary.** `libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 build if Intel is needed.
-- Minimum macOS version target. Build host is macOS 26.5; ScreenCaptureKit screen+audio capture
-  needs macOS 13+. Target **macOS 14+** unless a needed API forces higher.
-- The **live Realtime transcription wiring** in `Sources/JarvisApp/Capture/RealtimeTranscriber.swift` is the
-  one thing untested headlessly — the connect/config follow current docs but the bare-WebSocket
-  connect for a transcription-only session is unverified until the live run (see Next Action).
-
-## Next Action
-
-The headless build is done. Remaining is the **human smoke run** — build, run, and validate live:
+Run the **human smoke run** — build, run, and validate live:
 
 1. `./scripts/build-app.sh release` → `open ./Jarvis.app`; grant Microphone + Screen Recording
    (one-time; they persist afterward — see [build-and-run.md](./build-and-run.md)).
@@ -72,7 +28,35 @@ The headless build is done. Remaining is the **human smoke run** — build, run,
    excluded from the screenshot; while you talk steadily Jarvis stays mostly quiet (model restraint,
    not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --run`,
    then open Settings → Activity to watch each step.)
-4. **Only remaining live unknown:** the bare-WebSocket connect for a transcription-only Realtime
+4. **The one untested-headlessly edge:** the bare-WebSocket connect for a transcription-only Realtime
    session. The connect contract (`?intent=transcription`, the `session.update` payload) lives in
-   `RealtimeSession.swift`; if the live connect fails, that's the file to adjust (e.g. swap
-   `transcriptionModel` in `Config.swift`).
+   `Sources/JarvisCore/Transcription/RealtimeSession.swift`; if the live connect fails, that's the file
+   to adjust (e.g. swap `transcriptionModel` in `Config.swift`).
+
+## Built
+
+Tested `JarvisCore` + `JarvisOverlay` harness is green (`./scripts/run-tests.sh`); `JarvisApp` is the
+thin OS shell, verified by the smoke run.
+
+- `Sources/JarvisCore/Audio/` — PCM + utterance buffering (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`).
+- `Sources/JarvisCore/Transcription/` — realtime session wire contract + rolling transcript (`RealtimeSession`, `Transcript`, `NoiseReduction`).
+- `Sources/JarvisCore/Coach/` — the event loop and brain client: `CoachDriver`, `OpenAIBrainClient`, `ToolDefs`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
+- `Sources/JarvisCore/Triggers/` — turn/silence trigger detection + silence backoff (`Trigger`, `SilenceBackoff`).
+- `Sources/JarvisCore/Screen/ScreenCapture.swift` — the model-triggered screen-capture tool contract.
+- `Sources/JarvisCore/Overlay/` — overlay text model + length-proportional timing + fan-out (`OverlayRendering`, `OverlayTiming`, `OverlayAppearance`, `BroadcastOverlay`).
+- `Sources/JarvisCore/Config/` — config + owner-only secrets + brain preferences (`Config`, `Secrets`, `BrainPreferences`).
+- `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, session-history store, user-facing errors (`ActivityLog`, `SessionStore`, `UserFacingError`).
+- `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
+- `Sources/JarvisApp/App/` + `MenuBar/` — entry point, menu bar, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`).
+- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`, `RealtimeTranscriber`, `Permissions`).
+- `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting API-key / Overlay / Brain / Activity sections).
+- `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.
+- `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer.
+- `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 C edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
+
+## Not yet built
+
+- **Live smoke run verified** — the one remaining gate before "done"; see Next action.
+- **Universal binary** — `Sources/CJarvisAEC/lib/libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 slice if Intel is ever needed.
+- **Neural double-talk canceller** (DTLN / Muesli-style on the same aligned streams) — the escalation if AEC3 over-attenuates the user under loud far audio in practice.
+- **Minimum macOS version confirmed** — currently targeting macOS 14+; confirm against the APIs actually used (ScreenCaptureKit needs 13+).


### PR DESCRIPTION
Follow-up to #36. Removes the **intentional divergences** from the [`JINGBANZ/rules`](https://github.com/JINGBANZ/rules) template so Jarvis follows the template's standards, while keeping project-specific content (targets table, Layout, Modularity, the `Detail:` design-page links in `decisions.md`).

## Conventions adopted

- **Conventional Commits** — `Repository etiquette` now follows `type(scope): summary` (lowercase; `feat`/`fix`/`docs`/…; `!`/`BREAKING CHANGE:`), replacing the capitalized-imperative rule. The `(#N)` squash subject stays compatible (`type: summary (#N)`). Also adds the template's "Never commit" bullet.
- **`@`-imports** — `Further context` uses `@wiki/index.md` and `@CONTRIBUTING.md (if present)` instead of plain links.
- **`wiki/CLAUDE.md`** — restores the template's "Cold start" guidance (Convention 7) and `code ↔ config` (keep-in-sync item 6).
- **README** — documents the `AGENTS.md → CLAUDE.md` symlink (the template's cross-tool-compatibility idea we'd missed).

## Structure conformed

- **`wiki/status.md`** rewritten into the template's layout: `Current phase` / `Next action` / `Built` (file → what it is) / `Not yet built`. The decision log stays in `decisions.md` (linked from `index.md`).

## Deliberate, agreed exception

- The standing **`## Known drift`** section stays **dropped** — per the improvement proposed upstream in [JINGBANZ/rules#3](https://github.com/JINGBANZ/rules/issues/3) (fix drift in-PR; don't park it in the wiki).

## Drift fixed along the way

- `libjarvis-aec.a` pointer corrected to `Sources/CJarvisAEC/lib/libjarvis-aec.a` (was `lib/…`) in CLAUDE.md + status.md.
- `JarvisOverlay` Layout label "single file" → "caption + box" (it has three files now).

Docs/symlink only — no Swift touched. Every `status.md` file pointer verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)