### PR TITLE
Fix silent-session coaching gaps: nudge before first speech, quiet hourly rotation

### DIFF
--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -49,6 +49,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private var stopped = false
     private var connected = false        // true only between "session ready" and the next drop/close
     private var everConnected = false    // distinguishes the first connect from a reconnect
+    private var rotating = false         // an EXPECTED server rotation is mid-flight; quiet the noise it makes
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
          silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
@@ -72,7 +73,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
 
     func connect() {
         // Start clean: clear the stopped flag AND any stale backoff state from a prior session.
-        lock.lock(); stopped = false; reconnectAttempt = 0; isReconnecting = false; lock.unlock()
+        lock.lock(); stopped = false; reconnectAttempt = 0; isReconnecting = false; rotating = false; lock.unlock()
         openSocket()
     }
 
@@ -89,7 +90,12 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         task.resume()
         configureSession()
         receiveLoop()
-        resetSilenceTimer()
+        // Arm the proactive silence check on the FIRST connect only. On a reconnect (session rotation)
+        // the existing timer keeps running — it's tied to the conversation, not the socket — so the
+        // backoff step and the elapsed quiet carry across the rotation instead of snapping back to the
+        // base interval every time the ~hourly session rotates. (Speech still resets it, via `handle`.)
+        lock.lock(); let firstConnect = !everConnected; lock.unlock()
+        if firstConnect { resetSilenceTimer() }
         startPing()
     }
 
@@ -172,9 +178,11 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
             case .failure(let err):
                 // A failed pending receive is the EXPECTED artifact of an intentional Stop
                 // (cancel → ENOTCONN/POSIX 57). Suppress it then; only a live failure reconnects.
-                self.lock.lock(); let isStopped = self.stopped; self.connected = false; self.lock.unlock()
+                self.lock.lock(); let isStopped = self.stopped; let quiet = self.rotating; self.connected = false; self.lock.unlock()
                 if isStopped { return }
-                jlog("Jarvis realtime receive failed: \(err)")
+                // During an expected rotation the failing receive is just the old socket going away — the
+                // rotation line already covers it, so don't surface "Socket is not connected" on top.
+                if !quiet { jlog("Jarvis realtime receive failed: \(err)") }
                 self.scheduleReconnect()
             case .success(let message):
                 self.lock.lock(); self.reconnectAttempt = 0; self.lock.unlock() // healthy
@@ -212,14 +220,20 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
             // handled on the completed event above. Just refresh the silence timer here.
             resetSilenceTimer()
         case "session.created", "transcription_session.created":
-            lock.lock(); let wasReconnect = everConnected; everConnected = true; lock.unlock()
+            // A fresh session is up: the rotation (if any) completed, so re-enable normal drop logging.
+            lock.lock(); let wasReconnect = everConnected; everConnected = true; rotating = false; lock.unlock()
             jlog("Jarvis realtime: transcription session ready")
             // Flush buffered audio BEFORE marking connected, so live mic audio (which keeps buffering
             // while !connected) can't be sent ahead of the older buffered chunks and scramble order.
             flushBufferedAudio(isReconnect: wasReconnect)
             lock.lock(); connected = true; lock.unlock()
         case "error":
-            jlog("Jarvis realtime error event: \(text)")
+            // A session_expired error is the server telling us this session hit its lifetime cap. That's
+            // an expected rotation, not a fault: announce it once, calmly, and mark `rotating` so the
+            // close / receive-failure it triggers next don't pile on scary lines. The reconnect itself is
+            // driven by those paths as usual. Any OTHER error is a real fault — log it verbatim.
+            if RealtimeSession.isSessionExpired(obj) { noteRotation("reached its time limit") }
+            else { jlog("Jarvis realtime error event: \(text)") }
         default:
             break
         }
@@ -262,10 +276,21 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask,
                     didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
         // An intentional Stop closes the socket on purpose; don't alarm the user with it.
-        lock.lock(); let isStopped = stopped; connected = false; lock.unlock()
+        lock.lock(); let isStopped = stopped; let quiet = rotating; connected = false; lock.unlock()
         if isStopped { return }
-        jlog("Jarvis realtime socket closed: code \(closeCode.rawValue)")
+        // A server "going away" (1001) is a routine rotation/restart we just reconnect through. Treat it
+        // as expected even if no session_expired error preceded it (the two can arrive in either order);
+        // any other close code is unexpected and stays visible.
+        if closeCode == .goingAway { noteRotation("server going away") }
+        else if !quiet { jlog("Jarvis realtime socket closed: code \(closeCode.rawValue)") }
         scheduleReconnect()
+    }
+
+    /// Announce an expected server-initiated rotation exactly once, then mark `rotating` so the close /
+    /// receive-failure it produces stay quiet until the replacement session is ready (which clears it).
+    private func noteRotation(_ reason: String) {
+        lock.lock(); let already = rotating; rotating = true; lock.unlock()
+        if !already { jlog("Jarvis realtime: session rotating (\(reason)) — reconnecting") }
     }
 
     private func scheduleReconnect() {
@@ -306,8 +331,10 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         }
     }
 
-    /// (Re)start the proactive silence check from its base interval — called on connect and whenever
-    /// speech is heard, so a fresh quiet stretch always begins at the base interval before backing off.
+    /// (Re)start the proactive silence check from its base interval — called on the first connect and
+    /// whenever speech is heard, so a fresh quiet stretch always begins at the base interval before
+    /// backing off. A reconnect deliberately does NOT call this (see `openSocket`), so a session
+    /// rotation preserves the current backoff step rather than resetting it.
     private func resetSilenceTimer() {
         // The "them" transcriber leaves onSilence nil (only the mic owns the "are you stuck?" prompt);
         // skip arming a timer that would just no-op, avoiding per-utterance main-queue/Timer churn.

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -75,6 +75,11 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         // Start clean: clear the stopped flag AND any stale backoff state from a prior session.
         lock.lock(); stopped = false; reconnectAttempt = 0; isReconnecting = false; rotating = false; lock.unlock()
         openSocket()
+        // Arm the proactive silence check exactly once, here on the first connect. A reconnect (session
+        // rotation) re-enters via openSocket() directly, NOT connect(), so the running timer is left
+        // alone — its backoff step and elapsed quiet carry across the rotation instead of snapping back
+        // to the base interval every ~hour. (Speech still resets it, via `handle`.)
+        resetSilenceTimer()
     }
 
     private func openSocket() {
@@ -90,12 +95,6 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         task.resume()
         configureSession()
         receiveLoop()
-        // Arm the proactive silence check on the FIRST connect only. On a reconnect (session rotation)
-        // the existing timer keeps running — it's tied to the conversation, not the socket — so the
-        // backoff step and the elapsed quiet carry across the rotation instead of snapping back to the
-        // base interval every time the ~hourly session rotates. (Speech still resets it, via `handle`.)
-        lock.lock(); let firstConnect = !everConnected; lock.unlock()
-        if firstConnect { resetSilenceTimer() }
         startPing()
     }
 
@@ -331,10 +330,10 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         }
     }
 
-    /// (Re)start the proactive silence check from its base interval — called on the first connect and
-    /// whenever speech is heard, so a fresh quiet stretch always begins at the base interval before
-    /// backing off. A reconnect deliberately does NOT call this (see `openSocket`), so a session
-    /// rotation preserves the current backoff step rather than resetting it.
+    /// (Re)start the proactive silence check from its base interval — called from `connect()` (the first
+    /// connect) and whenever speech is heard, so a fresh quiet stretch always begins at the base interval
+    /// before backing off. A reconnect re-enters via `openSocket()` and deliberately does NOT call this,
+    /// so a session rotation preserves the current backoff step rather than resetting it.
     private func resetSilenceTimer() {
         // The "them" transcriber leaves onSilence nil (only the mic owns the "are you stuck?" prompt);
         // skip arming a timer that would just no-op, avoiding per-utterance main-queue/Timer churn.

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -176,7 +176,9 @@ public final class CoachDriver: @unchecked Sendable {
             let delta = transcript.renderFrom(index: currentSentCount())   // single snapshot: text + upTo
             newSpeech = delta.text; upTo = delta.upTo
         } else {
-            newSpeech = transcript.renderWindow(seconds: config.transcriptWindowSeconds, now: now)
+            // `renderWindow` filters on session-relative line times (`.at`), so the cutoff must be
+            // session-relative too — pass elapsed, not absolute `clock.now()`, or the window is empty.
+            newSpeech = transcript.renderWindow(seconds: config.transcriptWindowSeconds, now: now - sessionStart)
             upTo = 0   // unused: stateless mode never advances the sent-index
         }
 

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -161,7 +161,7 @@ public final class CoachDriver: @unchecked Sendable {
         let now = clock.now()
         let ctx = TriggerContext(
             reason: reason,
-            secondsSinceLastSpeech: transcript.silenceDuration(now: now),
+            secondsSinceLastSpeech: transcript.silenceDuration(now: now - sessionStart),
             sessionElapsedSeconds: now - sessionStart
         )
 

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -159,11 +159,7 @@ public final class CoachDriver: @unchecked Sendable {
         if case .silence(let secs) = reason { jlog("🤫 quiet for \(Int(secs))s") }
 
         let now = clock.now()
-        let ctx = TriggerContext(
-            reason: reason,
-            secondsSinceLastSpeech: transcript.silenceDuration(now: now - sessionStart),
-            sessionElapsedSeconds: now - sessionStart
-        )
+        let ctx = TriggerContext(reason: reason, sessionElapsedSeconds: now - sessionStart)
 
         // A hotkey trigger leaves no "🗣 heard:" line (the user pressed a key, didn't speak), so record
         // it — with the synthetic request we pre-fill as the user's message — so the activity viewer

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -51,6 +51,17 @@ public enum RealtimeSession {
         ["type": "input_audio_buffer.append", "audio": base64PCM]
     }
 
+    /// True if a parsed wire event is the server's `session_expired` error — emitted when a transcription
+    /// session hits its maximum lifetime (~60 min). The socket then closes (1001) and we reconnect. This
+    /// is an EXPECTED rotation, not a failure: callers use it to log the rotation calmly and suppress the
+    /// redundant close / receive-failure noise that follows, while the reconnect path handles it
+    /// transparently. We don't predict *when* this fires — we just react to it whenever it does.
+    public static func isSessionExpired(_ event: [String: Any]) -> Bool {
+        guard event["type"] as? String == "error",
+              let error = event["error"] as? [String: Any] else { return false }
+        return error["code"] as? String == "session_expired"
+    }
+
     /// The event type the server emits when an utterance's transcription is final.
     public static let completedTranscriptionType = "conversation.item.input_audio_transcription.completed"
 

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -52,10 +52,8 @@ public enum RealtimeSession {
     }
 
     /// True if a parsed wire event is the server's `session_expired` error — emitted when a transcription
-    /// session hits its maximum lifetime (~60 min). The socket then closes (1001) and we reconnect. This
-    /// is an EXPECTED rotation, not a failure: callers use it to log the rotation calmly and suppress the
-    /// redundant close / receive-failure noise that follows, while the reconnect path handles it
-    /// transparently. We don't predict *when* this fires — we just react to it whenever it does.
+    /// session hits its maximum lifetime (~60 min) and the socket rotates. An EXPECTED rotation, not a
+    /// fault (callers log it calmly and quiet the reconnect noise; see `RealtimeTranscriber`).
     public static func isSessionExpired(_ event: [String: Any]) -> Bool {
         guard event["type"] as? String == "error",
               let error = event["error"] as? [String: Any] else { return false }

--- a/Sources/JarvisCore/Transcription/Transcript.swift
+++ b/Sources/JarvisCore/Transcription/Transcript.swift
@@ -43,9 +43,12 @@ public final class RollingTranscript: @unchecked Sendable {
         return lines.map(\.at).max()
     }
 
-    /// Seconds since the last spoken line (0 if none).
+    /// Seconds since the last spoken line. Callers pass session-relative time, so with **no speech yet
+    /// this session** the user has been silent the *whole* session — return the elapsed `now`, not 0.
+    /// Returning 0 would peg the "are you stuck?" silence check below its interval forever, so it would
+    /// never fire before the first utterance (a user who opens Jarvis and works silently got no nudges).
     public func silenceDuration(now: TimeInterval) -> TimeInterval {
-        guard let last = lastSpeechTime else { return 0 }
+        guard let last = lastSpeechTime else { return max(0, now) }
         return max(0, now - last)
     }
 

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -11,11 +11,9 @@ public enum TriggerReason: Sendable, Equatable {
 /// Timing context handed to the model so it can tell "thinking" from "stuck".
 public struct TriggerContext: Sendable {
     public let reason: TriggerReason
-    public let secondsSinceLastSpeech: TimeInterval
     public let sessionElapsedSeconds: TimeInterval
-    public init(reason: TriggerReason, secondsSinceLastSpeech: TimeInterval, sessionElapsedSeconds: TimeInterval) {
+    public init(reason: TriggerReason, sessionElapsedSeconds: TimeInterval) {
         self.reason = reason
-        self.secondsSinceLastSpeech = secondsSinceLastSpeech
         self.sessionElapsedSeconds = sessionElapsedSeconds
     }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -45,8 +45,7 @@ import Testing
 
         await driver.handleTrigger(.silence(secondsQuiet: 30))
 
-        let expected = TriggerContext(reason: .silence(secondsQuiet: 30),
-                                      secondsSinceLastSpeech: 0, sessionElapsedSeconds: 0).promptLine
+        let expected = TriggerContext(reason: .silence(secondsQuiet: 30), sessionElapsedSeconds: 0).promptLine
         let msg = lastUserMessage(brain)
         #expect(msg == expected)
         #expect(msg?.contains("New since last turn") == false)

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -320,6 +320,24 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.createConversationCount == 1)               // failure flag prevents re-POST every turn
     }
 
+    /// Regression: the stateless context window is filtered on SESSION-RELATIVE line times, so the
+    /// cutoff must be session-relative too. The live `SystemClock` returns epoch seconds (~1.7e9), so
+    /// passing absolute `clock.now()` to `renderWindow` would push the cutoff past every line and send
+    /// an EMPTY window. The other stateless test starts the clock at 0 (absolute == relative, hiding
+    /// this); here the session starts at a large epoch-like origin so an absolute/relative mix-up fails.
+    @Test func statelessContextWindowSurvivesARealisticClockOrigin() async {
+        let clock = ManualClock(now: 1_000_000)   // session origin far from 0, like real epoch time
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["hi"])])],
+                                  failConversation: true)
+        let (driver, transcript) = makeDriver(brain: brain, screen: FakeScreen(), overlay: FakeOverlay(), clock: clock)
+        transcript.append(.init(speaker: .me, text: "the whole problem context", at: 2))   // spoken 2s in
+        clock.advance(by: 10)                                                               // 10s elapsed
+        await driver.handleTrigger(.turnEnd)
+        #expect(brain.conversationIds.last! == nil)                 // confirm the stateless path
+        let lastUser = brain.calls.last!.compactMap { $0.text }.joined(separator: " ")
+        #expect(lastUser.contains("the whole problem context"))     // window NON-empty despite the origin
+    }
+
     // MARK: - Observability: structured turn outcomes (Workstream B)
 
     @Test func spokeOutcome() async {

--- a/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
@@ -147,4 +147,21 @@ import Testing
         #expect(ev["type"] as? String == "input_audio_buffer.append")
         #expect(ev["audio"] as? String == "AAAA")
     }
+
+    /// The real `session_expired` wire event (the same JSON the socket delivers at the ~60-min cap) is
+    /// recognized as an expected rotation, so the transcriber logs it calmly instead of as a fault.
+    @Test func isSessionExpiredMatchesTheServerExpiryEvent() throws {
+        let wire = "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"code\":\"session_expired\",\"message\":\"Your session hit the maximum duration of 60 minutes.\"}}"
+        let obj = try #require(try JSONSerialization.jsonObject(with: Data(wire.utf8)) as? [String: Any])
+        #expect(RealtimeSession.isSessionExpired(obj))
+    }
+
+    /// Other errors, non-error events, and malformed payloads are NOT rotations — they stay visible as
+    /// real faults rather than being quietly swallowed.
+    @Test func isSessionExpiredRejectsEverythingElse() {
+        #expect(!RealtimeSession.isSessionExpired(["type": "error", "error": ["code": "invalid_api_key"]]))
+        #expect(!RealtimeSession.isSessionExpired(["type": "error"]))   // no error object
+        #expect(!RealtimeSession.isSessionExpired(["type": "transcription_session.created"]))
+        #expect(!RealtimeSession.isSessionExpired([:]))
+    }
 }

--- a/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
@@ -160,7 +160,9 @@ import Testing
     /// real faults rather than being quietly swallowed.
     @Test func isSessionExpiredRejectsEverythingElse() {
         #expect(!RealtimeSession.isSessionExpired(["type": "error", "error": ["code": "invalid_api_key"]]))
-        #expect(!RealtimeSession.isSessionExpired(["type": "error"]))   // no error object
+        #expect(!RealtimeSession.isSessionExpired(["type": "error"]))                       // no error object
+        #expect(!RealtimeSession.isSessionExpired(["type": "error", "error": ["message": "x"]]))  // error, but no code
+        #expect(!RealtimeSession.isSessionExpired(["type": "error", "error": ["code": 5]]))  // non-string code
         #expect(!RealtimeSession.isSessionExpired(["type": "transcription_session.created"]))
         #expect(!RealtimeSession.isSessionExpired([:]))
     }

--- a/Tests/JarvisCoreTests/Transcription/TranscriptTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/TranscriptTests.swift
@@ -33,9 +33,12 @@ import Testing
         #expect(abs(t.silenceDuration(now: 70) - 20) < 0.001)
     }
 
-    @Test func silenceDurationWhenEmptyIsZero() {
+    /// With no speech yet, the user has been silent for the whole session, so silence is measured from
+    /// session start (the passed `now`), not 0 — otherwise the "are you stuck?" check, gated on
+    /// `quiet >= interval`, could never fire before the first utterance.
+    @Test func silenceDurationWhenEmptyIsWholeSession() {
         let t = RollingTranscript()
-        #expect(abs(t.silenceDuration(now: 70) - 0) < 0.001)
+        #expect(abs(t.silenceDuration(now: 70) - 70) < 0.001)
     }
 
     /// Silence is measured from the latest SPOKEN time, not the last appended line. The two sockets

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -3,12 +3,12 @@ import Testing
 
 @Suite struct TriggerContextTests {
     @Test func turnEndPromptLineIsSpeakerNeutralAndDescribesSessionElapsed() {
-        let ctx = TriggerContext(reason: .turnEnd, secondsSinceLastSpeech: 0, sessionElapsedSeconds: 95)
+        let ctx = TriggerContext(reason: .turnEnd, sessionElapsedSeconds: 95)
         #expect(ctx.promptLine == "Trigger: a turn just ended. The session has been running for 95s.")
     }
 
     @Test func silencePromptLineDescribesQuietDurationAndSessionElapsed() {
-        let ctx = TriggerContext(reason: .silence(secondsQuiet: 120), secondsSinceLastSpeech: 120, sessionElapsedSeconds: 600)
+        let ctx = TriggerContext(reason: .silence(secondsQuiet: 120), sessionElapsedSeconds: 600)
         #expect(ctx.promptLine == "Trigger: the user has been silent for 120s. The session has been running for 600s.")
     }
 }


### PR DESCRIPTION
## Why

Triaging a real session that ran silently for ~an hour surfaced two issues:

1. **No proactive nudge / screen check ever fired.** The "are you stuck?" silence check is anchored to *time since last utterance*. With no utterance, `Transcript.silenceDuration` returned `0`, so the `quiet >= interval` guard never passed — a user who opens Jarvis and works silently gets zero nudges and zero screen checks for the whole session.
2. **The hourly session rotation looked like a crash.** OpenAI's realtime transcription session has a hard 60-minute cap. The reconnect path already recovers losslessly (buffers + replays audio), but the expected expiry logged a five-line error burst and reset the silence backoff to the base interval every rotation.

## What

**Silence check before the first utterance** (`34ec9be`)
- `silenceDuration` measures from session start when nobody has spoken yet (silent the whole session), instead of returning `0`.
- Fixed a latent units bug at the `CoachDriver` call site, which passed absolute epoch time into a session-relative function.

**Routine rotation, not a fault** (`43476e8`)
- New pure, unit-tested `RealtimeSession.isSessionExpired` predicate recognizes a server-initiated rotation (`session_expired` error or a `1001` "going away" close, in either arrival order).
- An expected rotation is announced once, calmly; the redundant close / receive-failure lines are suppressed while reconnecting. Real faults and the give-up-after-6-attempts case still log loudly.
- The silence timer is armed only on the **first** connect, so the backoff step and elapsed quiet carry across a rotation instead of snapping back to base.

No change to the reconnect *mechanics* — purely the silence fix plus honest, quiet logging of the expected rotation. Reactive by design: we don't predict when OpenAI closes the socket, we just react to it.

## Testing

- `swift build && ./scripts/run-tests.sh` — green, 198 tests.
- Added Core tests: `isSessionExpired` matches the real expiry wire event and rejects everything else; `silenceDuration` measures from session start when empty.
- Silence-timer-across-rotation behavior lives in `JarvisApp` (socket glue), which is intentionally not unit-tested; verified by reasoning about the timer lifecycle (the `Timer` survives a drop; only `stop()` invalidates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)