### PR TITLE
fix(diagnostics): add ⌨️ prefix to cssClass so manual-hint lines render as hear

### DIFF
--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -169,7 +169,7 @@ public final class ActivityLog: @unchecked Sendable {
         let m = message.trimmingCharacters(in: .whitespaces)
         if m.hasPrefix("💬") { return "say" }
         if m.hasPrefix("👁") { return "see" }
-        if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
+        if m.hasPrefix("🗣") || m.hasPrefix("🤫") || m.hasPrefix("⌨️") { return "hear" }
         if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -8,6 +8,7 @@ import Foundation
         #expect(ActivityLog.cssClass(for: "👁 looking at your screen") == "see")
         #expect(ActivityLog.cssClass(for: "🗣 heard: \"hello\"") == "hear")
         #expect(ActivityLog.cssClass(for: "🤫 quiet for 8s") == "hear")
+        #expect(ActivityLog.cssClass(for: "⌨️ hint shortcut — Trigger: the user pressed the hint shortcut.") == "hear")
         #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
         #expect(ActivityLog.cssClass(for: "… nothing useful to add, staying silent") == "think")
         #expect(ActivityLog.cssClass(for: "Jarvis realtime error event: oops") == "err")


### PR DESCRIPTION
## Summary

- Added `⌨️` to the `cssClass(for:)` method in `ActivityLog.swift`, grouped with the other user-triggered turn-event prefixes (`🗣`, `🤫`), so manual-hint log lines now receive the `"hear"` CSS class and are coloured blue in the activity viewer instead of rendering as unstyled lifecycle noise.
- Added a pinning assertion to `ActivityLogTests.cssClassKeysOnLeadingMarker` that verifies the new mapping.

No other files changed.

Fixes #48

Generated with [Claude Code](https://claude.ai/code)