### PR TITLE
fix(coach): context hygiene — fresh transcript per start, slim trigger notes, idle silence cutoff

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -6,7 +6,9 @@ import JarvisOverlay
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private let clock = SystemClock()
     private let config = Config.default
-    private let transcript = RollingTranscript()
+    /// Recreated on every `start()`: the transcript must live and die with the driver/transcriber
+    /// pair built there — they carry its [mm:ss] clock base and the driver's sent-index into it.
+    private var transcript = RollingTranscript()
     private let secretFile = FileSecretStore()
     private lazy var secrets = ChainedSecretStore([secretFile, EnvSecretStore()])
     /// The single funnel for user-facing failures (alerts + fatal session teardown). See `ErrorReporter`.
@@ -134,6 +136,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return false
         }
         stop() // tear down any existing pipeline so we start cleanly
+        // A fresh transcript for the fresh pipeline (even on an in-place restart, which rebuilds the
+        // driver and transcribers too). Reusing the old one would re-send a dead run's lines as "new
+        // since last turn" — their [mm:ss] stamps minted against the previous transcriber's clock —
+        // and anchor the silence math to that run's last utterance instead of real quiet time.
+        transcript = RollingTranscript()
         if freshSession {
             beginNewSession()       // rotate to a fresh session dir + activity/debug log
             menuBar.resetCounter()  // a user Start begins a fresh session
@@ -180,6 +187,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                               speaker: .me, transcript: transcript, clock: clock,
                                               silenceTimeout: config.silenceTimeoutSeconds,
                                               silenceMaxInterval: config.silenceMaxIntervalSeconds,
+                                              silenceIdleCutoff: config.silenceIdleCutoffSeconds,
                                               silenceDurationMs: config.vadSilenceDurationMs,
                                               noiseReduction: config.audioNoiseReduction,
                                               turnDebounce: config.turnDebounceSeconds,

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -53,6 +53,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
          silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
+         silenceIdleCutoff: TimeInterval = .infinity,
          silenceDurationMs: Int = 1000, noiseReduction: NoiseReductionMode = .auto,
          turnDebounce: TimeInterval = 0.4, maxBufferedAudioSeconds: TimeInterval = 60) {
         self.apiKey = apiKey
@@ -61,7 +62,8 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         self.transcript = transcript
         self.clock = clock
         self.sessionStart = clock.now()
-        self.silenceBackoff = SilenceBackoff(base: silenceTimeout, maxInterval: silenceMaxInterval)
+        self.silenceBackoff = SilenceBackoff(base: silenceTimeout, maxInterval: silenceMaxInterval,
+                                             idleCutoff: silenceIdleCutoff)
         self.silenceDurationMs = silenceDurationMs
         self.noiseReduction = noiseReduction
         self.turnDebounce = turnDebounce
@@ -350,7 +352,13 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     /// next, longer interval — so a long silence is gently re-checked (the interval doubles each step
     /// up to a cap; see `Config`) rather than nudged once and never again. Must be called on the main queue.
     private func armSilenceTimer() {
-        let interval = silenceBackoff.next()
+        // Past the idle cutoff the user has stepped away — stop probing entirely (each probe bills a
+        // full brain request). The next utterance re-arms via resetSilenceTimer as usual.
+        let quiet = transcript.silenceDuration(now: clock.now() - sessionStart)
+        guard let interval = silenceBackoff.next(quietSoFar: quiet) else {
+            jlog("🤫 quiet for \(Int(quiet))s — pausing silence checks until speech resumes")
+            return
+        }
         lock.lock(); silenceTimer?.invalidate()
         silenceTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             guard let self else { return }

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -40,6 +40,9 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     /// Backs off the proactive silence-check interval across a long quiet stretch. Mutated only on
     /// the main queue (where the silence timer is scheduled and fires), so it needs no extra lock.
     private var silenceBackoff: SilenceBackoff
+    /// Whether the idle-cutoff pause has been logged for the current quiet stretch (log it once, not
+    /// on every dormant re-check). Main-queue only, like `silenceBackoff`.
+    private var silencePausedLogged = false
     private var pingTimer: Timer?
     private var debounceTimer: Timer?         // coalesces rapid fragments into one trigger
     private let pending = UtteranceBuffer()   // fragments heard since the last fired trigger
@@ -343,6 +346,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
             self.silenceBackoff.reset()
+            self.silencePausedLogged = false
             self.armSilenceTimer()
         }
     }
@@ -352,13 +356,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     /// next, longer interval — so a long silence is gently re-checked (the interval doubles each step
     /// up to a cap; see `Config`) rather than nudged once and never again. Must be called on the main queue.
     private func armSilenceTimer() {
-        // Past the idle cutoff the user has stepped away — stop probing entirely (each probe bills a
-        // full brain request). The next utterance re-arms via resetSilenceTimer as usual.
-        let quiet = transcript.silenceDuration(now: clock.now() - sessionStart)
-        guard let interval = silenceBackoff.next(quietSoFar: quiet) else {
-            jlog("🤫 quiet for \(Int(quiet))s — pausing silence checks until speech resumes")
-            return
-        }
+        let interval = silenceBackoff.next()
         lock.lock(); silenceTimer?.invalidate()
         silenceTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
             guard let self else { return }
@@ -373,10 +371,22 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
             // covers the them side, which only feeds the shared transcript and doesn't reset the timer.)
             guard quiet >= interval else {
                 self.silenceBackoff.reset()
+                self.silencePausedLogged = false
                 self.armSilenceTimer()
                 return
             }
-            self.onSilence?(quiet)
+            // Idle cutoff, enforced at FIRE time (a timer scheduled just under the cutoff must not
+            // bill one last probe past it). Past the cutoff the user has stepped away, so suppress
+            // the probe but keep this (free, local) check chain alive: it is the only path that can
+            // revive probing on "them" speech — that side only feeds the shared transcript, and the
+            // guard above then resets the backoff. Mic speech revives via resetSilenceTimer as usual.
+            if self.silenceBackoff.shouldProbe(quietSoFar: quiet) {
+                self.silencePausedLogged = false
+                self.onSilence?(quiet)
+            } else if !self.silencePausedLogged {
+                self.silencePausedLogged = true   // log the pause once, not every capped interval
+                jlog("🤫 quiet for \(Int(quiet))s — pausing silence checks until speech resumes")
+            }
             self.armSilenceTimer()             // re-arm with the next (backed-off) interval
         }
         lock.unlock()

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -126,7 +126,7 @@ public final class CoachDriver: @unchecked Sendable {
         // A hotkey trigger leaves no "🗣 heard:" line (the user pressed a key, didn't speak), so record
         // it — with the synthetic request we pre-fill as the user's message — so the activity viewer
         // shows what the shortcut sent to the brain.
-        if reason == .manualHint { jlog("⌨️ hint shortcut — \(ctx.promptLine)") }
+        if reason == .manualHint, let line = ctx.promptLine { jlog("⌨️ hint shortcut — \(line)") }
 
         // The delta: only the lines the brain hasn't seen yet (the rest live in `history`).
         let delta = transcript.renderFrom(index: currentSentCount())
@@ -150,11 +150,11 @@ public final class CoachDriver: @unchecked Sendable {
         // snapshotted once, so the prefix is stable across the turn's tool-loop iterations (and
         // across turns, history being append-only — that's what keeps the prompt cache hitting).
         let historyBase: [ChatMessage] = [.system(coachSystemPrompt)] + history.snapshot()
-        // Lead with the trigger line; prepend new speech only when there is any (a manual hint often
-        // has none, and an empty "New since last turn" block just buries the real signal).
-        let userText = delta.text.isEmpty
-            ? ctx.promptLine
-            : "New since last turn:\n\(delta.text)\n\n\(ctx.promptLine)"
+        // New speech (when there is any) followed by the trigger note (when there is one — a
+        // turn-end has none, the stamped delta already carries that signal). Never both empty:
+        // an empty turn-end delta is gated above, and silence/manual-hint always have a note.
+        let userText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
+                        ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
         var turnMessages: [ChatMessage] = [.user(userText)]
 
         // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and
@@ -200,7 +200,7 @@ public final class CoachDriver: @unchecked Sendable {
                 // Speech already marked sent (a later-iteration failure) must not vanish from memory —
                 // commit what this turn accumulated. A first-request failure commits nothing; the
                 // un-advanced sentCount re-sends the delta next turn instead.
-                if committed { history.commit(turnMessages) }
+                if committed { commitIfWorthKeeping(turnMessages, deltaText: delta.text) }
                 return .brainError
             }
             // The input provably reached the server — NOW mark the delta as sent.
@@ -208,7 +208,7 @@ public final class CoachDriver: @unchecked Sendable {
 
             if Task.isCancelled {
                 jlog("… turn cancelled (stopped) mid-think")
-                history.commit(turnMessages)   // the delta was sent; keep memory consistent with it
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text)   // the delta was sent; keep memory consistent with it
                 return .cancelled
             }
 
@@ -216,7 +216,7 @@ public final class CoachDriver: @unchecked Sendable {
             // model ignoring `tool_choice: required`. Treat the latter as silence — rendering nothing
             // is the safe interpretation. Either way the sent delta must land in memory.
             guard let call = response.toolCalls.first else {
-                history.commit(turnMessages)
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text)
                 if let reasonText = response.incompleteReason {
                     jlog("⚠️ response truncated (\(reasonText)) — not deliberate silence")
                     return .truncated
@@ -279,7 +279,7 @@ public final class CoachDriver: @unchecked Sendable {
                 // The model's explicit stay-quiet decision. Deliberately NOT recorded: the call and
                 // its non-answer would only bloat every later request — silence needs no memory.
                 jlog("… nothing useful to add, staying silent")
-                history.commit(turnMessages)
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text)
                 await compactIfNeeded()
                 return .silentByModel
             }
@@ -288,6 +288,16 @@ public final class CoachDriver: @unchecked Sendable {
         history.commit(turnMessages)   // captures + speech stay in memory even on the backstop path
         await compactIfNeeded()
         return .exhausted
+    }
+
+    /// Commit a finished turn to session memory ONLY when it left something a later turn can use —
+    /// new transcript lines, or tool activity (a capture the model may refer back to). A turn that
+    /// was just a trigger note the model shrugged at (a silence check → stay_silent) is dropped
+    /// whole: committing it would pile up answerless user messages in memory, re-billed on every
+    /// later request and confusing to read back.
+    private func commitIfWorthKeeping(_ turn: [ChatMessage], deltaText: String) {
+        guard !deltaText.isEmpty || turn.count > 1 else { return }
+        history.commit(turn)
     }
 
     /// The capture_screen tool-result text: the OCR sidecar rides here when present, so exact text

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -39,10 +39,11 @@ you decide, and staying quiet remains the default when "me" is doing fine.
 You cannot see the screen unless you call capture_screen — do that when you need to read the problem or
 their code to be specific and correct.
 
-Each turn you get timing context: a transcript (each line stamped [mm:ss]), why the turn fired (the
-user spoke, a silence, or a manual hint), and how long the session has run. Use it: early in a session
-the problem may not be on screen yet, so capture before assuming they're stuck; the longer the silence,
-the more likely they are stuck rather than thinking.
+Each turn you get timing context. New speech arrives under "New since last turn", each line stamped
+[mm:ss] with session time — its presence means someone just finished speaking. A quiet stretch
+arrives instead as a note like "[12:40] (no speech for 2m 26s)". Use the timing: early in a session
+the problem may not be on screen yet, so capture before assuming they're stuck; the longer the
+silence, the more likely they are stuck rather than thinking.
 
 Every turn, answer with exactly one tool call — speak, capture_screen, or stay_silent. Never write
 plain text output: it is not shown to anyone, it just pollutes the conversation.

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -9,6 +9,10 @@ public struct Config: Sendable {
     /// Upper bound on the silence-check interval as it backs off, so a long silence still gets an
     /// occasional gentle check rather than going dark forever.
     public var silenceMaxIntervalSeconds: TimeInterval
+    /// Stop the silence checks entirely once the user has been continuously quiet this long — they
+    /// have stepped away, and every probe into the empty room still bills a full-history brain
+    /// request (often plus a screenshot). Speech re-arms the checks from the base interval.
+    public var silenceIdleCutoffSeconds: TimeInterval
     /// When the client-managed session memory (`CoachHistory`) grows past this many estimated tokens,
     /// the driver condenses its oldest span into a short summary (see `CoachDriver.compactIfNeeded`).
     /// Sized to industry practice for conversational loads (~5–20k): big enough that compaction is
@@ -51,6 +55,7 @@ public struct Config: Sendable {
     public init(
         silenceTimeoutSeconds: TimeInterval = 120,
         silenceMaxIntervalSeconds: TimeInterval = 960,
+        silenceIdleCutoffSeconds: TimeInterval = 1_800,
         historyCompactionTokenThreshold: Int = 10_000,
         overlayNoticeBufferSeconds: TimeInterval = 2.0,
         overlaySecondsPerWord: TimeInterval = 0.35,
@@ -63,6 +68,7 @@ public struct Config: Sendable {
     ) {
         self.silenceTimeoutSeconds = silenceTimeoutSeconds
         self.silenceMaxIntervalSeconds = silenceMaxIntervalSeconds
+        self.silenceIdleCutoffSeconds = silenceIdleCutoffSeconds
         self.historyCompactionTokenThreshold = historyCompactionTokenThreshold
         self.overlayNoticeBufferSeconds = overlayNoticeBufferSeconds
         self.overlaySecondsPerWord = overlaySecondsPerWord

--- a/Sources/JarvisCore/Triggers/SilenceBackoff.swift
+++ b/Sources/JarvisCore/Triggers/SilenceBackoff.swift
@@ -7,18 +7,27 @@ import Foundation
 /// calls `reset()`, so the next quiet gap starts from `base` again. This avoids both over-nudging
 /// (a flat short timer firing every few seconds) and under-nudging (a single one-shot timer that
 /// never checks again through a long silence).
+///
+/// Past `idleCutoff` of continuous quiet, `next(quietSoFar:)` returns nil: the user has stepped
+/// away, and each probe into the empty room still costs a full brain request. Speech re-arms via
+/// `reset()` as usual.
 public struct SilenceBackoff {
     private let base: TimeInterval
     private let maxInterval: TimeInterval
+    private let idleCutoff: TimeInterval
     private var step = 0
 
-    public init(base: TimeInterval, maxInterval: TimeInterval) {
+    public init(base: TimeInterval, maxInterval: TimeInterval, idleCutoff: TimeInterval = .infinity) {
         self.base = base
         self.maxInterval = maxInterval
+        self.idleCutoff = idleCutoff
     }
 
-    /// The interval to wait before the next silence check, then advance the backoff one step.
-    public mutating func next() -> TimeInterval {
+    /// The interval to wait before the next silence check (advancing the backoff one step) — or nil
+    /// once `quietSoFar` (how long the user has already been quiet) reaches the idle cutoff, meaning:
+    /// stop probing until speech resumes.
+    public mutating func next(quietSoFar: TimeInterval = 0) -> TimeInterval? {
+        guard quietSoFar < idleCutoff else { return nil }
         let interval = min(base * pow(2, Double(step)), maxInterval)
         step += 1
         return interval

--- a/Sources/JarvisCore/Triggers/SilenceBackoff.swift
+++ b/Sources/JarvisCore/Triggers/SilenceBackoff.swift
@@ -8,9 +8,10 @@ import Foundation
 /// (a flat short timer firing every few seconds) and under-nudging (a single one-shot timer that
 /// never checks again through a long silence).
 ///
-/// Past `idleCutoff` of continuous quiet, `next(quietSoFar:)` returns nil: the user has stepped
-/// away, and each probe into the empty room still costs a full brain request. Speech re-arms via
-/// `reset()` as usual.
+/// Past `idleCutoff` of continuous quiet, `shouldProbe(quietSoFar:)` turns false: the user has
+/// stepped away, and each probe into the empty room still costs a full brain request. Only the
+/// probe is suppressed — the caller keeps its (free, local) check running, so probing resumes as
+/// soon as speech from either side restarts the quiet stretch.
 public struct SilenceBackoff {
     private let base: TimeInterval
     private let maxInterval: TimeInterval
@@ -23,14 +24,19 @@ public struct SilenceBackoff {
         self.idleCutoff = idleCutoff
     }
 
-    /// The interval to wait before the next silence check (advancing the backoff one step) — or nil
-    /// once `quietSoFar` (how long the user has already been quiet) reaches the idle cutoff, meaning:
-    /// stop probing until speech resumes.
-    public mutating func next(quietSoFar: TimeInterval = 0) -> TimeInterval? {
-        guard quietSoFar < idleCutoff else { return nil }
+    /// The interval to wait before the next silence check, then advance the backoff one step.
+    public mutating func next() -> TimeInterval {
         let interval = min(base * pow(2, Double(step)), maxInterval)
         step += 1
         return interval
+    }
+
+    /// Whether a check that just fired should actually probe (drive a brain request): true while
+    /// the current quiet stretch is under the idle cutoff. Evaluated at FIRE time, not schedule
+    /// time, so a timer that crosses the cutoff mid-wait stays quiet instead of billing one last
+    /// request past the deadline.
+    public func shouldProbe(quietSoFar: TimeInterval) -> Bool {
+        quietSoFar < idleCutoff
     }
 
     /// Reset to the base interval — call when speech is heard.

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -17,16 +17,33 @@ public struct TriggerContext: Sendable {
         self.sessionElapsedSeconds = sessionElapsedSeconds
     }
 
-    /// A one-line natural-language summary appended to the user message.
-    public var promptLine: String {
-        let elapsed = Int(sessionElapsedSeconds)
+    /// The trigger note appended to the user message — or nil when the message already says it all.
+    /// A turn-end adds nothing: the "New since last turn" block IS the signal, its [mm:ss] stamps
+    /// carry the timing, and a boilerplate sentence on top would be committed to memory and re-billed
+    /// on every later request. The notes that remain (silence, manual hint) open with the same
+    /// [mm:ss] session stamp as transcript lines, so the model reads all timing in one idiom.
+    public var promptLine: String? {
+        let stamp = RollingTranscript.stamp(sessionElapsedSeconds)
         switch reason {
         case .turnEnd:
-            return "Trigger: a turn just ended. The session has been running for \(elapsed)s."
+            return nil
         case .silence(let secs):
-            return "Trigger: the user has been silent for \(Int(secs))s. The session has been running for \(elapsed)s."
+            return "[\(stamp)] (no speech for \(Self.durationPhrase(secs)))"
         case .manualHint:
-            return "Trigger: the user pressed the hint shortcut. They want your single most useful hint about what's on their screen right now — answer using the attached screenshot and the recent transcript. The session has been running for \(elapsed)s."
+            return "[\(stamp)] The user pressed the hint shortcut. They want your single most useful hint about what's on their screen right now — answer using the attached screenshot and the recent transcript."
         }
+    }
+
+    /// Human-readable duration ("45s", "2m 26s", "3h 30m"): a quiet stretch can run to hours, where
+    /// a raw seconds count makes the model (and anyone reading the request log) do arithmetic.
+    static func durationPhrase(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds.rounded(.down))
+        if total < 60 { return "\(total)s" }
+        if total < 3600 {
+            let (m, s) = (total / 60, total % 60)
+            return s == 0 ? "\(m)m" : "\(m)m \(s)s"
+        }
+        let (h, m) = (total / 3600, (total % 3600) / 60)
+        return m == 0 ? "\(h)h" : "\(h)h \(m)m"
     }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -3,9 +3,9 @@ import Testing
 @testable import JarvisCore
 
 /// How the per-turn user message is assembled (CoachDriver.runTurn): new speech is wrapped in a
-/// "New since last turn:" block ONLY when there is any, and the turn always ends with the trigger
-/// line. A turn with no new speech (a silence wake-up, or a manual hint with nothing said since)
-/// must lead with the trigger line alone — no empty wrapper, no "(nothing new)" filler.
+/// "New since last turn:" block ONLY when there is any, followed by the trigger note ONLY when the
+/// trigger has one — a turn-end has none (the stamped delta already says the user just spoke), so
+/// its message is the bare block; a silence wake-up with nothing said is the bare note.
 @Suite struct CoachDriverContextMessageTests {
     private func makeDriver(brain: BrainClient, clock: Clock) -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
@@ -21,34 +21,41 @@ import Testing
         brain.calls.last?.first { $0.role == .user }?.text
     }
 
-    /// New speech is wrapped in the "New since last turn:" block, the trigger line follows it, and the
-    /// stale "(timestamped)" header is gone (lines already carry their own [mm:ss] stamps).
-    @Test func newSpeechIsWrappedAndFollowedByTheTriggerLine() async {
+    /// A turn-end sends the delta block and nothing else: no boilerplate trigger sentence to be
+    /// committed and re-billed every turn — the [mm:ss] stamps already carry the timing.
+    @Test func turnEndSendsTheDeltaBlockAlone() async {
         let brain = ScriptedBrain(script: [.init(toolCalls: [])])   // stay silent → one call
         let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
         transcript.append(.init(speaker: .me, text: "brute force two-sum", at: 0))
 
         await driver.handleTrigger(.turnEnd)
 
-        let msg = lastUserMessage(brain)
-        #expect(msg?.hasPrefix("New since last turn:\n") == true)
-        #expect(msg?.contains("brute force two-sum") == true)
-        #expect(msg?.contains("a turn just ended") == true)   // trigger line rides along
-        #expect(msg?.contains("(timestamped)") == false)      // dropped header
+        #expect(lastUserMessage(brain) == "New since last turn:\n[00:00] me: brute force two-sum")
     }
 
-    /// No new speech (a silence wake-up with nothing said): the message is the bare trigger line —
+    /// No new speech (a silence wake-up with nothing said): the message is the bare trigger note —
     /// no "New since last turn" wrapper and no "(nothing new)" filler burying the real signal.
-    @Test func emptySpeechSendsOnlyTheTriggerLine() async {
+    @Test func emptySpeechSendsOnlyTheTriggerNote() async {
         let brain = ScriptedBrain(script: [.init(toolCalls: [])])
         let (driver, _) = makeDriver(brain: brain, clock: ManualClock(now: 0))   // empty transcript
 
         await driver.handleTrigger(.silence(secondsQuiet: 30))
 
-        let expected = TriggerContext(reason: .silence(secondsQuiet: 30), sessionElapsedSeconds: 0).promptLine
         let msg = lastUserMessage(brain)
-        #expect(msg == expected)
+        #expect(msg == "[00:00] (no speech for 30s)")
         #expect(msg?.contains("New since last turn") == false)
         #expect(msg?.contains("nothing new") == false)
+    }
+
+    /// A silence wake-up WITH unsent speech carries both: the delta block first, then the note.
+    @Test func silenceWithNewSpeechCarriesBlockThenNote() async {
+        let brain = ScriptedBrain(script: [.init(toolCalls: [])])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "hmm let me think", at: 0))
+
+        await driver.handleTrigger(.silence(secondsQuiet: 45))
+
+        #expect(lastUserMessage(brain) ==
+                "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
     }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -301,7 +301,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 
         transcript.append(.init(speaker: .me, text: "ok here is an idea", at: 5))
         await driver.handleTrigger(.turnEnd)
-        #expect(!brain.calls[1].contains { ($0.text ?? "").contains("no speech for") })
+        // Scoped to user messages: the system prompt legitimately shows a "(no speech for …)" example.
+        #expect(!brain.calls[1].contains { $0.role == .user && ($0.text ?? "").contains("no speech for") })
     }
 
     /// But a silence check where the model DID look at the screen keeps the whole turn in memory —
@@ -321,8 +322,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         transcript.append(.init(speaker: .me, text: "ok here is an idea", at: 5))
         await driver.handleTrigger(.turnEnd)
         let last = brain.calls.last!
-        #expect(last.contains { ($0.text ?? "").contains("no speech for") })          // the note survives
-        #expect(last.contains { $0.role == .tool && $0.toolCallId == "c1" })          // with its capture
+        #expect(last.contains { $0.role == .user && ($0.text ?? "").contains("no speech for") })   // the note survives
+        #expect(last.contains { $0.role == .tool && $0.toolCallId == "c1" })                        // with its capture
     }
 
     /// Defensive: a model that answers with NO tool call despite `required` still reads as deliberate

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -289,6 +289,42 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(!second.contains { $0.role == .tool })                                       // no dangling result
     }
 
+    /// A silence check the model shrugs at (stay_silent, nothing new said) leaves NO trace in the
+    /// session memory: committing its bare trigger note would pile up answerless user messages,
+    /// re-billed on every later request and confusing to read back in the request log.
+    @Test func silentSilenceCheckLeavesNoTriggerNoteInHistory() async {
+        let clock = ManualClock(now: 0)
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "q1")],
+                                                 rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")])])
+        let (driver, transcript) = makeDriver(brain: brain, clock: clock)
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 120)) == .silentByModel)
+
+        transcript.append(.init(speaker: .me, text: "ok here is an idea", at: 5))
+        await driver.handleTrigger(.turnEnd)
+        #expect(!brain.calls[1].contains { ($0.text ?? "").contains("no speech for") })
+    }
+
+    /// But a silence check where the model DID look at the screen keeps the whole turn in memory —
+    /// the capture (and the note that prompted it) is context a later turn can build on.
+    @Test func silenceCheckWithCaptureIsKeptInHistory() async {
+        let clock = ManualClock(now: 0)
+        let brain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "c1")],
+                  rawToolCalls: [RawToolCall(id: "c1", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(toolCalls: [.staySilent(callId: "q1")],
+                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")]),
+            .init(toolCalls: []),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: clock)
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 120)) == .silentByModel)
+
+        transcript.append(.init(speaker: .me, text: "ok here is an idea", at: 5))
+        await driver.handleTrigger(.turnEnd)
+        let last = brain.calls.last!
+        #expect(last.contains { ($0.text ?? "").contains("no speech for") })          // the note survives
+        #expect(last.contains { $0.role == .tool && $0.toolCallId == "c1" })          // with its capture
+    }
+
     /// Defensive: a model that answers with NO tool call despite `required` still reads as deliberate
     /// silence — render nothing rather than fail the turn.
     @Test func noToolCallsStillRendersNothing() async {

--- a/Tests/JarvisCoreTests/Config/ConfigTests.swift
+++ b/Tests/JarvisCoreTests/Config/ConfigTests.swift
@@ -6,6 +6,7 @@ import Testing
         let c = Config.default
         #expect(c.silenceTimeoutSeconds == 120)
         #expect(c.silenceMaxIntervalSeconds == 960)
+        #expect(c.silenceIdleCutoffSeconds == 1_800)
         #expect(c.historyCompactionTokenThreshold == 10_000)
         #expect(c.overlayNoticeBufferSeconds == 2.0)
         #expect(c.overlaySecondsPerWord == 0.35)

--- a/Tests/JarvisCoreTests/Triggers/SilenceBackoffTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/SilenceBackoffTests.swift
@@ -33,29 +33,28 @@ import Testing
         #expect(b.next() == 30)
     }
 
-    /// Once the quiet stretch reaches the idle cutoff, probing stops (nil): the user has stepped
-    /// away, and each probe into the empty room still bills a full brain request.
-    @Test func idleCutoffStopsProbing() {
-        var b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
-        #expect(b.next(quietSoFar: 0) == 30)
-        #expect(b.next(quietSoFar: 1799) != nil)   // just under the cutoff: still probing
-        #expect(b.next(quietSoFar: 1800) == nil)   // at the cutoff: stop
-        #expect(b.next(quietSoFar: 9999) == nil)
+    /// The idle cutoff gates the PROBE (the brain request), not the schedule: `shouldProbe` is
+    /// evaluated against the quiet stretch at fire time, so a check that crosses the cutoff
+    /// mid-wait stays quiet instead of billing one last request past the deadline.
+    @Test func shouldProbeStopsAtTheIdleCutoff() {
+        let b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
+        #expect(b.shouldProbe(quietSoFar: 0))
+        #expect(b.shouldProbe(quietSoFar: 1799))    // just under the cutoff: still probing
+        #expect(!b.shouldProbe(quietSoFar: 1800))   // at the cutoff: suppressed
+        #expect(!b.shouldProbe(quietSoFar: 9999))
     }
 
-    /// The cutoff gates on the CURRENT quiet stretch, so speech (which resets the stretch) re-arms
-    /// probing — the next gap is measured afresh from zero.
+    /// The cutoff gates on the CURRENT quiet stretch: once speech (either side) restarts it,
+    /// probing resumes — a shorter `quietSoFar` probes again without any state to clear.
     @Test func probingResumesOnceQuietStretchRestarts() {
-        var b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
-        _ = b.next(quietSoFar: 0); _ = b.next(quietSoFar: 30)   // advance to 120
-        #expect(b.next(quietSoFar: 2000) == nil)                // gone idle
-        b.reset()                                               // speech heard
-        #expect(b.next(quietSoFar: 10) == 30)                   // probing again, from the base
+        let b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
+        #expect(!b.shouldProbe(quietSoFar: 2000))   // gone idle
+        #expect(b.shouldProbe(quietSoFar: 10))      // speech restarted the stretch: probing again
     }
 
     /// Without an explicit cutoff, probing never stops (the default keeps old behavior).
     @Test func defaultHasNoIdleCutoff() {
-        var b = SilenceBackoff(base: 30, maxInterval: 240)
-        #expect(b.next(quietSoFar: 1e9) == 30)
+        let b = SilenceBackoff(base: 30, maxInterval: 240)
+        #expect(b.shouldProbe(quietSoFar: 1e9))
     }
 }

--- a/Tests/JarvisCoreTests/Triggers/SilenceBackoffTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/SilenceBackoffTests.swift
@@ -32,4 +32,30 @@ import Testing
         b.reset()
         #expect(b.next() == 30)
     }
+
+    /// Once the quiet stretch reaches the idle cutoff, probing stops (nil): the user has stepped
+    /// away, and each probe into the empty room still bills a full brain request.
+    @Test func idleCutoffStopsProbing() {
+        var b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
+        #expect(b.next(quietSoFar: 0) == 30)
+        #expect(b.next(quietSoFar: 1799) != nil)   // just under the cutoff: still probing
+        #expect(b.next(quietSoFar: 1800) == nil)   // at the cutoff: stop
+        #expect(b.next(quietSoFar: 9999) == nil)
+    }
+
+    /// The cutoff gates on the CURRENT quiet stretch, so speech (which resets the stretch) re-arms
+    /// probing — the next gap is measured afresh from zero.
+    @Test func probingResumesOnceQuietStretchRestarts() {
+        var b = SilenceBackoff(base: 30, maxInterval: 240, idleCutoff: 1800)
+        _ = b.next(quietSoFar: 0); _ = b.next(quietSoFar: 30)   // advance to 120
+        #expect(b.next(quietSoFar: 2000) == nil)                // gone idle
+        b.reset()                                               // speech heard
+        #expect(b.next(quietSoFar: 10) == 30)                   // probing again, from the base
+    }
+
+    /// Without an explicit cutoff, probing never stops (the default keeps old behavior).
+    @Test func defaultHasNoIdleCutoff() {
+        var b = SilenceBackoff(base: 30, maxInterval: 240)
+        #expect(b.next(quietSoFar: 1e9) == 30)
+    }
 }

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -2,13 +2,43 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct TriggerContextTests {
-    @Test func turnEndPromptLineIsSpeakerNeutralAndDescribesSessionElapsed() {
+    /// A turn-end adds NO trigger note: the "New since last turn" block (with its [mm:ss] stamps)
+    /// already says the user just spoke and when — a boilerplate sentence on top would be committed
+    /// to memory and re-billed on every later request.
+    @Test func turnEndHasNoPromptLine() {
         let ctx = TriggerContext(reason: .turnEnd, sessionElapsedSeconds: 95)
-        #expect(ctx.promptLine == "Trigger: a turn just ended. The session has been running for 95s.")
+        #expect(ctx.promptLine == nil)
     }
 
-    @Test func silencePromptLineDescribesQuietDurationAndSessionElapsed() {
-        let ctx = TriggerContext(reason: .silence(secondsQuiet: 120), sessionElapsedSeconds: 600)
-        #expect(ctx.promptLine == "Trigger: the user has been silent for 120s. The session has been running for 600s.")
+    /// A silence check reads like a transcript line: the session stamp plus how long the quiet has
+    /// lasted, in human units (no raw seconds arithmetic for the model or a log reader).
+    @Test func silencePromptLineIsStampedAndHumanReadable() {
+        let ctx = TriggerContext(reason: .silence(secondsQuiet: 146), sessionElapsedSeconds: 1225)
+        #expect(ctx.promptLine == "[20:25] (no speech for 2m 26s)")
+    }
+
+    @Test func shortSilenceStaysInSeconds() {
+        let ctx = TriggerContext(reason: .silence(secondsQuiet: 45), sessionElapsedSeconds: 60)
+        #expect(ctx.promptLine == "[01:00] (no speech for 45s)")
+    }
+
+    @Test func hourLongSilenceSpellsHoursAndMinutes() {
+        let ctx = TriggerContext(reason: .silence(secondsQuiet: 12640), sessionElapsedSeconds: 13719)
+        #expect(ctx.promptLine == "[228:39] (no speech for 3h 30m)")
+    }
+
+    /// The manual hint keeps its instruction (it's rare and carries real semantics), stamped the
+    /// same way — and the old raw-seconds "running for Ns" sentence is gone.
+    @Test func manualHintPromptLineCarriesInstructionAndStamp() {
+        let ctx = TriggerContext(reason: .manualHint, sessionElapsedSeconds: 600)
+        #expect(ctx.promptLine?.hasPrefix("[10:00]") == true)
+        #expect(ctx.promptLine?.contains("hint shortcut") == true)
+        #expect(ctx.promptLine?.contains("running for") == false)
+    }
+
+    /// Exact-minute and exact-hour durations drop the zero component.
+    @Test func durationPhraseDropsZeroComponents() {
+        #expect(TriggerContext.durationPhrase(120) == "2m")
+        #expect(TriggerContext.durationPhrase(7200) == "2h")
     }
 }

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -54,7 +54,9 @@ moments the model judges worthwhile.
 1. The Transcriber emits a **turn-end** event (`gpt-4o-transcribe` server VAD ends the turn after a
    tuned silence window) or a **silence check** fires (you've gone quiet, maybe stuck). The silence
    check carries *how long* you've been quiet and backs off across a long silence (the interval
-   doubles each step up to a cap — see `Config`), resetting on speech.
+   doubles each step up to a cap — see `Config`), resetting on speech; past an idle cutoff it stops
+   probing entirely (you've stepped away — a nudge into an empty room still bills a request) until
+   speech re-arms it.
 2. The CoachDriver calls the brain on every trigger that carries **substance** — there is no
    cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's


### PR DESCRIPTION
## Why

Reading the raw OpenAI request logs from a real session showed the context we send is noisier — and in two places outright wrong — compared to what the code intends:

1. The first turn of a new session carried **18 minutes of a previous session's transcript** ("Hey Jin Changzhen…") stamped against a dead clock, 11s into the run.
2. The same stale lines corrupted the silence math: `lastSpeechTime` stayed pinned at the ghost utterance (`1225s − 146s = 1079s = [17:59]`, the old session's last line).
3. Silence checks that ended in `stay_silent` left **dangling, answerless user messages** in session memory, re-billed on every later request.
4. Every turn carried boilerplate ("Trigger: a turn just ended. The session has been running for 130s.") that duplicates what the `[mm:ss]` stamps already say.
5. Silence probes kept firing **3.5 hours into an empty room**, a full-history request every 960s.

## What

- **Fresh `RollingTranscript` per `start()`** (`AppDelegate`): the transcript now lives and dies with the driver/transcriber pair that own its clock base and sent-index. Fixes 1 and 2.
- **Commit-worthiness gate** (`CoachDriver.commitIfWorthKeeping`): a turn is committed to `CoachHistory` only when it carries new transcript lines or tool activity; a bare trigger note the model shrugged at leaves no trace. Fixes 3.
- **Slim trigger notes** (`Trigger.swift`, system prompt): turn-end sends just the `New since last turn` block; a silence check is a transcript-style note — `[20:25] (no speech for 2m 26s)` — with human-readable durations; the manual hint keeps its instruction in the same idiom. Sent bytes stay byte-identical to committed bytes, so the append-only prompt-cache property is preserved. Fixes 4.
- **Idle cutoff** (`SilenceBackoff`, `Config.silenceIdleCutoffSeconds = 1800`): after 30 min of continuous quiet the checks stop; the next utterance re-arms them from the base interval. Fixes 5.

## Tests

- `TriggerContextTests`: new note formats, nil for turn-end, duration phrasing (s/m/h).
- `SilenceBackoffTests`: cutoff stops probing, reset re-arms, default keeps old behavior.
- `CoachDriverContextMessageTests`: exact per-turn user-message shapes for turn-end / bare silence / silence-with-speech.
- `CoachDriverPipelineTests`: a shrugged-at silence check leaves no history trace; one that captured is kept.
- `ConfigTests`: new default pinned.

Verified here (Linux): `swift build --target JarvisCore` and `--target JarvisCoreTests` compile clean. The full Gate (`swift build && ./scripts/run-tests.sh`) needs macOS — CI runs it on this PR; please also give it a live smoke run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)