### PR TITLE
ci: use central reusable Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,53 +1,21 @@
 name: Claude Code Review
 
+# Thin caller: the review logic lives in the central reusable workflow at JINGBANZ/workflows. This
+# file just owns the trigger and passes the secret down.
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
-  claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
-    runs-on: ubuntu-latest
+  review:
+    uses: JINGBANZ/workflows/.github/workflows/claude-code-review.yml@main
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          # --comment makes the review post to the PR (inline comments per issue); without it the
-          # review only prints to the Actions log.
-          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # --model pins the top-level driver model (the code-review command still spawns its own
-          # Opus bug-hunting subagents internally). The inline-comment tool MUST be listed here:
-          # in agent mode the action only starts the github_inline_comment MCP server when this tool
-          # is in --allowedTools, otherwise the review falls back to a single top-level comment.
-          claude_args: |
-            --model claude-sonnet-4-6
-            --allowedTools "mcp__github_inline_comment__create_inline_comment"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    # Optional: override the driver model (default: claude-sonnet-4-6)
+    # with:
+    #   model: claude-opus-4-7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,5 +1,7 @@
 name: Claude Code
 
+# Thin caller: the @claude logic lives in the central reusable workflow at JINGBANZ/workflows. This
+# file owns the trigger events and the @claude gate, and passes the secret down.
 on:
   issue_comment:
     types: [created]
@@ -17,34 +19,12 @@ jobs:
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+    uses: JINGBANZ/workflows/.github/workflows/claude.yml@main
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Replaces jarvis's inline Claude workflows with thin callers that `uses:` the reusable workflows in [JINGBANZ/workflows](https://github.com/JINGBANZ/workflows), so the review logic is maintained in one place.

- `claude-code-review.yml` → calls `JINGBANZ/workflows/.github/workflows/claude-code-review.yml@main`
- `claude.yml` → calls `JINGBANZ/workflows/.github/workflows/claude.yml@main`

The `CLAUDE_CODE_OAUTH_TOKEN` secret stays in jarvis and is passed down. Behavior is unchanged (inline diff comments, sonnet-4-6).

**Merge order:** merge the hub PR (JINGBANZ/workflows#1) first, since these callers reference `@main` of that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)