### PR TITLE
feat(menubar): minimal icon-prefixed menu via one standard item format

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -177,9 +177,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // and anchor the silence math to that run's last utterance instead of real quiet time.
         transcript = RollingTranscript()
         if freshSession {
-            beginNewSession()       // rotate to a fresh session dir + activity/debug log
-            menuBar.resetCounter()  // a user Start begins a fresh session
-            overlayBox.clear()      // …and a fresh response history for the new conversation
+            beginNewSession()  // rotate to a fresh session dir + activity/debug log
+            overlayBox.clear() // …and a fresh response history for the new conversation
         }
 
         // Both clients record their wire traffic into the session's `brain-traffic.jsonl` (enabled in
@@ -202,8 +201,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let driver = CoachDriver(config: config, transcript: transcript,
                                  brain: brain, summarizer: summarizer,
                                  screen: WindowScopedScreenCapture(preferences: screenPreferences),
-                                 overlay: overlaySink, clock: clock,
-                                 onSpoke: { [weak self] in Task { @MainActor in self?.menuBar.noteSpoke() } })
+                                 overlay: overlaySink, clock: clock)
 
         // CoachDriver is @unchecked Sendable; capture it (not @MainActor self) in the callbacks.
         // Route turns through TurnTaskBox so Stop can cancel an in-flight one. Concurrent triggers are

--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -1,8 +1,8 @@
 import AppKit
 
-/// Menu-bar status item: start/stop, live connection health, Settings, and the session interjection
-/// counter. The icon is full-colour only while mic transcription is actually ready; starting and
-/// reconnecting stay visibly distinct from a healthy listening session.
+/// Menu-bar status item: Start/Stop, Settings, Quit — every item in the standard icon+title format
+/// (see `NSMenuItem+Standard.swift`). The icon is full-colour only while mic transcription is
+/// actually ready; starting and reconnecting stay visibly distinct from a healthy listening session.
 @MainActor
 final class MenuBarController: NSObject {
     enum State: Equatable {
@@ -15,27 +15,13 @@ final class MenuBarController: NSObject {
 
         var isActive: Bool { self != .stopped }
 
-        var statusText: String {
-            switch self {
-            case .stopped: "Status: Stopped"
-            case .starting: "Status: Connecting…"
-            case .listening: "Status: Listening"
-            case .reconnecting(let attempt): "Status: Reconnecting microphone (attempt \(attempt))…"
-            case .systemAudioConnecting: "Status: Listening — system audio connecting"
-            case .microphoneOnly: "Status: Listening — system audio unavailable"
-            }
-        }
-
         var isMicReady: Bool {
             self == .listening || self == .systemAudioConnecting || self == .microphoneOnly
         }
     }
 
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-    private let connectionItem = NSMenuItem(title: "Status: Stopped", action: nil, keyEquivalent: "")
-    private let counterItem = NSMenuItem(title: "Interjections: 0", action: nil, keyEquivalent: "")
-    private let startStopItem = NSMenuItem(title: "Start Jarvis", action: nil, keyEquivalent: "s")
-    private var interjections = 0
+    private let startStopItem = NSMenuItem.standard("Start Jarvis", symbol: "play.fill", keyEquivalent: "s")
     private(set) var state: State = .stopped
     /// Whether a pipeline exists, including its startup/reconnect windows.
     var isRunning: Bool { state.isActive }
@@ -49,32 +35,18 @@ final class MenuBarController: NSObject {
 
     override init() {
         super.init()
-        let menu = NSMenu()
         startStopItem.target = self
         startStopItem.action = #selector(toggleStartStop)
-        menu.addItem(startStopItem)
-        menu.addItem(connectionItem)
-        let settings = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
-        settings.target = self
-        menu.addItem(settings)
-        menu.addItem(.separator())
-        menu.addItem(counterItem)
-        menu.addItem(.separator())
-        let quit = NSMenuItem(title: "Quit Jarvis", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
-        menu.addItem(quit)
+        let menu = NSMenu()
+        menu.items = [
+            startStopItem,
+            .standard("Settings…", symbol: "gearshape",
+                      action: #selector(openSettings), target: self, keyEquivalent: ","),
+            .standard("Quit Jarvis", symbol: "power",
+                      action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"),
+        ]
         statusItem.menu = menu
         refreshUI()
-    }
-
-    func noteSpoke() {
-        interjections += 1
-        counterItem.title = "Interjections: \(interjections)"
-    }
-
-    /// Reset the per-session interjection count (called on each Start).
-    func resetCounter() {
-        interjections = 0
-        counterItem.title = "Interjections: 0"
     }
 
     /// The single source of truth for pipeline and mic-connection health.
@@ -94,10 +66,10 @@ final class MenuBarController: NSObject {
         }
     }
 
-    /// Single source of truth for the status icon and the start/stop label.
+    /// Single source of truth for the status icon and the start/stop item.
     private func refreshUI() {
-        startStopItem.title = state.isActive ? "Stop Jarvis" : "Start Jarvis"
-        connectionItem.title = state.statusText
+        startStopItem.applyStandard(title: state.isActive ? "Stop Jarvis" : "Start Jarvis",
+                                    symbol: state.isActive ? "stop.fill" : "play.fill")
         guard let button = statusItem.button else { return }
         button.image = state.isMicReady ? MenuBarIcon.running : MenuBarIcon.stopped
         button.title = ""

--- a/Sources/JarvisApp/MenuBar/NSMenuItem+Standard.swift
+++ b/Sources/JarvisApp/MenuBar/NSMenuItem+Standard.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+/// The one standard format for items in the Jarvis menu-bar menu: an SF Symbol icon followed by the
+/// title. Build every item through `standard(...)` — and restyle mutable ones with `applyStandard` —
+/// so new entries automatically match; never hand-construct a bare `NSMenuItem` for the menu.
+@MainActor
+extension NSMenuItem {
+    static func standard(_ title: String, symbol: String,
+                         action: Selector? = nil, target: AnyObject? = nil,
+                         keyEquivalent: String = "") -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: keyEquivalent)
+        item.target = target
+        item.applyStandard(title: title, symbol: symbol)
+        return item
+    }
+
+    /// Restyle an existing item in place — for items whose title/icon change at runtime
+    /// (e.g. Start ↔ Stop).
+    func applyStandard(title: String, symbol: String) {
+        self.title = title
+        image = NSImage(systemSymbolName: symbol, accessibilityDescription: title)
+    }
+}

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -29,7 +29,6 @@ public final class CoachDriver: @unchecked Sendable {
     private let overlay: OverlayRendering
     private let clock: Clock
     private let sessionStart: TimeInterval
-    private let onSpoke: (@Sendable () -> Void)?
     private let history = CoachHistory()
 
     /// Safety backstop against a pathological model that loops on capture_screen forever.
@@ -47,8 +46,7 @@ public final class CoachDriver: @unchecked Sendable {
 
     public init(config: Config, transcript: RollingTranscript,
                 brain: BrainClient, summarizer: BrainClient? = nil,
-                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock,
-                onSpoke: (@Sendable () -> Void)? = nil) {
+                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock) {
         self.config = config
         self.transcript = transcript
         self.brain = brain
@@ -57,7 +55,6 @@ public final class CoachDriver: @unchecked Sendable {
         self.overlay = overlay
         self.clock = clock
         self.sessionStart = clock.now()
-        self.onSpoke = onSpoke
     }
 
     // Synchronous lock accessors — NSLock can't be held across an `await`, so all critical sections
@@ -261,13 +258,12 @@ public final class CoachDriver: @unchecked Sendable {
 
             case .speak(let callId, let lines):
                 // Last gate before side effects: a turn cancelled by Stop (or a Stop→Start that
-                // rotated the session) must not render a stale tip, bump the counter, or log into
-                // the new session. This is the "speak after Stop" guard the TurnTaskBox relies on.
+                // rotated the session) must not render a stale tip or log into the new session.
+                // This is the "speak after Stop" guard the TurnTaskBox relies on.
                 if Task.isCancelled { jlog("… turn cancelled (stopped) before speaking"); return .cancelled }
                 jlog("💬 \(lines.joined(separator: " "))")
                 let perLine = lines.map { OverlayTiming.displaySeconds(for: $0, config: config) }
                 overlay.render(lines, perLineSeconds: perLine)
-                onSpoke?()
                 // Close the call locally — we own the history, so no follow-up round trip is needed.
                 turnMessages.append(.assistantToolCalls(response.rawToolCalls))
                 turnMessages.append(.init(role: .tool, text: "shown to the user", toolCallId: callId))

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -258,8 +258,8 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
   This keeps
   conversation natural: a follow-up question is never stranded behind a timer. The hard control is
   the menu-bar **Start/Stop** — coaching never runs until explicitly started, and stopping tears the
-  pipeline down entirely. A session interjection counter in the menu bar makes over-talking visible;
-  cost is accepted as tracking usage for now (a future improvement, not a v1 guardrail).
+  pipeline down entirely. Cost is accepted as tracking usage for now (a future improvement, not a
+  v1 guardrail).
 
 ## 6. Non-Goals (v1)
 

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -133,8 +133,7 @@ readable by this user account and by nothing else. See [build-and-run.md](./buil
 - **Manual Start/Stop** in the menu bar — the only hard gate. Coaching never runs until started, and
   Stop tears the pipeline down entirely.
 - **Visible "listening" indicator** — the user always knows when Jarvis is active (also a consent cue).
-- **Session interjection counter** in the menu bar (reset on each Start), so over-talking is visible
-  immediately. Cost is accepted as tracking usage for now (a future improvement, not a v1 guardrail).
+  Cost is accepted as tracking usage for now (a future improvement, not a v1 guardrail).
 
 ## Consent Note
 


### PR DESCRIPTION
## What

The menu-bar menu is now just **Start/Stop, Settings…, Quit Jarvis** — the status line, the interjection counter, and both separators are gone. Every item is icon-prefixed (SF Symbol + title) in one shared format.

## How

- **New `NSMenuItem+Standard.swift`** — the modular standard going forward: `NSMenuItem.standard(_:symbol:action:target:keyEquivalent:)` builds an item as an SF Symbol icon followed by its title, and `applyStandard(title:symbol:)` restyles an item whose content changes at runtime. All future menu items go through this factory.
- **`MenuBarController`** — three items built through the factory: Start/Stop (`play.fill` ↔ `stop.fill`), Settings… (`gearshape`), Quit (`power`). `State` stays (it still drives the colour/grayscale status icon); `statusText`, `connectionItem`, `counterItem`, `noteSpoke()`, and `resetCounter()` are removed.
- **Dead plumbing removed** — `AppDelegate` no longer resets/feeds the counter, and `CoachDriver` drops its `onSpoke` hook (the counter was its only consumer; no tests used it).
- **Wiki sync** — `architecture.md` / `sandbox.md` no longer cite the interjection counter as a restraint-visibility feature.

## Verification

- `JarvisCore` builds and all 226 Core tests pass on the Linux dev box via the Core-only scratch package (the one failure is the known Linux-only `defaultLocationIsUnderApplicationSupport` path issue, pre-existing).
- The full Gate and a visual check of the menu icons need a Mac — the changed menu code is AppKit and isn't unit-tested by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)