### PR TITLE
test: verify inline Claude review comments (do not merge)

### DIFF
--- a/Sources/JarvisCore/Support/ReviewProbe.swift
+++ b/Sources/JarvisCore/Support/ReviewProbe.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Scratch type used to verify the automated PR-review workflow posts inline diff comments.
+/// Deliberately violates a CLAUDE.md rule so the reviewer has something to flag. Safe to delete.
+struct ReviewProbe: @unchecked Sendable {
+    var count: Int
+}


### PR DESCRIPTION
Second verification PR — confirms findings now post as **inline diff comments** after PR #41 enabled the inline-comment MCP server. Will close + delete once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)