### PR TITLE
ci: pin agent pipeline to workflows@main, cron 03:07 Beijing

### DIFF
--- a/.github/workflows/issue-opener.yml
+++ b/.github/workflows/issue-opener.yml
@@ -1,4 +1,3 @@
-# E2E TEST: pinned to @feat/issue-opener-worker — switch to @main after JINGBANZ/workflows#3 merges.
 # Caller template — copy to a target repo's .github/workflows/issue-opener.yml
 # Calls the reusable workflow in JINGBANZ/workflows. Requires two secrets in the target repo:
 #   CLAUDE_CODE_OAUTH_TOKEN — run /install-github-app or `claude setup-token`
@@ -8,19 +7,19 @@ name: Issue Opener
 
 on:
   schedule:
-    - cron: '17 6 * * *' # daily; odd minute dodges peak-load cron delays
+    - cron: '7 19 * * *' # daily 03:07 Beijing (UTC+8); off-the-hour minute dodges peak cron delays
   workflow_dispatch: {} # manual runs; also re-enables the schedule after 60-day repo inactivity
 
 jobs:
   open-issue:
-    uses: JINGBANZ/workflows/.github/workflows/issue-opener.yml@feat/issue-opener-worker
+    uses: JINGBANZ/workflows/.github/workflows/issue-opener.yml@main
     permissions:
       contents: read
       issues: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       BOT_PAT: ${{ secrets.BOT_PAT }}
-    # Optional: pick the engine/model (defaults: claude / claude-sonnet-4-6)
+    # Optional: pick the engine/model (defaults: claude / claude-opus-4-8)
     # with:
     #   engine: claude
-    #   model: claude-opus-4-7
+    #   model: claude-sonnet-4-6

--- a/.github/workflows/issue-worker.yml
+++ b/.github/workflows/issue-worker.yml
@@ -1,4 +1,3 @@
-# E2E TEST: pinned to @feat/issue-opener-worker — switch to @main after JINGBANZ/workflows#3 merges.
 # Caller template — copy to a target repo's .github/workflows/issue-worker.yml
 # Calls the reusable workflow in JINGBANZ/workflows. Requires two secrets in the target repo:
 #   CLAUDE_CODE_OAUTH_TOKEN — run /install-github-app or `claude setup-token`
@@ -19,7 +18,7 @@ concurrency:
 
 jobs:
   work:
-    uses: JINGBANZ/workflows/.github/workflows/issue-worker.yml@feat/issue-opener-worker
+    uses: JINGBANZ/workflows/.github/workflows/issue-worker.yml@main
     permissions:
       contents: write
       pull-requests: write
@@ -27,7 +26,7 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       BOT_PAT: ${{ secrets.BOT_PAT }}
-    # Optional: pick the engine/model (defaults: claude / claude-sonnet-4-6)
+    # Optional: pick the engine/model (defaults: claude / claude-opus-4-8)
     # with:
     #   engine: claude
-    #   model: claude-opus-4-7
+    #   model: claude-sonnet-4-6


### PR DESCRIPTION
Follow-up to #47 now that JINGBANZ/workflows#3 is merged:

- `uses:` refs flip from `@feat/issue-opener-worker` to `@main` (callers regenerated from the merged hub templates)
- Opener cron moves to `7 19 * * *` UTC = **03:07 Beijing** (off-the-hour to dodge peak cron delays)
- Opus 4.8 default now comes from the hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)