### PR TITLE
ci: anchor Claude review comments on diff lines

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,9 +41,13 @@ jobs:
           # --comment makes the review post to the PR (inline comments per issue); without it the
           # review only prints to the Actions log.
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # Pin the top-level driver model. Note: the code-review command still spawns its own
-          # Opus bug-hunting subagents internally — this only sets the orchestrator model.
-          claude_args: '--model claude-sonnet-4-6'
+          # --model pins the top-level driver model (the code-review command still spawns its own
+          # Opus bug-hunting subagents internally). The inline-comment tool MUST be listed here:
+          # in agent mode the action only starts the github_inline_comment MCP server when this tool
+          # is in --allowedTools, otherwise the review falls back to a single top-level comment.
+          claude_args: |
+            --model claude-sonnet-4-6
+            --allowedTools "mcp__github_inline_comment__create_inline_comment"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
The current workflow posts the review as one top-level comment. Root cause: in agent mode the action only starts the `github_inline_comment` MCP server when `mcp__github_inline_comment__create_inline_comment` is in `claude_args --allowedTools` (see `src/mcp/install-mcp-server.ts`). The slash command's frontmatter isn't enough — it permits the call but doesn't start the server.

This adds the tool to `--allowedTools` so findings post as inline diff comments (matching Anthropic's own PR-review workflow and `pr-review-comprehensive.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)