### PR TITLE
ci: add issue-opener and issue-worker callers

### DIFF
--- a/.github/workflows/issue-opener.yml
+++ b/.github/workflows/issue-opener.yml
@@ -1,0 +1,26 @@
+# E2E TEST: pinned to @feat/issue-opener-worker — switch to @main after JINGBANZ/workflows#3 merges.
+# Caller template — copy to a target repo's .github/workflows/issue-opener.yml
+# Calls the reusable workflow in JINGBANZ/workflows. Requires two secrets in the target repo:
+#   CLAUDE_CODE_OAUTH_TOKEN — run /install-github-app or `claude setup-token`
+#   BOT_PAT — a PAT (issues + PRs + contents on this repo); issues it creates must trigger the
+#             issue-worker workflow, which the default GITHUB_TOKEN cannot do.
+name: Issue Opener
+
+on:
+  schedule:
+    - cron: '17 6 * * *' # daily; odd minute dodges peak-load cron delays
+  workflow_dispatch: {} # manual runs; also re-enables the schedule after 60-day repo inactivity
+
+jobs:
+  open-issue:
+    uses: JINGBANZ/workflows/.github/workflows/issue-opener.yml@feat/issue-opener-worker
+    permissions:
+      contents: read
+      issues: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      BOT_PAT: ${{ secrets.BOT_PAT }}
+    # Optional: pick the engine/model (defaults: claude / claude-sonnet-4-6)
+    # with:
+    #   engine: claude
+    #   model: claude-opus-4-7

--- a/.github/workflows/issue-worker.yml
+++ b/.github/workflows/issue-worker.yml
@@ -1,0 +1,33 @@
+# E2E TEST: pinned to @feat/issue-opener-worker — switch to @main after JINGBANZ/workflows#3 merges.
+# Caller template — copy to a target repo's .github/workflows/issue-worker.yml
+# Calls the reusable workflow in JINGBANZ/workflows. Requires two secrets in the target repo:
+#   CLAUDE_CODE_OAUTH_TOKEN — run /install-github-app or `claude setup-token`
+#   BOT_PAT — a PAT (issues + PRs + contents on this repo); PRs it creates must trigger the
+#             PR-review workflow, which the default GITHUB_TOKEN cannot do.
+#
+# No gate here on purpose: the hub's reusable workflow verifies the issue author has write
+# access before any agent step runs, so callers stay trivial and the policy updates centrally.
+name: Issue Worker
+
+on:
+  issues:
+    types: [opened]
+
+concurrency:
+  group: issue-worker-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  work:
+    uses: JINGBANZ/workflows/.github/workflows/issue-worker.yml@feat/issue-opener-worker
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      BOT_PAT: ${{ secrets.BOT_PAT }}
+    # Optional: pick the engine/model (defaults: claude / claude-sonnet-4-6)
+    # with:
+    #   engine: claude
+    #   model: claude-opus-4-7


### PR DESCRIPTION
Installs the autonomous issue pipeline from JINGBANZ/workflows#3 — merging this arms the full chain on this repo: **daily opener files issue → worker opens PR → existing Claude review comments**.

Note the `uses:` refs are pinned to `@feat/issue-opener-worker` for e2e testing; I'll flip them to `@main` once JINGBANZ/workflows#3 merges.

Also requires the `BOT_PAT` secret on this repo (fine-grained PAT: Contents/Issues/Pull requests read-write) — without it the chain's hand-offs won't trigger downstream workflows.

Heads-up for review: the worker allows broad `Bash` by design (it must run arbitrary build/test commands); the trust gate in the hub workflow restricts it to issues opened by write-access authors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)