### PR TITLE
test: verify reusable Claude review workflow (do not merge)

### DIFF
--- a/Sources/JarvisCore/Support/ReviewProbe.swift
+++ b/Sources/JarvisCore/Support/ReviewProbe.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Scratch type to verify the centralized reusable PR-review workflow end-to-end.
+/// Deliberately violates a CLAUDE.md rule so the reviewer has something to flag. Safe to delete.
+struct ReviewProbe: @unchecked Sendable {
+    var count: Int
+}


### PR DESCRIPTION
Verifies the thin caller -> central reusable workflow path posts an inline review. Will close once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)