### PR TITLE
fix(coach): mask stale OCR sidecar with its screenshot in history

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -290,21 +290,27 @@ public final class CoachDriver: @unchecked Sendable {
         return .exhausted
     }
 
+    /// The capture_screen tool-result text with no OCR sidecar. Also what `CoachHistory` truncates a
+    /// stale capture result down to once its screenshot is stubbed (the OCR is masked with the image).
+    static let captureResultBase = "screenshot captured"
+
+    /// The fixed opening line of the OCR sidecar block. Exposed (rather than kept private to
+    /// `recognizedTextBlock`) so `CoachHistory` can recognize a stale observation's OCR at commit time
+    /// and neutralize it alongside the stubbed screenshot — without duplicating the literal.
+    static let recognizedTextMarker =
+        "Text recognized on the captured window (on-device OCR — may contain errors; the screenshot image is ground truth):"
+
     /// The capture_screen tool-result text: the OCR sidecar rides here when present, so exact text
     /// and the image arrive as one result the model reasons over together.
     private static func captureResultText(_ shot: ScreenSnapshot) -> String {
-        guard let text = shot.recognizedText else { return "screenshot captured" }
-        return "screenshot captured\n\n\(recognizedTextBlock(text))"
+        guard let text = shot.recognizedText else { return captureResultBase }
+        return "\(captureResultBase)\n\n\(recognizedTextBlock(text))"
     }
 
     /// Framed so the model treats OCR as a reading aid, not gospel — recognition mangles the odd
     /// identifier, and the screenshot stays the ground truth to verify against.
     private static func recognizedTextBlock(_ text: String) -> String {
-        """
-        Text recognized on the captured window (on-device OCR — may contain errors; \
-        the screenshot image is ground truth):
-        \(text)
-        """
+        "\(recognizedTextMarker)\n\(text)"
     }
 
     // MARK: - History compaction

--- a/Sources/JarvisCore/Coach/CoachHistory.swift
+++ b/Sources/JarvisCore/Coach/CoachHistory.swift
@@ -19,6 +19,9 @@ public final class CoachHistory: @unchecked Sendable {
     /// stale one rarely helps — the model can always capture a fresh look.
     private let maxImagesRetained = 1
     static let imageStub = "[an earlier screenshot was here — no longer available; call capture_screen for a fresh look]"
+    /// Replaces a stale standalone OCR message (the manual-hint path's `.user` sidecar). Tool-result
+    /// OCR is instead truncated back to `CoachDriver.captureResultBase`, keeping the call linkage.
+    static let ocrStub = "[earlier on-screen text was here — no longer available; call capture_screen for a fresh look]"
 
     public init() {}
 
@@ -35,10 +38,32 @@ public final class CoachHistory: @unchecked Sendable {
         guard !turn.isEmpty else { return }
         lock.lock(); defer { lock.unlock() }
         messages.append(contentsOf: turn)
+
         let imageIndices = messages.indices.filter { messages[$0].imageBase64JPEG != nil }
+        let retained = Set(imageIndices.suffix(maxImagesRetained))
+
+        // Mask the OCR sidecar of every stale observation alongside its screenshot: the recognized
+        // text (often hundreds of tokens of dense code) is re-billed on every later request just like
+        // a stale image would be. OCR sits immediately next to its screenshot — before it on the
+        // capture_screen tool-result path, after it on the manual-hint `.user` path — so an OCR
+        // message is stale exactly when neither neighbor is a still-retained image.
+        for index in messages.indices where messages[index].text?.contains(CoachDriver.recognizedTextMarker) == true {
+            let accompaniesRetainedImage = retained.contains(index - 1) || retained.contains(index + 1)
+            if !accompaniesRetainedImage { messages[index] = Self.neutralizeOCR(messages[index]) }
+        }
+
         for index in imageIndices.dropLast(maxImagesRetained) {
             messages[index] = .user(Self.imageStub)
         }
+    }
+
+    /// Strip the OCR block from a stale observation. A tool result keeps its role + `toolCallId` (the
+    /// wire format requires the tool message to stay paired with its assistant call) and drops to the
+    /// marker-free base line; a standalone `.user` OCR message becomes a tiny stub.
+    private static func neutralizeOCR(_ m: ChatMessage) -> ChatMessage {
+        m.role == .tool
+            ? .init(role: .tool, text: CoachDriver.captureResultBase, toolCallId: m.toolCallId)
+            : .user(ocrStub)
     }
 
     /// Rough size of the memory in tokens (chars/4 for text, a flat estimate per screenshot) — used

--- a/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
@@ -21,6 +21,60 @@ import Testing
         #expect(snap.contains { ($0.text ?? "").contains("no longer available") })    // the stub
     }
 
+    /// The OCR sidecar is masked with its screenshot: on the capture_screen tool-result path, a stale
+    /// turn's recognized text drops to the marker-free base line (call linkage preserved), while the
+    /// newest turn keeps both its image and its OCR.
+    @Test func staleOCRMaskedOnToolResultPath() {
+        let h = CoachHistory()
+        let marker = CoachDriver.recognizedTextMarker
+        h.commit([
+            .assistantToolCalls([RawToolCall(id: "c1", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(role: .tool, text: "screenshot captured\n\n\(marker)\nOLD_CODE_ONE", toolCallId: "c1"),
+            .userImage("QUJD"),
+        ])
+        h.commit([
+            .assistantToolCalls([RawToolCall(id: "c2", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(role: .tool, text: "screenshot captured\n\n\(marker)\nNEW_CODE_TWO", toolCallId: "c2"),
+            .userImage("REVG"),
+        ])
+        let snap = h.snapshot()
+        let allText = snap.compactMap(\.text).joined(separator: "\n")
+        #expect(!allText.contains("OLD_CODE_ONE"))     // stale OCR gone
+        #expect(allText.contains("NEW_CODE_TWO"))       // newest OCR intact
+        // The newest screenshot survives as pixels; the stale one is stubbed.
+        #expect(snap.filter { $0.imageBase64JPEG != nil }.count == 1)
+        #expect(snap.last { $0.imageBase64JPEG != nil }?.imageBase64JPEG == "REVG")
+        // Stale tool result keeps its call linkage but drops to the marker-free base line.
+        #expect(snap.contains { $0.role == .tool && $0.toolCallId == "c1" && $0.text == "screenshot captured" })
+        #expect(snap.contains { $0.role == .tool && $0.toolCallId == "c2" && ($0.text ?? "").contains(marker) })
+    }
+
+    /// The manual-hint path appends OCR as a standalone `.user` message right after its image; a stale
+    /// one is stubbed away while the newest turn's image + OCR survive.
+    @Test func staleOCRMaskedOnManualHintPath() {
+        let h = CoachHistory()
+        let marker = CoachDriver.recognizedTextMarker
+        h.commit([.user("hint one"), .userImage("QUJD"), .user("\(marker)\nOLD_MANUAL_OCR")])
+        h.commit([.user("hint two"), .userImage("REVG"), .user("\(marker)\nNEW_MANUAL_OCR")])
+        let snap = h.snapshot()
+        let allText = snap.compactMap(\.text).joined(separator: "\n")
+        #expect(!allText.contains("OLD_MANUAL_OCR"))    // stale OCR gone
+        #expect(allText.contains("NEW_MANUAL_OCR"))      // newest OCR intact
+        #expect(snap.filter { $0.imageBase64JPEG != nil }.count == 1)
+        #expect(snap.last { $0.imageBase64JPEG != nil }?.imageBase64JPEG == "REVG")
+        #expect(!allText.contains(marker) || allText.contains("NEW_MANUAL_OCR"))   // only newest marker remains
+    }
+
+    /// A `stay_silent` / no-image turn carries no OCR and no screenshot — masking must leave it fully
+    /// intact (no spurious stubbing of ordinary text).
+    @Test func noImageTurnsAreUntouched() {
+        let h = CoachHistory()
+        h.commit([.user("heard: let's try two pointers"),
+                  .init(role: .tool, text: "shown to the user", toolCallId: "s1")])
+        let snap = h.snapshot()
+        #expect(snap.compactMap(\.text) == ["heard: let's try two pointers", "shown to the user"])
+    }
+
     /// The compaction prefix always leaves the newest message verbatim and hands out at least one —
     /// a single oversized message must still be compactable once a second one exists.
     @Test func compactionPrefixBoundsRespectTheTail() {


### PR DESCRIPTION
## Problem

`CoachHistory` masked stale **screenshots** (older ones become the one-line `imageStub`) to keep re-billed tokens down, but the **OCR sidecar text** that rides alongside each screenshot was never masked. The exact recognized text of every past screenshot — often hundreds of tokens of dense code — accumulated in history verbatim and was re-billed on every subsequent request until the next compaction, undercutting the savings the sidecar/masking were built to deliver.

The OCR reached history on two paths, neither stubbed when its screenshot was:
- **`capture_screen` tool path** — OCR rides inside the `.tool` result text (`captureResultText`).
- **Manual-hint path** — OCR is appended as a standalone `.user` message (`recognizedTextBlock`).

## Change

1. Lifted the OCR-block marker (and the `"screenshot captured"` base line) into shared `static let`s on `CoachDriver` — `recognizedTextMarker` / `captureResultBase` — so `CoachHistory` matches on it without duplicating the literal (per CLAUDE.md "never copy prompts/config — link to the source").
2. In `CoachHistory.commit`, alongside stubbing every image except the newest `maxImagesRetained`, neutralize the OCR of each stale observation. OCR sits immediately next to its screenshot (before it on the tool-result path, after it on the manual-hint path), so an OCR message is stale exactly when neither neighbor is a still-retained image:
   - tool result → truncated to `"screenshot captured"`, keeping its `toolCallId` call linkage;
   - standalone `.user` OCR → replaced with a tiny `ocrStub`.
   - The OCR accompanying the still-retained newest screenshot is left intact.
3. Kept it purely a `commit`-time rewrite, preserving the append-only prompt-cache-stable prefix, exactly as image stubbing already does.

## Tests

Extended `Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift`:
- `staleOCRMaskedOnToolResultPath` — older turn's OCR gone, newest turn's image **and** OCR remain, stale tool result keeps its call linkage.
- `staleOCRMaskedOnManualHintPath` — same for the standalone `.user` path.
- `noImageTurnsAreUntouched` — `stay_silent`/no-image cases unchanged.

All 8 `CoachHistoryTests` pass (verified by running the Core test target in isolation — the full `run-tests.sh` can't build `JarvisOverlay`/`JarvisApp` on the Linux CI runner since they need macOS AppKit).

Fixes #61

Generated with [Claude Code](https://claude.ai/code)