### PR TITLE
fix(coach): raise brain request ceiling and drop in-request retry

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -231,6 +231,11 @@ public final class CoachDriver: @unchecked Sendable {
                 // A cancellation (barge-in / Stop) is expected — report it quietly, not as a failure.
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
                 jlog("Jarvis coach: brain request failed on \(reason): \(error.localizedDescription)")
+                // A capture answered in THIS failed request left its function_call open server-side (the
+                // earlier iteration stored the call; the tool-result send is what just failed). Record it
+                // so the next turn closes it — otherwise the conversation carries a dangling function_call
+                // and the next request can choke on it. Mirrors the tool-loop-cap close below.
+                if convId != nil, let cap = unansweredCaptureCallId { setPendingCloseCallId(cap) }
                 return .brainError
             }
             // The input provably reached the server — NOW commit the conversation-state mutations:

--- a/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Coach/OpenAIBrainClient.swift
@@ -16,19 +16,22 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
     private let reasoningEffort: String
     private let endpoint: URL
     private let timeout: TimeInterval
-    private let maxRetries: Int
-    private let backoffBaseSeconds: Double
     private let maxOutputTokens: Int
     private let promptCacheKey: String
     private let send: Sender
+
+    /// A generous request ceiling that is a HANG backstop, not a latency knob. Normal coaching turns
+    /// finish in a few seconds; this only fires on a genuinely stuck request, so it sits well above the
+    /// slow-but-real reasoning tail. A tight value (the old 15s) abandons a still-generating turn while
+    /// the server keeps the per-session conversation lock — stranding every following turn with
+    /// `conversation_locked`. Waiting instead lets the turn finish and release the lock naturally.
+    public static let defaultTimeout: TimeInterval = 60
 
     public init(apiKey: String,
                 model: String,
                 reasoningEffort: String = ReasoningEffort.default.rawValue,
                 endpoint: URL = URL(string: "https://api.openai.com/v1/responses")!,
-                timeout: TimeInterval = 15,
-                maxRetries: Int = 2,
-                backoffBaseSeconds: Double = 0.5,
+                timeout: TimeInterval = OpenAIBrainClient.defaultTimeout,
                 // The cap MUST track the effort: it's a combined reasoning+output budget, so a value
                 // too small for the effort truncates the run (the high-effort bug). Callers pass the
                 // budget for the *selected* effort (`AppDelegate` → `effort.maxOutputTokens`); this
@@ -41,8 +44,6 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
         self.reasoningEffort = reasoningEffort
         self.endpoint = endpoint
         self.timeout = timeout
-        self.maxRetries = maxRetries
-        self.backoffBaseSeconds = backoffBaseSeconds
         self.maxOutputTokens = maxOutputTokens
         self.promptCacheKey = promptCacheKey
         self.send = send ?? { request in
@@ -60,25 +61,19 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
         request.httpBody = try encodeBody(messages: messages, tools: tools, toolChoice: toolChoice,
                                           conversationId: conversationId)
 
-        var attempt = 0
-        while true {
-            let (data, http) = try await send(request)
-            let status = http?.statusCode ?? 0
-            if (200..<300).contains(status) { return try decode(data) }
-
-            let retryable = status == 429 || (500...599).contains(status)
-            if retryable && attempt < maxRetries {
-                let retryAfter = http?.value(forHTTPHeaderField: "Retry-After").flatMap { Double($0) }
-                // Exponential backoff with multiplicative jitter; honor Retry-After when present.
-                let backoff = backoffBaseSeconds * pow(2, Double(attempt)) * Double.random(in: 1.0...1.3)
-                let delay = max(0, retryAfter ?? backoff)
-                if delay > 0 { try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000)) }
-                attempt += 1
-                continue
-            }
+        // One attempt, no in-request retry. Any failure — a client-side timeout past the ceiling, a
+        // dropped connection, an HTTP error, or a `conversation_locked` while a prior turn is still
+        // generating — throws to the driver, which recovers on the NEXT trigger: `sentCount` only
+        // advances on success, so the next turn's delta re-sends the failed lines PLUS everything newer.
+        // That's fresher than resending a stale body, and it lets a held conversation lock clear
+        // naturally instead of hammering it within the turn.
+        let (data, http) = try await send(request)
+        let status = http?.statusCode ?? 0
+        guard (200..<300).contains(status) else {
             throw NSError(domain: "OpenAIBrainClient", code: status,
                           userInfo: [NSLocalizedDescriptionKey: String(data: data, encoding: .utf8) ?? "http \(status)"])
         }
+        return try decode(data)
     }
 
     /// Create a server-side conversation (one per coaching session) so the model keeps continuity —

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -286,6 +286,26 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls[afterTurn1].contains { $0.role == .tool && $0.toolCallId == "cap" })
     }
 
+    /// A capture whose tool-result SEND then fails must not be left dangling either: the earlier
+    /// iteration stored the function_call server-side, so the failed send leaves it open. With the
+    /// one-attempt client (no in-request retry), the driver's catch must record it and the next turn
+    /// closes it — otherwise the conversation carries a dangling function_call and 400s forever.
+    @Test func captureClosedNextTurnWhenToolResultSendFails() async {
+        let clock = ManualClock(now: 0)
+        let brain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "cap")],
+                  rawToolCalls: [RawToolCall(id: "cap", name: "capture_screen", argumentsJSON: "{}")]), // capture
+            nil,                    // the tool-result send throws
+            .init(toolCalls: []),   // next turn: silent
+        ])
+        let (driver, _) = makeDriver(brain: brain, screen: FakeScreen(), overlay: FakeOverlay(), clock: clock)
+        #expect(await driver.handleTrigger(.turnEnd) == .brainError)
+        let afterTurn1 = brain.calls.count
+        await driver.handleTrigger(.turnEnd)
+        // The follow-up turn's first request must close the capture left open by the failed send.
+        #expect(brain.calls[afterTurn1].contains { $0.role == .tool && $0.toolCallId == "cap" })
+    }
+
     /// A prior speak's tool-result must NOT be lost if the very next turn fails before sending — it
     /// stays pending and is carried on the turn after.
     @Test func speakCallRetainedWhenNextTurnFails() async {

--- a/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Coach/OpenAIBrainClientTests.swift
@@ -109,27 +109,17 @@ private func speakResponseBody(arguments: String) -> Data {
         #expect(id == "conv_new123")
     }
 
-    @Test func httpErrorThrows() async {
-        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5", maxRetries: 0,
-                                       send: { _ in (Data("nope".utf8), http(400)) })
+    /// Any non-2xx fails fast — there is no in-request retry. A failure throws to the driver, which
+    /// recovers on the next trigger by re-sending the (still-uncommitted) backlog. This one-attempt
+    /// contract is what lets a held `conversation_locked` clear naturally instead of being hammered.
+    @Test func httpErrorThrowsWithoutRetry() async {
+        let attempts = Counter()
+        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
+                                       send: { _ in _ = attempts.next(); return (Data("nope".utf8), http(400)) })
         await #expect(throws: (any Error).self) {
             _ = try await client.respond(messages: [.user("hi")], tools: coachTools)
         }
-    }
-
-    /// 429 is retried with backoff; a subsequent 200 succeeds.
-    @Test func retriesOn429ThenSucceeds() async throws {
-        let attempts = Counter()
-        let ok = #"{"output":[{"type":"function_call","id":"f","call_id":"c","name":"speak","arguments":"{\"lines\":[\"hi\"]}"}]}"#
-        let client = OpenAIBrainClient(apiKey: "sk-x", model: "gpt-5.5",
-                                       maxRetries: 3, backoffBaseSeconds: 0,
-                                       send: { _ in
-            let n = attempts.next()
-            return n < 2 ? (Data("rate".utf8), http(429)) : (Data(ok.utf8), http(200))
-        })
-        let resp = try await client.respond(messages: [.user("hi")], tools: coachTools)
-        #expect(resp.toolCalls == [.speak(callId: "c", lines: ["hi"])])
-        #expect(attempts.value == 3) // two 429s + one 200
+        #expect(attempts.value == 1) // single attempt, no retry
     }
 
     /// Request body uses the Responses shape + hardening flags.

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -200,8 +200,14 @@ The always-on legs are built to survive transient failure rather than die on it:
   (`PCMBuffer`, capped at `maxBufferedAudioSeconds`, oldest evicted) and **flushes it into the new
   session on reconnect** — a mid-sentence drop no longer loses the user's words. Reconnect uses
   capped exponential backoff with a ping keepalive.
-- **The brain call** retries 429/5xx with bounded backoff (honoring `Retry-After`) under a request
-  timeout, and the coach loop is single-flighted so a turn can't double-speak.
+- **The brain call** is single-flighted (a turn can't double-speak) and runs under a generous request
+  timeout — a hang backstop set well above the reasoning-turn tail, so a slow turn is waited out, not
+  abandoned. It makes **one attempt** per turn: a failed request (a stuck/timed-out call, a dropped
+  connection, an HTTP error, or a `conversation_locked` while a prior turn still holds the per-session
+  conversation lock) fails the turn rather than retrying in place. Recovery is on the **next trigger** —
+  sent-state advances only on a successful send, so the next turn re-sends the still-unsent transcript
+  (the failed lines plus anything newer, fresher than a resend) and a held lock clears naturally instead
+  of being hammered.
 
 ## 5. Safety Model
 

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -225,3 +225,11 @@
 - **Rejected:** The hard 48 kHz aggregate pin.
 - **Revisit if:** AirPods-as-mic HFP narrowband quality bites — use the built-in mic for fidelity.
 - **Detail:** [architecture.md §3](./architecture.md#3-components).
+
+### 2026-07-03 — Brain call: generous ceiling, one attempt, recover on next trigger
+
+- **Chose:** A single server-side `conversation` per session with a **generous request timeout** (a hang backstop, not a latency knob) and **no in-request retry** — a failed brain call fails the turn and recovers on the next trigger, since sent-state advances only on a successful send.
+- **Why:** A tight timeout abandoned a still-generating turn while the server kept the conversation's single-writer lock, so every following turn hit `conversation_locked` and the coach went silent for minutes. Turns are single-flighted, so waiting for a slow turn lets it finish and release the lock naturally; and because the driver re-sends the still-unsent transcript next turn, a retry would only resend a *staler* body while hammering a held lock.
+- **Rejected:** (a) In-request retry with backoff — near-useless for `conversation_locked` (a >ceiling generation outlasts it) and it resends stale content; the only thing given up is `Retry-After` backoff on transient 429/5xx, negligible for a single-user app. (b) Cancel-and-send-the-latest via background mode + `POST /responses/{id}/cancel` — the only way to *abandon* a stale turn and jump to freshest context, but a much larger build; deferred.
+- **Revisit if:** the app grows beyond single-user (429 backpressure starts to matter), or the ceiling-length wait on a genuinely slow turn proves too laggy live (then reach for background-mode cancel).
+- **Detail:** [architecture.md → Resilience](./architecture.md#resilience).


### PR DESCRIPTION
## Problem

A live session went nearly silent for minutes. The activity log is dominated by:

```
"message": "Another process is currently operating on this conversation. Please retry in a few seconds.",
"code": "conversation_locked"
```

interleaved with `The request timed out.` — one cascading failure, not two.

### Root cause

The coach keeps **one server-side `conversation` per session** (`store:true` + `conversation`), which the Responses API locks to a single in-flight request. The brain client used a **15s `URLRequest` timeout**. gpt‑5.5 reasoning turns occasionally run longer, so:

1. Request exceeds 15s → client aborts (`The request timed out.`).
2. But `store:true` means the **server keeps generating and holds the conversation lock**.
3. The next `turnEnd` fires against the same conversation → **`conversation_locked`**, and the cascade holds for the rest of the session.

Turns are already serialized to one in-flight slot (`CoachDriver.claimOrPend`), so **waiting** for a slow turn — rather than abandoning it — lets it finish and release the lock naturally.

## Changes

- **Generous ceiling.** Raise the request timeout to **60s** (`OpenAIBrainClient.defaultTimeout`) — a hang backstop, not a latency knob. Normal turns finish in 2–4s; this only fires on a genuinely stuck request.
- **Drop in-request retry entirely.** `respond` makes a **single attempt**. Any failure (timeout, dropped connection, HTTP error, or `conversation_locked`) throws to the driver, which recovers on the **next trigger**: `sentCount` only advances on success, so the next turn's delta re-sends the failed lines **plus everything newer** — fresher than resending a stale body, and a held lock clears naturally instead of being hammered. Removes `maxRetries` / `backoffBaseSeconds` and the retry classifier.
- **Close a latent gap this exposes.** When a capture's tool-result *send* fails mid-turn, the earlier iteration already stored the `function_call` server-side — so the driver's `catch` now records it to be closed on the next turn (mirroring the tool-loop-cap path). Otherwise the conversation carries a dangling `function_call` and the next request 400s.
- **Docs synced.** `wiki/architecture.md` Resilience and a `decisions.md` entry updated to the single-attempt / recover-on-next-trigger model.

## Regression review — why the retry existed, and why removing it is safe

The 429/5xx retry-with-backoff originated in the **original Phase‑2 implementation (#2)**, built around a **streaming (SSE)** brain client (commits "test streaming 429 retry", "Honor Retry-After on streaming retries"). Streaming was later dropped; the retry survived as general **transient 429/5xx production hardening**. It never guarded the lock problem.

Removing it is **not a correctness regression**:
- **No data loss.** A failed turn doesn't advance `sentCount`, so the backlog re-sends on the next trigger. This is pinned by an existing test — `CoachDriverPipelineTests.swift:461` ("Speech is NOT marked sent on a failed turn — it is re-sent next turn").
- **No stuck state.** Recovery only needs a subsequent trigger; turn-end and silence triggers both provide one.
- **What we give up:** in-request `Retry-After` backoff on transient 429/5xx — a transient rate-limit/5xx now recovers on the *next trigger* instead of *within the same turn*. Negligible for a single-user app; those recover on the next trigger anyway.

### Deferred

`cancel-and-send-the-latest` (background mode + `POST /responses/{id}/cancel` to unlock a stranded conversation and jump to freshest context) is a larger build for the rare >ceiling / hung case; not in this PR (logged in `decisions.md`).

## Tests

- `httpErrorThrowsWithoutRetry` — a non-2xx fails fast in a single attempt (no retry).
- `captureClosedNextTurnWhenToolResultSendFails` — a capture whose tool-result send fails is closed on the next turn (the new catch path), so no dangling `function_call`.
- Removed the now-obsolete retry tests; kept the advance-on-success re-send test as the no-data-loss guard.

Gate: `swift build && ./scripts/run-tests.sh` — build clean, **199 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)