### PR TITLE
test: verify automated Claude PR review (do not merge)

### DIFF
--- a/Sources/JarvisCore/Support/ReviewProbe.swift
+++ b/Sources/JarvisCore/Support/ReviewProbe.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Scratch type used to verify the automated PR-review workflow end-to-end.
+/// Deliberately violates a CLAUDE.md rule so the reviewer has something to flag. Safe to delete.
+struct ReviewProbe: @unchecked Sendable {
+    var count: Int
+}


### PR DESCRIPTION
Verification PR for the new `Claude Code Review` workflow.

Adds a scratch type using `@unchecked Sendable` with no written reason — a deliberate violation of the CLAUDE.md rule *"Never silence Swift 6 concurrency warnings with `@unchecked` … without a written reason."*

**Expected:** the reviewer posts an inline comment flagging that line and quoting the rule. Will close + delete the branch once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)