### PR TITLE
feat(eval): reopen saved report instead of re-evaluating an audited session

### DIFF
--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -76,8 +76,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
 
         let evaluate = NSButton(title: "Evaluate", target: self, action: #selector(evaluateTapped))
         evaluate.bezelStyle = .rounded
-        evaluate.toolTip = "Send this session's recorded LLM traffic to the brain model for a context-engineering audit (stopped sessions only)"
-        evaluate.frame = NSRect(x: content.bounds.width - 232, y: 8, width: 90, height: 28)
+        evaluate.frame = NSRect(x: content.bounds.width - 246, y: 8, width: 104, height: 28)
         evaluate.autoresizingMask = [.minXMargin]
         header.addSubview(evaluate)
         self.evaluateButton = evaluate
@@ -154,18 +153,33 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
 
     /// Evaluate is enabled only for a *finished* conversation: any past session, or the current one
     /// once coaching is stopped. A live session's traffic file is still being appended to, so an
-    /// audit of it would judge half a story. Owns the title too: `isEvaluating` survives a Settings
-    /// close/reopen (the viewer outlives its content view), so a rebuilt button mid-audit correctly
-    /// shows "Evaluating…" disabled instead of inviting a duplicate audit.
+    /// audit of it would judge half a story. A session that already has a persisted report flips the
+    /// button to "Show report" instead — reopening the saved audit is free and always safe, so it
+    /// stays enabled regardless of coaching state. Owns the title too: `isEvaluating` survives a
+    /// Settings close/reopen (the viewer outlives its content view), so a rebuilt button mid-audit
+    /// correctly shows "Evaluating…" disabled instead of inviting a duplicate audit.
     private func refreshEvaluateButtonState() {
         guard let button = evaluateButton else { return }
-        button.title = isEvaluating ? "Evaluating…" : "Evaluate"
-        if isEvaluating { button.isEnabled = false; return }
-        guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else {
+        if isEvaluating {
+            button.title = "Evaluating…"
             button.isEnabled = false
             return
         }
-        button.isEnabled = !(sessions[idx].isCurrent && (isCoachingRunning?() ?? false))
+        guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else {
+            button.title = "Evaluate"
+            button.isEnabled = false
+            return
+        }
+        let session = sessions[idx]
+        if SessionEvaluator.savedReport(in: session.url) != nil {
+            button.title = "Show report"
+            button.toolTip = "Open the evaluation report already generated for this session"
+            button.isEnabled = true
+        } else {
+            button.title = "Evaluate"
+            button.toolTip = "Send this session's recorded LLM traffic to the brain model for a context-engineering audit (stopped sessions only)"
+            button.isEnabled = !(session.isCurrent && (isCoachingRunning?() ?? false))
+        }
     }
 
     // MARK: - Loading
@@ -231,13 +245,18 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
     // MARK: - Session evaluation
 
     /// One click: send the selected session's recorded brain traffic to the evaluation model and
-    /// show (and persist) the resulting audit report. Only *stopped* conversations qualify: any past
-    /// session, or the current one once coaching is stopped. The button is already disabled for the
-    /// live session (`refreshEvaluateButtonState`); the guard here is the race-proof backstop for a
-    /// click that lands exactly as a Start flips the state.
+    /// show (and persist) the resulting audit report. A session that was already evaluated just
+    /// reopens its saved report — no re-billing. Only *stopped* conversations qualify for a fresh
+    /// audit: any past session, or the current one once coaching is stopped. The button is already
+    /// disabled for the live session (`refreshEvaluateButtonState`); the guard here is the
+    /// race-proof backstop for a click that lands exactly as a Start flips the state.
     @objc private func evaluateTapped() {
         guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else { return }
         let session = sessions[idx]
+        if let report = SessionEvaluator.savedReport(in: session.url) {
+            showReport(report, for: session)
+            return
+        }
         if session.isCurrent, isCoachingRunning?() == true {
             info("Session still running",
                  "Evaluation works on a finished conversation. Stop Jarvis first, then evaluate this session.")

--- a/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
@@ -33,6 +33,15 @@ public struct SessionEvaluator: Sendable {
         }
     }
 
+    /// The report persisted by an earlier `evaluate`, if any. Lets the viewer reopen a finished
+    /// audit ("Show report") instead of re-billing an evaluation of the same session.
+    public static func savedReport(in sessionDir: URL) -> String? {
+        let url = sessionDir.appendingPathComponent(reportFilename)
+        guard let report = try? String(contentsOf: url, encoding: .utf8), !report.isEmpty
+        else { return nil }
+        return report
+    }
+
     /// Whether a session has anything to evaluate (a non-empty traffic file).
     public static func hasTraffic(in sessionDir: URL) -> Bool {
         let url = sessionDir.appendingPathComponent(BrainTrafficLog.filename)
@@ -55,7 +64,8 @@ public struct SessionEvaluator: Sendable {
         guard let report = response.outputText, !report.isEmpty else {
             throw EvaluationError.emptyReport
         }
-        FileManager.default.createFile(
+        // A failed write is tolerable: the report is still shown; only "Show report" reuse is lost.
+        _ = FileManager.default.createFile(
             atPath: sessionDir.appendingPathComponent(Self.reportFilename).path,
             contents: Data(report.utf8), attributes: [.posixPermissions: 0o600])
         return report

--- a/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
@@ -112,6 +112,24 @@ private final class CannedBrain: BrainClient, @unchecked Sendable {
         #expect(perms?.int16Value == 0o600)
     }
 
+    /// `savedReport` is the "Show report" gate: nil until an evaluation persisted a report, then the
+    /// exact saved text — and an empty file (a failed/interrupted write) must not count as a report.
+    @Test func savedReportReturnsPersistedReportOnly() async throws {
+        let dir = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(SessionEvaluator.savedReport(in: dir) == nil)
+
+        let traffic = BrainTrafficLog(); traffic.enable(directory: dir)
+        traffic.record(tag: "coach",
+                       request: Data(#"{"model":"gpt-5.5","input":[]}"#.utf8),
+                       response: Data(#"{"status":"completed","output":[]}"#.utf8),
+                       status: 200, latencyMs: 300)
+        let report = try await SessionEvaluator(brain: CannedBrain(text: "## Audit\nfine")).evaluate(sessionDir: dir)
+        #expect(SessionEvaluator.savedReport(in: dir) == report)
+
+        try Data().write(to: dir.appendingPathComponent(SessionEvaluator.reportFilename))
+        #expect(SessionEvaluator.savedReport(in: dir) == nil)
+    }
+
     @Test func evaluateThrowsWhenSessionHasNoTraffic() async throws {
         let dir = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         #expect(!SessionEvaluator.hasTraffic(in: dir))


### PR DESCRIPTION
## What

When the selected session already has a persisted `eval-report.md`, the activity viewer's **Evaluate** button becomes **Show report** and one click reopens the saved audit — no re-billing an evaluation of the same session.

- New `SessionEvaluator.savedReport(in:)` (Core) reads back the report that `evaluate()` already persists; an empty file (interrupted write) doesn't count as a report.
- `refreshEvaluateButtonState()` switches title + tooltip per state. "Show report" stays enabled even while coaching runs — opening a saved file is always safe; the stopped-sessions-only rule still gates fresh audits. The button flips to "Show report" right after a successful evaluation (the existing post-audit refresh picks it up).
- `evaluateTapped()` short-circuits to `showReport(...)` when a saved report exists.
- Button widened 90 → 104 pt so "Show report" fits; sentence case matches "Clear history".
- Silenced the pre-existing unused-result warning on the report write while in that function.

## Testing

- New test `savedReportReturnsPersistedReportOnly` pins the helper's contract: nil before evaluation → exact saved text after → nil again for an empty file.
- `swiftc -typecheck` over `JarvisCore` passes on this (Linux) box; the full Gate (`swift build && ./scripts/run-tests.sh`) and the click-through (Evaluate → reopen → "Show report") need a Mac — please run before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)