### PR TITLE
feat(screen): add stable screen change monitor

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -319,12 +319,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         themTranscriber.onTerminalFailure = onThemTerminalFailure
 
         // One-clock capture + echo cancellation: a single aggregate device (mic + system tap) feeds
-        // the cleaned mic to the "me" socket and the raw system audio to the "them" socket, with AEC3
-        // run inside its IOProc. If the device can't be built, the whole capture is gone, so treat it
-        // as a full (mic-side) terminal failure.
+        // the cleaned mic to the "me" socket and the sample-preserving system timeline to the "them"
+        // socket, with AEC3 run inside its IOProc. If the device can't be built, the whole capture is
+        // gone, so treat it as a full (mic-side) terminal failure.
         let capture = AggregateEchoCapture(
-            onMicClean: { [weak transcriber] data in transcriber?.sendAudio(data) },
-            onSystem: { [weak themTranscriber] data in themTranscriber?.sendAudio(data) })
+            onMicCaptured: { [weak transcriber] sequence, samples, capturedAt in
+                transcriber?.recordCapturedAudio(
+                    sequenceNumber: sequence, sampleCount: samples, capturedAt: capturedAt)
+            },
+            onSystemCaptured: { [weak themTranscriber] sequence, samples, capturedAt in
+                themTranscriber?.recordCapturedAudio(
+                    sequenceNumber: sequence, sampleCount: samples, capturedAt: capturedAt)
+            },
+            onMicClean: { [weak transcriber] data, sequence, capturedAt in
+                transcriber?.sendAudio(
+                    data, sequenceNumber: sequence, capturedAt: capturedAt)
+            },
+            onSystem: { [weak themTranscriber] data, sequence, capturedAt in
+                themTranscriber?.sendAudio(
+                    data, sequenceNumber: sequence, capturedAt: capturedAt)
+            })
         capture.onUnavailable = { [errorReporter] reason in
             errorReporter.report(.captureFailed(reason: reason))
         }

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -37,6 +37,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// In-flight coaching turns, so Stop can cancel one mid-brain-call (otherwise it could speak
     /// after the user pressed Stop).
     private var turns: TurnTaskBox?
+    /// Watches low-rate, one-shot downscaled captures for stable visual changes without creating a
+    /// persistent macOS sharing session. One full local capture follows quiescence; only the snapshot
+    /// accepted by CoachDriver becomes auditable.
+    private var screenChangeMonitor: ScreenChangeMonitor?
+    /// Rejects a late screenshot callback from a stopped driver after a rapid Stop → Start. Without
+    /// this identity token, that old point-in-time image could seed the new session's monitor.
+    private var screenMonitorGeneration = 0
     /// The global hint hotkey. Lives for the whole app run; its callback beeps when no session runs.
     private var hotkeys: HotkeyController?
     /// Fires an on-demand hint for the running session. Non-nil only while running — set in `start()`,
@@ -247,15 +254,62 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let brain = RetryingBrainClient(base: coachBase)
         // Fan each spoken tip out to both the Overlay Caption and the persistent Overlay Box.
         let overlaySink = BroadcastOverlay([overlayCaption, overlayBox])
+        // Share one capture surface between the driver and change monitor so both observe the same
+        // selected display/window policy. The monitor seeds itself locally when the session starts;
+        // every real coach capture still acknowledges/resets its baseline through `onScreenCaptured`.
+        let screen = WindowScopedScreenCapture(preferences: screenPreferences)
+        let screenMonitorGeneration = self.screenMonitorGeneration
         let driver = CoachDriver(config: config, transcript: transcript,
                                  brain: brain, summarizer: summarizer,
-                                 screen: WindowScopedScreenCapture(preferences: screenPreferences),
-                                 overlay: overlaySink, clock: clock)
+                                 screen: screen,
+                                 overlay: overlaySink, clock: clock,
+                                 onScreenCaptured: { [weak self] snapshot in
+                                     Task { @MainActor [weak self] in
+                                         guard let self,
+                                               self.screenMonitorGeneration == screenMonitorGeneration
+                                         else { return }
+                                         self.screenChangeMonitor?.observe(snapshot)
+                                     }
+                                 },
+                                 onScreenCaptureRejected: { [weak self] in
+                                     Task { @MainActor [weak self] in
+                                         guard let self,
+                                               self.screenMonitorGeneration == screenMonitorGeneration
+                                         else { return }
+                                         self.screenChangeMonitor?.retryUnacknowledgedChange()
+                                     }
+                                 })
 
         // CoachDriver is @unchecked Sendable; capture it (not @MainActor self) in the callbacks.
         // Route turns through TurnTaskBox so Stop can cancel an in-flight one. Concurrent triggers are
         // coalesced inside CoachDriver (the running turn batches them in), so we don't cancel here.
         let turns = TurnTaskBox()
+        let monitorCapture = InMemoryScreenCapture(preferences: screenPreferences)
+        let screenChangeMonitor = ScreenChangeMonitor(
+            preferences: screenPreferences,
+            capture: { await monitorCapture.capture() },
+            config: config
+        ) {
+            [turns, driver] snapshot in
+            turns.run { await driver.handleScreenChange(snapshot) }
+        }
+        self.screenChangeMonitor = screenChangeMonitor
+        screenChangeMonitor.start()
+        // Give a stable visual candidate to the next audio turn whenever possible. The request is
+        // already required by the transcript, so this improves context without adding model cost.
+        let handleAudioTurn: @Sendable () -> Void = {
+            [weak self, turns, driver] in
+            Task { @MainActor [weak self] in
+                guard let self,
+                      self.screenMonitorGeneration == screenMonitorGeneration,
+                      self.screenChangeMonitor != nil else { return }
+                if let snapshot = self.screenChangeMonitor?.takePendingSnapshotForSpeech() {
+                    turns.run { await driver.handleTurnEnd(screenSnapshot: snapshot) }
+                } else {
+                    turns.run { await driver.handleTrigger(.turnEnd) }
+                }
+            }
+        }
         // Mic socket gave up (bad key / quota / network): coaching can't continue. Report fatal — the
         // reporter's onFatal stops the session and corrects the menu (no more lying 🟢).
         let onMicTerminalFailure: @Sendable () -> Void = { [errorReporter] in
@@ -294,7 +348,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                               networkStatus: { [networkDiagnostics] in
                                                   networkDiagnostics.currentSummary
                                               })
-        transcriber.onTurnEnd = { turns.run { await driver.handleTrigger(.turnEnd) } }
+        transcriber.onTurnEnd = handleAudioTurn
         transcriber.onSilence = { secs in turns.run { await driver.handleTrigger(.silence(secondsQuiet: secs)) } }
         transcriber.onTerminalFailure = onMicTerminalFailure
 
@@ -315,13 +369,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                   networkStatus: { [networkDiagnostics] in
                                                       networkDiagnostics.currentSummary
                                                   })
-        themTranscriber.onTurnEnd = { turns.run { await driver.handleTrigger(.turnEnd) } }
+        themTranscriber.onTurnEnd = handleAudioTurn
         themTranscriber.onTerminalFailure = onThemTerminalFailure
 
         // One-clock capture + echo cancellation: a single aggregate device (mic + system tap) feeds
         // the cleaned mic to the "me" socket and the sample-preserving system timeline to the "them"
-        // socket, with AEC3 run inside its IOProc. If the device can't be built, the whole capture is
-        // gone, so treat it as a full (mic-side) terminal failure.
+        // socket, with AEC3 run inside its IOProc. If the device can't be built, the whole capture is gone, so treat it
+        // as a full (mic-side) terminal failure.
         let capture = AggregateEchoCapture(
             onMicCaptured: { [weak transcriber] sequence, samples, capturedAt in
                 transcriber?.recordCapturedAudio(
@@ -390,6 +444,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func stop() {
         let wasRunning = transcriber != nil || themTranscriber != nil
         requestManualHint = nil              // hotkey beeps again once there's no live session
+        screenMonitorGeneration &+= 1
+        screenChangeMonitor?.stop(); screenChangeMonitor = nil
         let cancelled = turns?.cancelAll() ?? []; turns = nil   // cancel any in-flight coaching turn
         aggregateCapture?.stop(); aggregateCapture = nil   // stop the IOProc, tear down tap+aggregate
         transcriber?.stop()

--- a/Sources/JarvisApp/Capture/AggregateEchoCapture.swift
+++ b/Sources/JarvisApp/Capture/AggregateEchoCapture.swift
@@ -20,10 +20,20 @@ import JarvisCore
 /// `@unchecked Sendable`: audio state is touched only by the single IOProc thread; lifecycle
 /// (build/teardown/rebuild/stop) is serialized by `lock`. The IOProc never takes `lock`, and teardown
 /// calls `AudioDeviceStop` (which drains in-flight callbacks) before destroying anything. Client
-/// callbacks (`onUnavailable`) are invoked OUTSIDE the lock.
+/// audio delivery is moved onto one serial queue so encoding/network work cannot stall Core Audio;
+/// `onUnavailable` is invoked outside the lock.
 final class AggregateEchoCapture: @unchecked Sendable {
-    private let onMicClean: @Sendable (Data) -> Void
-    private let onSystem: @Sendable (Data) -> Void
+    private struct SequencedAudioChunk: Sendable {
+        let data: Data
+        let sequence: UInt64
+        let sampleCount: Int
+        let capturedAt: TimeInterval
+    }
+
+    private let onMicCaptured: @Sendable (UInt64, Int, TimeInterval) -> Void
+    private let onSystemCaptured: @Sendable (UInt64, Int, TimeInterval) -> Void
+    private let onMicClean: @Sendable (Data, UInt64, TimeInterval) -> Void
+    private let onSystem: @Sendable (Data, UInt64, TimeInterval) -> Void
     /// Fired if the device can't be built/started mid-session (route-change rebuild) — the caller
     /// decides how to surface it. Carries a human-readable reason.
     var onUnavailable: (@Sendable (String) -> Void)?
@@ -46,11 +56,23 @@ final class AggregateEchoCapture: @unchecked Sendable {
 
     private let lock = NSLock()
     private let routeQueue = DispatchQueue(label: "jarvis.aec.routes")
+    /// Both speaker streams share one queue to preserve the IOProc's callback order (cleaned mic,
+    /// then untouched system tap) without doing Realtime encoding/sends on the audio thread.
+    private let deliveryQueue = DispatchQueue(label: "jarvis.aec.delivery", qos: .userInitiated)
     private var routeListener: AudioObjectPropertyListenerBlock?
     private var pendingRebuild: DispatchWorkItem?
     private var stopped = false
+    /// Assigned on the single IOProc thread and preserved across route rebuilds. A gap at any later
+    /// boundary is therefore diagnosable without retaining the audio itself.
+    private var micSequence: UInt64 = 0
+    private var systemSequence: UInt64 = 0
 
-    init(onMicClean: @escaping @Sendable (Data) -> Void, onSystem: @escaping @Sendable (Data) -> Void) {
+    init(onMicCaptured: @escaping @Sendable (UInt64, Int, TimeInterval) -> Void,
+         onSystemCaptured: @escaping @Sendable (UInt64, Int, TimeInterval) -> Void,
+         onMicClean: @escaping @Sendable (Data, UInt64, TimeInterval) -> Void,
+         onSystem: @escaping @Sendable (Data, UInt64, TimeInterval) -> Void) {
+        self.onMicCaptured = onMicCaptured
+        self.onSystemCaptured = onSystemCaptured
         self.onMicClean = onMicClean
         self.onSystem = onSystem
     }
@@ -230,20 +252,53 @@ final class AggregateEchoCapture: @unchecked Sendable {
         // 48 kHz and the up-resamplers are nil).
         if let micUp { mic = micUp.convert(mic) }
         if let sysUp { tap = sysUp.convert(tap) }
+        // Keep two purpose-specific copies. Transcription preserves every real tap sample and pads a
+        // short/empty callback to the mic duration so the server audio clock and trailing-silence VAD
+        // keep advancing. AEC needs an exact mic-length reference and may therefore also truncate.
+        let systemTap = tap
         // Keep far and near in lockstep AT THE AEC RATE: AEC3's reference and capture must advance by the
         // SAME sample count each callback, or the two framers drift apart for the rest of the session. The
         // tap can legitimately be short/empty (silence), and the two converters can emit a sample or two
         // apart — so pad/truncate the tap to the mic's count after resampling.
-        if tap.count != mic.count {
-            if tap.count < mic.count { tap.append(contentsOf: repeatElement(0, count: mic.count - tap.count)) }
-            else { tap.removeLast(tap.count - mic.count) }
-        }
+        let aecTap = EchoReferenceAlignment.aligned(systemTap, toFrameCount: mic.count)
+        let systemTimeline = SystemAudioTimeline.preservingSamples(
+            systemTap, minimumFrameCount: mic.count)
 
-        aec.processReverse(tap)            // far-end reference FIRST
+        aec.processReverse(aecTap)         // far-end reference FIRST
         let clean = aec.process(mic)       // near-end, echo removed
 
-        if !clean.isEmpty { onMicClean(Self.data(micDown.convert(clean))) }
-        if !tap.isEmpty { onSystem(Self.data(sysDown.convert(tap))) }
+        let micData = clean.isEmpty ? nil : Self.data(micDown.convert(clean))
+        let systemData = systemTimeline.isEmpty ? nil : Self.data(sysDown.convert(systemTimeline))
+        guard micData != nil || systemData != nil else { return }
+        let capturedAt = Date().timeIntervalSince1970
+        let micChunk: SequencedAudioChunk? = micData.map { data in
+            micSequence &+= 1
+            return SequencedAudioChunk(
+                data: data, sequence: micSequence,
+                sampleCount: data.count / MemoryLayout<Int16>.size,
+                capturedAt: capturedAt)
+        }
+        let systemChunk: SequencedAudioChunk? = systemData.map { data in
+            systemSequence &+= 1
+            return SequencedAudioChunk(
+                data: data, sequence: systemSequence,
+                sampleCount: data.count / MemoryLayout<Int16>.size,
+                capturedAt: capturedAt)
+        }
+        let onMicCaptured = self.onMicCaptured
+        let onSystemCaptured = self.onSystemCaptured
+        let onMicClean = self.onMicClean
+        let onSystem = self.onSystem
+        deliveryQueue.async {
+            if let micChunk {
+                onMicCaptured(micChunk.sequence, micChunk.sampleCount, micChunk.capturedAt)
+                onMicClean(micChunk.data, micChunk.sequence, micChunk.capturedAt)
+            }
+            if let systemChunk {
+                onSystemCaptured(systemChunk.sequence, systemChunk.sampleCount, systemChunk.capturedAt)
+                onSystem(systemChunk.data, systemChunk.sequence, systemChunk.capturedAt)
+            }
+        }
     }
 
     // MARK: - Core Audio / format helpers

--- a/Sources/JarvisApp/Capture/InMemoryScreenCapture.swift
+++ b/Sources/JarvisApp/Capture/InMemoryScreenCapture.swift
@@ -1,0 +1,96 @@
+import AppKit
+import ImageIO
+import JarvisCore
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+
+/// Full-resolution second stage of the visual monitor. ScreenActivityPoller handles cheap change /
+/// idle observations; this type runs only after quiescence (plus once to seed the baseline). It never
+/// creates a temporary file. A snapshot handed to CoachDriver may later become the one auditable
+/// session screenshot.
+struct InMemoryScreenCapture: Sendable {
+    private let preferences: ScreenCapturePreferences
+    private let recognizer = ScreenTextRecognizer()
+
+    init(preferences: ScreenCapturePreferences) {
+        self.preferences = preferences
+    }
+
+    func capture() async -> ScreenSnapshot? {
+        guard let content = try? await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: true
+        ) else { return nil }
+
+        let scope = preferences.scope
+        let activeWindow = scope == .activeWindow
+            ? WindowScopedScreenCapture.frontWindowID().flatMap { wantedID in
+                content.windows.first(where: { $0.windowID == CGWindowID(wantedID) })
+            }
+            : nil
+
+        let filter: SCContentFilter
+        let shouldSendRecognizedText: Bool
+        if let activeWindow {
+            filter = SCContentFilter(desktopIndependentWindow: activeWindow)
+            shouldSendRecognizedText = true
+        } else {
+            // Active-window fallbacks always use the main display. A previously selected secondary
+            // display applies only when the user explicitly chose entire-display scope, matching
+            // WindowScopedScreenCapture and ScreenCaptureCLI.
+            let displayIndex = scope == .entireDisplay ? preferences.displayIndex : 1
+            guard let display = await selectedDisplay(
+                index: displayIndex, in: content.displays
+            ) else { return nil }
+            filter = SCContentFilter(display: display, excludingWindows: [])
+            shouldSendRecognizedText = false
+        }
+
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(1, Int((filter.contentRect.width * CGFloat(filter.pointPixelScale)).rounded()))
+        configuration.height = max(1, Int((filter.contentRect.height * CGFloat(filter.pointPixelScale)).rounded()))
+        configuration.showsCursor = false
+        configuration.ignoreShadowsSingleWindow = true
+
+        let capturedAt = ProcessInfo.processInfo.systemUptime
+        guard let image = try? await SCScreenshotManager.captureImage(
+            contentFilter: filter, configuration: configuration
+        ), let jpeg = Self.jpegData(from: image) else { return nil }
+
+        // Whole-display OCR is useful locally for duplicate suppression, but is intentionally not sent
+        // to the model: it would turn unrelated display clutter into tokens. Only its content-free hash
+        // survives this call. Active-window OCR still rides with the screenshot as an exact reading aid.
+        let localText = recognizer.recognizedText(inJPEG: jpeg)
+        return ScreenSnapshot(
+            capturedAt: capturedAt,
+            imageBase64: jpeg.base64EncodedString(),
+            recognizedText: shouldSendRecognizedText ? localText : nil,
+            changeFingerprint: localText.flatMap(
+                ScreenChangeDetector.privacyPreservingTextFingerprint),
+            visualFingerprint: ScreenPerceptualHash.make(from: image))
+    }
+
+    private func selectedDisplay(index selectedIndex: Int,
+                                 in displays: [SCDisplay]) async -> SCDisplay? {
+        let selectedID: CGDirectDisplayID? = await MainActor.run {
+            let screens = NSScreen.screens
+            let screen = selectedIndex <= screens.count ? screens[selectedIndex - 1] : screens.first
+            return screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+                as? CGDirectDisplayID
+        }
+        if let selectedID, let display = displays.first(where: { $0.displayID == selectedID }) {
+            return display
+        }
+        return displays.first
+    }
+
+    private static func jpegData(from image: CGImage) -> Data? {
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data, UTType.jpeg.identifier as CFString, 1, nil
+        ) else { return nil }
+        let properties = [kCGImageDestinationLossyCompressionQuality: 0.82] as CFDictionary
+        CGImageDestinationAddImage(destination, image, properties)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
+    }
+}

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -34,6 +34,11 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private let silenceDurationMs: Int
     private let noiseReduction: NoiseReductionMode
     private let turnDebounce: TimeInterval
+    /// How long a VAD-stopped item may wait for completed/failed before streamed text is salvaged.
+    private let transcriptionTerminalTimeout: TimeInterval
+    /// Hard backstop for a speech-started item that never receives VAD stop or any terminal event.
+    /// Kept far above a normal interview answer so genuine continuous speech is not cut off.
+    private let transcriptionActiveTimeout: TimeInterval
     private let readyTimeout: TimeInterval
     private let pingInterval: TimeInterval
     private let pongTimeout: TimeInterval
@@ -53,22 +58,34 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     private var readyTimer: Timer?
     private var pongTimer: Timer?
     private var debounceTimer: Timer?         // coalesces rapid fragments into one trigger
+    private var continuityTimer: Timer?
     private let pending = UtteranceBuffer()   // fragments heard since the last fired trigger
+    private let transcriptionLedger = RealtimeTranscriptionLedger()
+    /// Content-free capture -> delivery -> socket -> server evidence. It inspects each PCM chunk
+    /// synchronously for a local activity bit, then retains metadata only (never PCM or words).
+    private let continuityWitness: AudioContinuityWitness
     private let audioBuffer: PCMBuffer        // mic audio captured while the socket is down
     private var reconnectAttempt = 0
     private var isReconnecting = false
     private var stopped = false
     private var connected = false        // true only between "session ready" and the next drop/close
     private var everConnected = false    // distinguishes the first connect from a reconnect
+    private var bufferOverflowEpisodeReported = false
     private var rotating = false         // an EXPECTED server rotation is mid-flight; quiet the noise it makes
     private var generation = 0           // rejects late callbacks from a replaced socket
     private var pendingPingGeneration: Int?
+    /// Realtime's `audio_start_ms` is relative to audio written on one socket. These origins map it
+    /// back onto Jarvis's overall session clock, including audio buffered during reconnect backoff.
+    private var pendingAudioTimelineOrigin: TimeInterval = 0
+    private var activeAudioTimelineOrigin: TimeInterval = 0
 
     init(apiKey: String, model: String, speaker: Speaker = .me, transcript: RollingTranscript, clock: Clock,
          silenceTimeout: TimeInterval, silenceMaxInterval: TimeInterval,
          silenceIdleCutoff: TimeInterval = .infinity,
          silenceDurationMs: Int = 1000, noiseReduction: NoiseReductionMode = .auto,
-         turnDebounce: TimeInterval = 0.4, maxBufferedAudioSeconds: TimeInterval = 60,
+         turnDebounce: TimeInterval = 0.4, transcriptionTerminalTimeout: TimeInterval = 8,
+         transcriptionActiveTimeout: TimeInterval = 180,
+         maxBufferedAudioSeconds: TimeInterval = 60,
          readyTimeout: TimeInterval = 10, pingInterval: TimeInterval = 20,
          pongTimeout: TimeInterval = 10,
          networkStatus: @escaping @Sendable () -> String = { "unavailable" }) {
@@ -83,6 +100,8 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         self.silenceDurationMs = silenceDurationMs
         self.noiseReduction = noiseReduction
         self.turnDebounce = turnDebounce
+        self.transcriptionTerminalTimeout = transcriptionTerminalTimeout
+        self.transcriptionActiveTimeout = transcriptionActiveTimeout
         self.readyTimeout = readyTimeout
         self.pingInterval = pingInterval
         self.pongTimeout = pongTimeout
@@ -90,12 +109,18 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         // PCM16 mono at the realtime sample rate → 2 bytes/sample.
         let bytesPerSecond = RealtimeSession.sampleRate * 2
         self.audioBuffer = PCMBuffer(maxBytes: Int(maxBufferedAudioSeconds) * bytesPerSecond)
+        self.continuityWitness = AudioContinuityWitness(startedAt: 0)
         super.init()
     }
 
     func connect() {
         // Start clean: clear the stopped flag AND any stale backoff state from a prior session.
-        lock.lock(); stopped = false; reconnectAttempt = 0; isReconnecting = false; rotating = false; lock.unlock()
+        lock.lock()
+        stopped = false; reconnectAttempt = 0; isReconnecting = false; rotating = false
+        bufferOverflowEpisodeReported = false
+        pendingAudioTimelineOrigin = 0; activeAudioTimelineOrigin = 0
+        lock.unlock()
+        transcriptionLedger.clear()
         emitState(.connecting)
         openSocket()
         // Arm the proactive silence check exactly once, here on the first connect. A reconnect (session
@@ -103,6 +128,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         // alone — its backoff step and elapsed quiet carry across the rotation instead of snapping back
         // to the base interval every ~hour. (Speech still resets it, via `handle`.)
         resetSilenceTimer()
+        startContinuityPolling()
     }
 
     private func openSocket() {
@@ -134,19 +160,25 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         let rt = readyTimer; readyTimer = nil
         let pot = pongTimer; pongTimer = nil
         let db = debounceTimer; debounceTimer = nil
+        let ct = continuityTimer; continuityTimer = nil
         let t = task; task = nil
         let s = session; session = nil
         pendingPingGeneration = nil
         generation += 1                 // invalidate every callback retained by the old task
+        audioBuffer.clear()             // atomic with `stopped`: no producer can append after this
         lock.unlock()
         // Timers must be invalidated on the thread that scheduled them (main); doing it synchronously
         // from an off-main Stop (e.g. the onTerminalFailure Task) would silently fail to cancel and
         // could let a stray timer fire onSilence on a torn-down pipeline.
         DispatchQueue.main.async {
             st?.invalidate(); pt?.invalidate(); rt?.invalidate(); pot?.invalidate(); db?.invalidate()
+            ct?.invalidate()
         }
+        handleContinuityOutput(
+            continuityWitness.poll(at: clock.now() - sessionStart, forceSnapshot: true),
+            appendContextMarkers: false)
         pending.clear()
-        audioBuffer.clear()   // a user Stop discards buffered audio; don't replay it on a later Start
+        transcriptionLedger.clear()
         // A user-initiated Stop is a normal closure (1000), not "going away" (1001).
         t?.cancel(with: .normalClosure, reason: nil)
         s?.invalidateAndCancel()             // breaks the URLSession→delegate(self)→closures→driver retain chain
@@ -161,50 +193,106 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
                                                  noiseReduction: profile))
     }
 
-    func sendAudio(_ pcm: Data) {
-        // Audio streams continuously from the mic tap. While the socket is down (between a drop and
-        // the reconnect's "session ready"), BUFFER it instead of discarding, so a mid-sentence drop
-        // doesn't lose the user's words — it's flushed into the new session on reconnect. A failed
-        // send is also a liveness signal and moves the socket into this buffering state immediately.
-        lock.lock(); let isConnected = connected; let isStopped = stopped; lock.unlock()
-        if isStopped { return }
-        if isConnected {
-            send(json: RealtimeSession.appendAudio(base64PCM: pcm.base64EncodedString()))
-        } else {
-            audioBuffer.append(pcm)
-        }
+    /// Records the first content-free checkpoint on the delivery queue using the timestamp assigned
+    /// inside the IOProc. This preserves capture-to-delivery timing without locking the audio thread.
+    func recordCapturedAudio(sequenceNumber: UInt64, sampleCount: Int,
+                             capturedAt: TimeInterval) {
+        lock.lock(); let isStopped = stopped; lock.unlock()
+        guard !isStopped else { return }
+        consumeContinuityOutput(continuityWitness.recordCapture(
+            sequence: sequenceNumber, sampleCount: sampleCount,
+            at: capturedAt - sessionStart))
     }
 
-    /// Replay any audio captured while disconnected into the freshly-ready session, then resume live.
-    /// On the FIRST connect this is just the brief connect-handshake gap, so it's flushed silently;
-    /// only a true reconnect logs the replay (the first-start "replayed … after reconnect" line was
-    /// misleading).
-    private func flushBufferedAudio(isReconnect: Bool) {
-        // Drain-and-send in a loop while `connected` is still false (so live mic audio keeps buffering
-        // and can't be sent ahead of these older chunks). Each pass catches audio that arrived during
-        // the previous send; a small cap prevents spinning if the mic streams continuously.
-        var total = 0
-        for _ in 0..<8 {
-            let chunks = audioBuffer.drain()
-            if chunks.isEmpty { break }
-            total += chunks.count
-            for chunk in chunks {
-                send(json: RealtimeSession.appendAudio(base64PCM: chunk.base64EncodedString()))
-            }
-        }
-        if isReconnect && total > 0 {
-            jlog("⏩ realtime [\(speaker.rawValue)] replayed \(total) buffered audio chunks after reconnect")
-        }
+    func sendAudio(_ pcm: Data, sequenceNumber: UInt64, capturedAt: TimeInterval) {
+        // Every chunk enters one ordered FIFO. Local send completion moves it into a bounded recovery
+        // tail rather than deleting it: Realtime does not acknowledge append events, so only later
+        // server audio-clock progress can retire that prefix safely.
+        let observedAt = clock.now() - sessionStart
+        let sessionRelativeCaptureAt = capturedAt - sessionStart
+        let duration = TimeInterval(pcm.count) / TimeInterval(RealtimeSession.sampleRate * 2)
+        lock.lock()
+        guard !stopped else { lock.unlock(); return }
+        let evicted = audioBuffer.append(pcm, sequenceNumber: sequenceNumber,
+                                         capturedAt: sessionRelativeCaptureAt,
+                                         duration: duration)
+        lock.unlock()
+        consumeContinuityOutput(continuityWitness.recordDelivery(
+            sequence: sequenceNumber, pcm16: pcm, at: observedAt))
+        reportBufferEviction(evicted)
+        pumpAudioIfReady()
     }
 
-    private func send(json: [String: Any]) {
+    private func reportBufferEviction(_ evicted: [PCMBuffer.Chunk]) {
+        guard !evicted.isEmpty else { return }
+        lock.lock()
+        let shouldReport = !bufferOverflowEpisodeReported
+        bufferOverflowEpisodeReported = true
+        lock.unlock()
+        guard shouldReport else { return }
+        consumeContinuityOutput(continuityWitness.recordReconnectBufferOverflow(
+            evictedSequences: evicted.compactMap(\.sequenceNumber),
+            at: clock.now() - sessionStart))
+    }
+
+    private func pumpAudioIfReady() {
+        lock.lock()
+        guard let task, connected, !stopped, !isReconnecting,
+              let claim = audioBuffer.claimNext() else { lock.unlock(); return }
+        let socketGeneration = generation
+        lock.unlock()
+        sendAudioClaim(claim, task: task, socketGeneration: socketGeneration)
+    }
+
+    @discardableResult
+    private func send(json: [String: Any]) -> Bool {
         guard let data = try? JSONSerialization.data(withJSONObject: json),
-              let str = String(data: data, encoding: .utf8) else { return }
+              let str = String(data: data, encoding: .utf8) else { return false }
         lock.lock(); let t = task; let socketGeneration = generation; lock.unlock()
-        t?.send(.string(str)) { [weak self, weak t] error in
-            guard let self, let t, let error else { return }
+        guard let t else { return false }
+        t.send(.string(str)) { [weak self, weak t] error in
+            guard let self, let t else { return }
+            guard let error else { return }
             self.failConnection(task: t, generation: socketGeneration,
                                 diagnostic: "send failed: \(error)")
+        }
+        return true
+    }
+
+    private func sendAudioClaim(_ claim: PCMBuffer.Claim, task: URLSessionWebSocketTask,
+                                socketGeneration: Int) {
+        guard let sequence = claim.chunk.sequenceNumber,
+              let data = try? JSONSerialization.data(withJSONObject: RealtimeSession.appendAudio(
+                base64PCM: claim.chunk.data.base64EncodedString())),
+              let text = String(data: data, encoding: .utf8) else {
+            _ = audioBuffer.retry(claim)
+            return
+        }
+        consumeContinuityOutput(continuityWitness.recordSendAttempt(
+            sequence: sequence, socketGeneration: socketGeneration,
+            at: clock.now() - sessionStart))
+        task.send(.string(text)) { [weak self, weak task] error in
+            guard let self, let task else { return }
+            if let error {
+                self.consumeContinuityOutput(self.continuityWitness.recordSendFailure(
+                    sequence: sequence, socketGeneration: socketGeneration,
+                    at: self.clock.now() - self.sessionStart))
+                // Disconnect first. Its state transition releases the current FIFO claim while no
+                // producer can select this failed socket; retrying before that transition would let
+                // a racing producer send the same head on the dead task.
+                self.failConnection(task: task, generation: socketGeneration,
+                                    diagnostic: "send failed: \(error)")
+                return
+            }
+            self.consumeContinuityOutput(self.continuityWitness.recordSendSuccess(
+                sequence: sequence, socketGeneration: socketGeneration,
+                at: self.clock.now() - self.sessionStart))
+            self.lock.lock()
+            let isCurrentLease = self.task === task && self.generation == socketGeneration
+                && self.connected && !self.stopped && !self.isReconnecting
+            let completed = isCurrentLease && self.audioBuffer.completeSend(claim)
+            self.lock.unlock()
+            if completed { self.pumpAudioIfReady() }
         }
     }
 
@@ -248,23 +336,103 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         }
 
         switch type {
+        case RealtimeSession.speechStartedType:
+            guard let itemID = obj["item_id"] as? String,
+                  let audioStartMilliseconds = obj["audio_start_ms"] as? Int else {
+                jlog("Jarvis realtime [\(speaker.rawValue)]: malformed speech_started event: \(text)")
+                break
+            }
+            lock.lock(); let timelineOrigin = activeAudioTimelineOrigin; lock.unlock()
+            if transcriptionLedger.recordSpeechStarted(
+                itemID: itemID, audioStartMilliseconds: audioStartMilliseconds,
+                timelineOrigin: timelineOrigin
+            ) {
+                discardServerConfirmedAudio()
+                jlog("Jarvis realtime [\(speaker.rawValue)] speech started "
+                     + "(item \(itemID), audio_start_ms \(audioStartMilliseconds))")
+                recordServerContinuity(.speechStarted,
+                                       audioTimeMilliseconds: audioStartMilliseconds,
+                                       sessionAudioTime: timelineOrigin
+                                           + TimeInterval(audioStartMilliseconds) / 1_000,
+                                       socketGeneration: socketGeneration)
+                scheduleTranscriptionActiveDeadline(itemID: itemID)
+            }
+        case RealtimeSession.deltaTranscriptionType:
+            guard let itemID = obj["item_id"] as? String else {
+                jlog("Jarvis realtime [\(speaker.rawValue)]: delta missing item_id")
+                break
+            }
+            if let delta = obj["delta"] as? String {
+                recordServerContinuity(.transcriptionDelta,
+                                       audioTimeMilliseconds: nil,
+                                       socketGeneration: socketGeneration)
+                transcriptionLedger.recordDelta(itemID: itemID, delta: delta)
+            }
         case RealtimeSession.completedTranscriptionType:
             // A completed utterance fragment: record it immediately (so the model's context is
             // whole), but DON'T fire the coach yet — debounce so rapid fragments of one spoken
-            // sentence coalesce into a single trigger. The wire→text parse lives in RealtimeSession
-            // (pure + unit-tested).
-            if let transcriptText = RealtimeSession.completedTranscript(from: obj, speaker: speaker) {
-                let at = clock.now() - sessionStart
-                transcript.append(.init(speaker: speaker, text: transcriptText, at: at))
-                jlog("🗣 heard (\(speaker.rawValue)): \"\(transcriptText)\"")   // show side + what was said
-                pending.append(transcriptText)
-                resetSilenceTimer()
-                scheduleTurnDebounce()
+            // sentence coalesces into a single trigger. `audio_start_ms`, captured by the ledger on
+            // speech_started, timestamps the line when it was spoken rather than when inference ended.
+            guard let itemID = obj["item_id"] as? String else {
+                jlog("Jarvis realtime [\(speaker.rawValue)]: completed transcription missing item_id")
+                break
             }
-        case "input_audio_buffer.speech_stopped":
-            // Server VAD detected end of speech; the actionable turn-end (with transcript) is
-            // handled on the completed event above. Just refresh the silence timer here.
-            resetSilenceTimer()
+            let transcriptText = obj["transcript"] as? String ?? ""
+            recordServerContinuity(.transcriptionCompleted,
+                                   audioTimeMilliseconds: nil,
+                                   socketGeneration: socketGeneration)
+            let item = transcriptionLedger.recordCompleted(
+                itemID: itemID, transcript: transcriptText, speaker: speaker
+            )
+            discardServerConfirmedAudio()
+            if let item {
+                appendFinalizedItem(item, reason: item.recoveredFromDeltas ? "completed without usable final" : nil)
+            } else {
+                jlog("Jarvis realtime [\(speaker.rawValue)] transcription completed "
+                     + "with no usable text (item \(itemID))")
+            }
+        case RealtimeSession.failedTranscriptionType:
+            guard let itemID = obj["item_id"] as? String else {
+                jlog("Jarvis realtime [\(speaker.rawValue)]: failed transcription missing item_id: \(text)")
+                break
+            }
+            let error = Self.transcriptionErrorDescription(from: obj)
+            recordServerContinuity(.transcriptionFailed,
+                                   audioTimeMilliseconds: nil,
+                                   socketGeneration: socketGeneration)
+            let item = transcriptionLedger.recordFailed(itemID: itemID, speaker: speaker)
+            discardServerConfirmedAudio()
+            let recovery: String
+            if item?.recoveredFromDeltas == true {
+                recovery = "salvaged streamed text"
+            } else if item?.isContextGap == true {
+                recovery = "recorded context gap"
+            } else {
+                recovery = "item was already finalized"
+            }
+            jlog("Jarvis realtime [\(speaker.rawValue)] transcription failed "
+                 + "(item \(itemID), \(error)); \(recovery)")
+            if let item { appendFinalizedItem(item, reason: "transcription failed") }
+        case RealtimeSession.speechStoppedType:
+            guard let itemID = obj["item_id"] as? String else {
+                jlog("Jarvis realtime [\(speaker.rawValue)]: speech_stopped missing item_id")
+                break
+            }
+            let audioEndMilliseconds = obj["audio_end_ms"] as? Int
+            recordServerContinuity(.speechStopped,
+                                   audioTimeMilliseconds: audioEndMilliseconds,
+                                   socketGeneration: socketGeneration)
+            let endDetail = audioEndMilliseconds.map { ", audio_end_ms \($0)" } ?? ""
+            jlog("Jarvis realtime [\(speaker.rawValue)] speech stopped "
+                 + "(item \(itemID)\(endDetail))")
+            if transcriptionLedger.recordSpeechStopped(
+                itemID: itemID, audioEndMilliseconds: audioEndMilliseconds
+            ) {
+                discardServerConfirmedAudio()
+                scheduleTranscriptionTerminalDeadline(itemID: itemID)
+            }
+            // Do not reset proactive silence here. Bare VAD start/stop events contain no usable
+            // context; only an appended final/salvaged line begins a fresh silence interval.
         case "session.created", "transcription_session.created":
             // The WebSocket handshake succeeded, but our transcription configuration has not yet
             // been acknowledged. Stay in `connecting` and keep buffering until the updated event.
@@ -289,25 +457,27 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
                            sessionID: String?) {
         lock.lock()
         guard let currentTask = self.task, currentTask === task,
-              generation == socketGeneration, !connected else {
+              generation == socketGeneration, !connected, !stopped, !isReconnecting else {
             lock.unlock(); return
         }
         let wasReconnect = everConnected
         everConnected = true; rotating = false; reconnectAttempt = 0
+        activeAudioTimelineOrigin = audioBuffer.oldestQueuedCaptureTime
+            ?? pendingAudioTimelineOrigin
+        let bufferedChunks = audioBuffer.queuedChunkCount
+        connected = true
+        bufferOverflowEpisodeReported = false
         lock.unlock()
         invalidateReadyTimer(task: task, generation: socketGeneration)
         let id = sessionID.map { ", session \($0)" } ?? ""
         jlog("Jarvis realtime [\(speaker.rawValue)]: transcription session ready (socket #\(socketGeneration)\(id))")
-        // Flush buffered audio BEFORE marking connected, so live mic audio (which keeps buffering
-        // while !connected) can't be sent ahead of the older buffered chunks and scramble order.
-        flushBufferedAudio(isReconnect: wasReconnect)
-        lock.lock()
-        guard let currentTask = self.task, currentTask === task,
-              generation == socketGeneration, !stopped, !isReconnecting else {
-            lock.unlock(); return
+        if wasReconnect && bufferedChunks > 0 {
+            jlog("⏩ realtime [\(speaker.rawValue)] replaying \(bufferedChunks) buffered audio chunks after reconnect")
         }
-        connected = true
-        lock.unlock()
+        // Producers always append to the same claimed FIFO. Making readiness visible before this
+        // pump is safe: a racing producer may claim the oldest chunk itself, but cannot bypass it or
+        // strand the chunk it just appended.
+        pumpAudioIfReady()
         emitState(.ready)
         startPing(task: task, generation: socketGeneration)
     }
@@ -344,6 +514,195 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         onTurnEnd?()
     }
 
+    private func scheduleTranscriptionTerminalDeadline(itemID: String) {
+        let timeout = transcriptionTerminalTimeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+            guard let self,
+                  let item = self.transcriptionLedger.resolveStoppedItemTimeout(
+                    itemID: itemID, speaker: self.speaker
+                  ) else { return }
+            let recovery = item.recoveredFromDeltas ? "salvaged streamed text" : "recorded context gap"
+            self.discardServerConfirmedAudio()
+            jlog("Jarvis realtime [\(self.speaker.rawValue)] transcription terminal timed out "
+                 + "after \(timeout)s (item \(itemID)); \(recovery)")
+            self.appendFinalizedItem(item, reason: "terminal timeout")
+        }
+    }
+
+    private func scheduleTranscriptionActiveDeadline(itemID: String) {
+        let timeout = transcriptionActiveTimeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout) { [weak self] in
+            guard let self,
+                  let item = self.transcriptionLedger.resolveActiveItemTimeout(
+                    itemID: itemID, speaker: self.speaker
+                  ) else { return }
+            let recovery = item.recoveredFromDeltas ? "salvaged streamed text" : "recorded context gap"
+            self.discardServerConfirmedAudio()
+            jlog("Jarvis realtime [\(self.speaker.rawValue)] active transcription timed out "
+                 + "after \(timeout)s (item \(itemID)); \(recovery)")
+            self.appendFinalizedItem(item, reason: "active-item timeout")
+        }
+    }
+
+    private func finalizeInterruptedTranscriptions(reason: String) {
+        let items = transcriptionLedger.resolveAllInterruptedItems(speaker: speaker)
+        discardServerConfirmedAudio()
+        guard !items.isEmpty else { return }
+        jlog("Jarvis realtime [\(speaker.rawValue)] resolving \(items.count) interrupted "
+             + "transcription item(s) after \(reason)")
+        for item in items {
+            appendFinalizedItem(item, reason: reason)
+        }
+    }
+
+    /// Realtime VAD timestamps are the first end-to-end evidence available for streamed audio.
+    /// The ledger holds the boundary behind the earliest unresolved item, including when terminal
+    /// events arrive out of order, so this never retires words that a reconnect may still need.
+    private func discardServerConfirmedAudio() {
+        guard let boundary = transcriptionLedger.safeReplayDiscardTime else { return }
+        _ = audioBuffer.discardSent(through: boundary)
+    }
+
+    private func appendFinalizedItem(_ item: RealtimeTranscriptionLedger.FinalizedItem,
+                                     reason: String?) {
+        lock.lock(); let isStopped = stopped; lock.unlock()
+        guard !isStopped else { return }
+        let at = item.spokenAt ?? (clock.now() - sessionStart)
+        transcript.append(.init(speaker: speaker, text: item.text, at: at))
+        if item.isContextGap {
+            jlog("⚠️ context gap (\(speaker.rawValue), item \(item.itemID)): \(item.text)")
+        } else {
+            let detail = reason.map { ", recovered after \($0)" } ?? ""
+            jlog("🗣 heard (\(speaker.rawValue)): \"\(item.text)\" "
+                 + "(item \(item.itemID)\(detail))")
+        }
+        pending.append(item.text)
+        resetSilenceTimer()
+        scheduleTurnDebounce()
+    }
+
+    private static func transcriptionErrorDescription(from event: [String: Any]) -> String {
+        guard let error = event["error"] as? [String: Any] else { return "unknown error" }
+        let code = error["code"] as? String
+        let message = error["message"] as? String
+        let description = [code, message].compactMap { $0 }.joined(separator: ": ")
+        return description.isEmpty ? "unknown error" : description
+    }
+
+    // MARK: - Privacy-preserving continuity evidence
+
+    private func startContinuityPolling() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.lock.lock(); let shouldStart = !self.stopped; self.lock.unlock()
+            guard shouldStart else { return }
+            self.continuityTimer?.invalidate()
+            self.continuityTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) {
+                [weak self] _ in
+                guard let self else { return }
+                self.consumeContinuityOutput(self.continuityWitness.poll(
+                    at: self.clock.now() - self.sessionStart))
+            }
+        }
+    }
+
+    private func recordServerContinuity(_ signal: AudioContinuityWitness.ServerSpeechSignal,
+                                        audioTimeMilliseconds: Int?,
+                                        sessionAudioTime: TimeInterval? = nil,
+                                        socketGeneration: Int) {
+        consumeContinuityOutput(continuityWitness.recordServerSpeech(
+            signal, audioTimeMilliseconds: audioTimeMilliseconds,
+            socketGeneration: socketGeneration, sessionAudioTime: sessionAudioTime,
+            observedAt: clock.now() - sessionStart))
+    }
+
+    /// Witness calls originate on the audio, URLSession, and main queues. Keep logging and transcript
+    /// mutation off the realtime audio callback while preserving the metadata observation itself at
+    /// the boundary where it occurred.
+    private func consumeContinuityOutput(_ output: AudioContinuityWitness.Output) {
+        guard output.snapshot != nil || !output.anomalies.isEmpty else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.lock.lock(); let isStopped = self.stopped; self.lock.unlock()
+            guard !isStopped else { return }
+            self.handleContinuityOutput(output, appendContextMarkers: true)
+        }
+    }
+
+    private func handleContinuityOutput(_ output: AudioContinuityWitness.Output,
+                                        appendContextMarkers: Bool) {
+        if let snapshot = output.snapshot {
+            let sockets = snapshot.socketGenerations.map { socket in
+                let lastSequence = socket.lastSendSequence.map(String.init) ?? "none"
+                return "g\(socket.generation):attempt=\(socket.sendAttempts),ok=\(socket.sendSuccesses),"
+                    + "fail=\(socket.sendFailures),server=\(socket.serverSpeechSignals),"
+                    + "last_seq=\(lastSequence)"
+            }.joined(separator: ";")
+            jlog("Jarvis audio witness [\(speaker.rawValue)] @\(Self.seconds(snapshot.emittedAt)): "
+                 + "capture=\(snapshot.capturedChunks)/\(snapshot.capturedSamples), "
+                 + "delivery=\(snapshot.deliveredChunks)/\(snapshot.deliveredSamples), "
+                 + "pending=\(snapshot.pendingCapturedChunks), active=\(snapshot.localActivityDetected), "
+                 + "sockets=[\(sockets)]")
+        }
+
+        for anomaly in output.anomalies {
+            switch anomaly {
+            case .captureStalled(let lastCaptureAt, let duration):
+                let lastCapture = lastCaptureAt.map(Self.seconds) ?? "never"
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] capture stalled for "
+                     + "\(Self.seconds(duration)) (last=\(lastCapture))")
+            case .sequenceGap(let stage, let expected, let observed):
+                let boundary = stage == .capture ? "capture" : "delivery"
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] \(boundary) sequence gap: "
+                     + "expected=\(expected), observed=\(observed)")
+            case .deliveryWithoutCapture(let sequence):
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] delivery had no capture record: "
+                     + "sequence=\(sequence)")
+            case .deliverySampleCountMismatch(let sequence, let captured, let delivered):
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] sample count changed before delivery: "
+                     + "sequence=\(sequence), captured=\(captured), delivered=\(delivered)")
+            case .captureToDeliveryLag(let sequence, let lag):
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] capture-to-delivery lag: "
+                     + "sequence=\(sequence), lag=\(Self.seconds(lag))")
+            case .reconnectBufferOverflow(let evictedChunks, let firstSequence, let lastSequence):
+                let first = firstSequence.map(String.init) ?? "unknown"
+                let last = lastSequence.map(String.init) ?? "unknown"
+                let marker = "[audio continuity warning: the bounded reconnect buffer overflowed; "
+                    + "some captured audio could not be replayed and its words are unavailable]"
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] reconnect buffer overflow: "
+                     + "evicted=\(evictedChunks), sequences=\(first)...\(last)")
+                if appendContextMarkers {
+                    transcript.append(.init(speaker: speaker, text: marker,
+                                            at: clock.now() - sessionStart))
+                }
+            case .localActivityUnmatched(let activeSince, let duration):
+                let marker = "[audio continuity warning: sustained local activity was captured, "
+                    + "but no server speech event arrived within the diagnostic window; "
+                    + "speech content, if any, was unavailable at that time]"
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] local activity had no server speech "
+                     + "event: since=\(Self.seconds(activeSince)), window=\(Self.seconds(duration))")
+                // Do not invent words or trigger an extra coach request. The marker is carried by the
+                // next real turn, making the missing context explicit if this activity was speech.
+                if appendContextMarkers {
+                    transcript.append(.init(speaker: speaker, text: marker, at: activeSince))
+                }
+            case .serverSpeechObservedAfterUnmatchedActivity(let activeSince, let serverObservedAt):
+                let marker = "[audio continuity update: a server speech event later arrived for "
+                    + "the locally observed activity]"
+                jlog("ℹ️ audio continuity [\(speaker.rawValue)] late server speech event resolved "
+                     + "the prior warning: activity_since=\(Self.seconds(activeSince)), "
+                     + "server_at=\(Self.seconds(serverObservedAt))")
+                if appendContextMarkers {
+                    transcript.append(.init(speaker: speaker, text: marker, at: serverObservedAt))
+                }
+            }
+        }
+    }
+
+    private static func seconds(_ value: TimeInterval) -> String {
+        String(format: "%.3fs", value)
+    }
+
     // MARK: - Reconnect / keepalive
 
     func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask,
@@ -377,6 +736,7 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     /// callback from an old socket from disrupting its healthy replacement.
     private func failConnection(task failedTask: URLSessionWebSocketTask, generation failedGeneration: Int,
                                 diagnostic: String?) {
+        let failureAt = clock.now() - sessionStart
         lock.lock()
         guard let currentTask = task else { lock.unlock(); return }
         if stopped || isReconnecting || generation != failedGeneration || currentTask !== failedTask {
@@ -394,6 +754,8 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         if reconnectAttempt >= maxReconnects {
             isReconnecting = true
             lock.unlock()
+            audioBuffer.retryInFlight()
+            finalizeInterruptedTranscriptions(reason: "socket failure")
             if let diagnostic { logTransportFailure(diagnostic, generation: failedGeneration) }
             invalidateConnectionTimers()
             failedTask.cancel(with: .goingAway, reason: nil)
@@ -406,8 +768,27 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
         isReconnecting = true
         let attempt = reconnectAttempt
         reconnectAttempt = attempt + 1
+        // Local WebSocket send completions are not server acknowledgements. Requeue the entire
+        // unconfirmed tail now, while producers are excluded by this lock, so audio sent during a
+        // half-open interval precedes audio captured during reconnect backoff.
+        let replay = audioBuffer.prepareForReconnect()
+        pendingAudioTimelineOrigin = replay.oldestCapturedAt ?? failureAt
         lock.unlock()
 
+        reportBufferEviction(replay.evicted)
+        let interruptedItems = transcriptionLedger.pendingItemCount
+        // Those items' PCM is in the reconnect tail. Clear their old socket IDs and let the new
+        // session transcribe the audio once, rather than appending a partial/gap and then duplicating
+        // it with the recovered final transcript.
+        transcriptionLedger.clear()
+        if interruptedItems > 0 {
+            jlog("Jarvis realtime [\(speaker.rawValue)] replaying audio for \(interruptedItems) "
+                 + "interrupted transcription item(s) after socket reconnect")
+        }
+        if replay.replayedChunks > 0 {
+            jlog("Jarvis realtime [\(speaker.rawValue)] retained \(replay.replayedChunks) "
+                 + "locally-sent audio chunks for end-to-end reconnect replay")
+        }
         if let diagnostic { logTransportFailure(diagnostic, generation: failedGeneration) }
         invalidateConnectionTimers()
         failedTask.cancel(with: .goingAway, reason: nil)
@@ -554,9 +935,9 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     }
 
     /// (Re)start the proactive silence check from its base interval — called from `connect()` (the first
-    /// connect) and whenever speech is heard, so a fresh quiet stretch always begins at the base interval
-    /// before backing off. A reconnect re-enters via `openSocket()` and deliberately does NOT call this,
-    /// so a session rotation preserves the current backoff step rather than resetting it.
+    /// connect) and whenever usable speech is appended, so a fresh quiet stretch always begins at the
+    /// base interval before backing off. A reconnect re-enters via `openSocket()` and deliberately does
+    /// NOT call this, so a session rotation preserves the current backoff step rather than resetting it.
     private func resetSilenceTimer() {
         // The "them" transcriber leaves onSilence nil (only the mic owns the "are you stuck?" prompt);
         // skip arming a timer that would just no-op, avoiding per-utterance main-queue/Timer churn.
@@ -575,38 +956,53 @@ final class RealtimeTranscriber: NSObject, URLSessionWebSocketDelegate, @uncheck
     /// up to a cap; see `Config`) rather than nudged once and never again. Must be called on the main queue.
     private func armSilenceTimer() {
         let interval = silenceBackoff.next()
+        scheduleSilenceTimer(after: interval, quietThreshold: interval)
+    }
+
+    /// Keep a due silence check pending while a transcription item is unresolved. This short local
+    /// recheck does not advance or reset backoff: a VAD noise/start event contains no usable context
+    /// and must not buy another full 120-second interval. A finalized line resets the real timer.
+    private func scheduleSilenceTimer(after delay: TimeInterval, quietThreshold interval: TimeInterval) {
         lock.lock(); silenceTimer?.invalidate()
-        silenceTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
+        silenceTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             guard let self else { return }
-            self.lock.lock(); let isStopped = self.stopped; self.lock.unlock()
-            guard !isStopped else { return }   // don't drive a coaching turn on a torn-down pipeline
-            let quiet = self.transcript.silenceDuration(now: self.clock.now() - self.sessionStart)
-            // Only nudge on GENUINE conversational silence. The transcript is shared with the "them"
-            // (system-audio) socket, so `quiet` reflects the last line from EITHER side. If the other
-            // party spoke within this interval the user isn't stuck — they're listening — so suppress
-            // the nudge and restart the backoff, so a fresh quiet stretch begins at the base interval
-            // once the conversation actually goes quiet. (Mic speech resets via resetSilenceTimer; this
-            // covers the them side, which only feeds the shared transcript and doesn't reset the timer.)
-            guard quiet >= interval else {
-                self.silenceBackoff.reset()
-                self.silencePausedLogged = false
-                self.armSilenceTimer()
-                return
-            }
-            // Idle cutoff, enforced at FIRE time (a timer scheduled just under the cutoff must not
-            // bill one last probe past it). Past the cutoff the user has stepped away, so suppress
-            // the probe but keep this (free, local) check chain alive: it is the only path that can
-            // revive probing on "them" speech — that side only feeds the shared transcript, and the
-            // guard above then resets the backoff. Mic speech revives via resetSilenceTimer as usual.
-            if self.silenceBackoff.shouldProbe(quietSoFar: quiet) {
-                self.silencePausedLogged = false
-                self.onSilence?(quiet)
-            } else if !self.silencePausedLogged {
-                self.silencePausedLogged = true   // log the pause once, not every capped interval
-                jlog("🤫 quiet for \(Int(quiet))s — pausing silence checks until speech resumes")
-            }
-            self.armSilenceTimer()             // re-arm with the next (backed-off) interval
+            self.silenceTimerDidFire(quietThreshold: interval)
         }
         lock.unlock()
+    }
+
+    private func silenceTimerDidFire(quietThreshold interval: TimeInterval) {
+        lock.lock(); let isStopped = stopped; lock.unlock()
+        guard !isStopped else { return }   // don't drive a coaching turn on a torn-down pipeline
+        if transcriptionLedger.hasPendingItems {
+            scheduleSilenceTimer(after: 1, quietThreshold: interval)
+            return
+        }
+        let quiet = transcript.silenceDuration(now: clock.now() - sessionStart)
+        // Only nudge on GENUINE conversational silence. The transcript is shared with the "them"
+        // (system-audio) socket, so `quiet` reflects the last line from EITHER side. If the other
+        // party spoke within this interval the user isn't stuck — they're listening — so suppress
+        // the nudge and restart the backoff, so a fresh quiet stretch begins at the base interval
+        // once the conversation actually goes quiet. (Mic speech resets via resetSilenceTimer; this
+        // covers the them side, which only feeds the shared transcript and doesn't reset the timer.)
+        guard quiet >= interval else {
+            silenceBackoff.reset()
+            silencePausedLogged = false
+            armSilenceTimer()
+            return
+        }
+        // Idle cutoff, enforced at FIRE time (a timer scheduled just under the cutoff must not
+        // bill one last probe past it). Past the cutoff the user has stepped away, so suppress
+        // the probe but keep this (free, local) check chain alive: it is the only path that can
+        // revive probing on "them" speech — that side only feeds the shared transcript, and the
+        // guard above then resets the backoff. Mic speech revives via resetSilenceTimer as usual.
+        if silenceBackoff.shouldProbe(quietSoFar: quiet) {
+            silencePausedLogged = false
+            onSilence?(quiet)
+        } else if !silencePausedLogged {
+            silencePausedLogged = true   // log the pause once, not every capped interval
+            jlog("🤫 quiet for \(Int(quiet))s — pausing silence checks until speech resumes")
+        }
+        armSilenceTimer()             // re-arm with the next (backed-off) interval
     }
 }

--- a/Sources/JarvisApp/Capture/ScreenActivityPoller.swift
+++ b/Sources/JarvisApp/Capture/ScreenActivityPoller.swift
@@ -1,0 +1,216 @@
+import AppKit
+import CoreGraphics
+import JarvisCore
+import ScreenCaptureKit
+
+/// Low-rate, low-resolution one-shot captures used only as a local change signal.
+///
+/// A long-lived `SCStream` makes macOS show an ongoing screen-sharing control, which violates
+/// Jarvis's capture-invisible interview posture. One-shot `SCScreenshotManager` captures have no
+/// persistent sharing session. Each image is immediately reduced to one grayscale byte per pixel;
+/// no JPEG encoding, OCR, network request, disk write, or frame retention beyond the previous
+/// grayscale sample happens here.
+@MainActor
+final class ScreenActivityPoller {
+    private enum TargetSelection: Equatable {
+        case activeWindow(CGWindowID?)
+        case entireDisplay(Int)
+    }
+
+    enum Event: Sendable {
+        case changed(areaRatio: Double,
+                     evidence: ScreenFrameActivityClassifier.ChangeEvidence)
+        case idle
+        case unclassifiable
+    }
+
+    typealias EventHandler = @MainActor @Sendable (Event) -> Void
+
+    private struct Target {
+        let filter: SCContentFilter
+        let width: Int
+        let height: Int
+    }
+
+    private let preferences: ScreenCapturePreferences
+    private let frameInterval: TimeInterval
+    private let onEvent: EventHandler
+    private var frameClassifier: ScreenFrameActivityClassifier
+    private var pollTask: Task<Void, Never>?
+    private var target: Target?
+    private var currentSelection: TargetSelection?
+    private var generation = 0
+
+    init(preferences: ScreenCapturePreferences, frameInterval: TimeInterval,
+         minimumChangedAreaRatio: Double,
+         onEvent: @escaping EventHandler) {
+        precondition(frameInterval > 0)
+        self.preferences = preferences
+        self.frameInterval = frameInterval
+        self.onEvent = onEvent
+        self.frameClassifier = ScreenFrameActivityClassifier(
+            minimumChangedAreaRatio: minimumChangedAreaRatio)
+    }
+
+    func start() {
+        guard pollTask == nil else { return }
+        generation &+= 1
+        let requestedGeneration = generation
+        frameClassifier.reset()
+        target = nil
+        currentSelection = nil
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled, self.generation == requestedGeneration {
+                await self.pollOnce(generation: requestedGeneration)
+                // Delay after completion, so a slow capture can only lower the poll rate; it can
+                // never collapse into a tight loop and increase CPU/privacy pressure.
+                try? await Task.sleep(for: .seconds(self.frameInterval))
+            }
+        }
+    }
+
+    func stop() {
+        generation &+= 1
+        pollTask?.cancel()
+        pollTask = nil
+        target = nil
+        currentSelection = nil
+        frameClassifier.reset()
+    }
+
+    private func pollOnce(generation requestedGeneration: Int) async {
+        guard requestedGeneration == generation else { return }
+        let selection = desiredSelection()
+        let targetChanged = currentSelection != nil && selection != currentSelection
+        if target == nil || selection != currentSelection {
+            guard let refreshedTarget = await makeTarget(for: selection) else {
+                target = nil
+                onEvent(.unclassifiable)
+                return
+            }
+            target = refreshedTarget
+            currentSelection = selection
+        }
+        guard let target else {
+            onEvent(.unclassifiable)
+            return
+        }
+
+        let configuration = configuration(for: target)
+        guard let image = try? await SCScreenshotManager.captureImage(
+            contentFilter: target.filter, configuration: configuration
+        ), requestedGeneration == generation,
+              let pixels = Self.grayscalePixels(from: image) else {
+            // Re-resolve the target on the next poll; the active window or display may have gone.
+            self.target = nil
+            onEvent(.unclassifiable)
+            return
+        }
+
+        if targetChanged {
+            // A target switch is semantically a screen change even when two windows happen to look
+            // similar at 320 px. Seed the new pixel baseline and force one normal quiescence pass so
+            // the full-resolution/OCR stage reconciles with the newly watched surface.
+            frameClassifier.reset()
+            _ = frameClassifier.observe(pixels: pixels, dirtyAreaRatio: nil)
+            onEvent(.changed(areaRatio: 1, evidence: .visualPixels))
+            return
+        }
+
+        switch frameClassifier.observe(pixels: pixels, dirtyAreaRatio: nil) {
+        case .changed(let areaRatio, let evidence):
+            onEvent(.changed(areaRatio: areaRatio, evidence: evidence))
+        case .idle:
+            onEvent(.idle)
+        }
+    }
+
+    private func desiredSelection() -> TargetSelection {
+        if preferences.scope == .activeWindow {
+            return .activeWindow(WindowScopedScreenCapture.frontWindowID().map(CGWindowID.init))
+        }
+        return .entireDisplay(preferences.displayIndex)
+    }
+
+    private func makeTarget(for selection: TargetSelection) async -> Target? {
+        guard let content = try? await SCShareableContent.excludingDesktopWindows(
+            false, onScreenWindowsOnly: true
+        ) else { return nil }
+
+        if case .activeWindow(let selectedWindowID) = selection,
+           let windowID = selectedWindowID,
+           let window = content.windows.first(where: { $0.windowID == windowID }) {
+            let filter = SCContentFilter(desktopIndependentWindow: window)
+            return Target(
+                filter: filter,
+                width: max(1, Int(filter.contentRect.width * CGFloat(filter.pointPixelScale))),
+                height: max(1, Int(filter.contentRect.height * CGFloat(filter.pointPixelScale))))
+        }
+
+        // Active-window fallback is always the main display. The selected display index applies
+        // only when the user explicitly chose entire-display scope.
+        let displayIndex = switch selection {
+        case .activeWindow: 1
+        case .entireDisplay(let index): index
+        }
+        guard let display = selectedDisplay(index: displayIndex, in: content.displays) else {
+            return nil
+        }
+        let filter = SCContentFilter(display: display, excludingWindows: [])
+        return Target(filter: filter, width: display.width, height: display.height)
+    }
+
+    private func configuration(for target: Target) -> SCStreamConfiguration {
+        let maxDimension = 320.0
+        let scale = min(1, maxDimension / Double(max(target.width, target.height)))
+        let configuration = SCStreamConfiguration()
+        configuration.width = max(1, Int((Double(target.width) * scale).rounded()))
+        configuration.height = max(1, Int((Double(target.height) * scale).rounded()))
+        configuration.showsCursor = false
+        configuration.scalesToFit = true
+        configuration.preservesAspectRatio = true
+        configuration.ignoreShadowsSingleWindow = true
+        configuration.capturesAudio = false
+        return configuration
+    }
+
+    private func selectedDisplay(index selectedIndex: Int,
+                                 in displays: [SCDisplay]) -> SCDisplay? {
+        let screens = NSScreen.screens
+        let screen = selectedIndex <= screens.count ? screens[selectedIndex - 1] : screens.first
+        let selectedID = screen?.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")]
+            as? CGDirectDisplayID
+        if let selectedID, let display = displays.first(where: { $0.displayID == selectedID }) {
+            return display
+        }
+        return displays.first
+    }
+
+    private static func grayscalePixels(from image: CGImage) -> [UInt8]? {
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return nil }
+        var pixels = [UInt8](repeating: 0, count: width * height)
+        let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
+            guard let baseAddress = bytes.baseAddress,
+                  let context = CGContext(
+                    data: baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: width,
+                    space: CGColorSpaceCreateDeviceGray(),
+                    bitmapInfo: CGImageAlphaInfo.none.rawValue
+                  ) else { return false }
+            context.interpolationQuality = .low
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        return rendered ? pixels : nil
+    }
+
+    deinit {
+        pollTask?.cancel()
+    }
+}

--- a/Sources/JarvisApp/Capture/ScreenChangeMonitor.swift
+++ b/Sources/JarvisApp/Capture/ScreenChangeMonitor.swift
@@ -1,0 +1,354 @@
+import Foundation
+import JarvisCore
+
+/// Two-stage, session-local visual monitor.
+///
+/// Stage A compares low-rate 320 px one-shot captures locally, without creating a persistent macOS
+/// screen-sharing session. Stage B takes one full-resolution screenshot and runs OCR only after
+/// quiescence. Stable snapshots wait briefly to piggyback on the next audio-triggered coach turn;
+/// otherwise one screen-only turn is allowed per configured minimum interval. No intermediate pixels
+/// or OCR are persisted, and request failure/cancellation re-arms the exact candidate.
+@MainActor
+final class ScreenChangeMonitor {
+    typealias ChangeHandler = @MainActor @Sendable (ScreenSnapshot) -> Void
+    typealias Capture = @Sendable () async -> ScreenSnapshot?
+
+    private let preferences: ScreenCapturePreferences
+    private let capture: Capture
+    private let frameInterval: TimeInterval
+    private let minimumRequestInterval: TimeInterval
+    private let piggybackWait: TimeInterval
+    private let minimumChangedAreaRatio: Double
+    private let onChange: ChangeHandler
+    private var activityDetector: ScreenActivityDetector
+    private var contentDetector = ScreenChangeDetector(requiredStablePollCount: 1)
+
+    private var activityPoller: ScreenActivityPoller?
+    private var seedTask: Task<Void, Never>?
+    private var captureTask: Task<Void, Never>?
+    private var fallbackTask: Task<Void, Never>?
+    private var generation = 0
+    /// Prevents an asynchronously completed startup capture from baselining content that the local
+    /// poller has already identified as a post-start change.
+    private var observedChangeBeforeSeedCompleted = false
+
+    private var pendingSnapshot: ScreenSnapshot?
+    private var pendingCandidateID: ScreenActivityDetector.CandidateID?
+    private var inFlightSnapshot: ScreenSnapshot?
+    private var inFlightCandidateID: ScreenActivityDetector.CandidateID?
+    private var lastVisualRequestAt: TimeInterval?
+    private var latestObservedChangeAt: TimeInterval?
+
+    // Content-free operational evidence, summarized once per minute instead of logging every frame.
+    private var changedFrameCount = 0
+    private var idleFrameCount = 0
+    private var pixelChangeFrameCount = 0
+    private var unclassifiableFrameCount = 0
+    private var ignoredFrameCount = 0
+    private var fullCaptureCount = 0
+    private var duplicateCount = 0
+    private var piggybackCount = 0
+    private var screenOnlyCount = 0
+    private var lastDiagnosticAt = ProcessInfo.processInfo.systemUptime
+
+    init(preferences: ScreenCapturePreferences, capture: @escaping Capture,
+         config: Config, onChange: @escaping ChangeHandler) {
+        self.preferences = preferences
+        self.capture = capture
+        self.frameInterval = config.screenMonitorFrameIntervalSeconds
+        self.minimumRequestInterval = config.screenMonitorMinimumRequestIntervalSeconds
+        self.piggybackWait = config.screenMonitorPiggybackWaitSeconds
+        self.minimumChangedAreaRatio = config.screenMonitorMinimumChangedAreaRatio
+        self.onChange = onChange
+        self.activityDetector = ScreenActivityDetector(
+            quiescenceInterval: config.screenMonitorQuiescenceSeconds,
+            minimumChangedAreaRatio: config.screenMonitorMinimumChangedAreaRatio)
+    }
+
+    func start() {
+        guard activityPoller == nil else { return }
+        let requestedGeneration = generation
+        observedChangeBeforeSeedCompleted = false
+        let poller = ScreenActivityPoller(
+            preferences: preferences, frameInterval: frameInterval,
+            minimumChangedAreaRatio: minimumChangedAreaRatio
+        ) { [weak self] event in
+            Task { @MainActor [weak self] in
+                self?.receive(event, generation: requestedGeneration)
+            }
+        }
+        activityPoller = poller
+
+        // Seed content separately from activity. The first low-resolution poll establishes only the
+        // activity baseline; a full-content baseline prevents the first real question/code change
+        // from being swallowed by duplicate suppression.
+        let capture = capture
+        seedTask = Task { [weak self, capture] in
+            let snapshot = await capture()
+            guard !Task.isCancelled, let self,
+                  self.generation == requestedGeneration, let snapshot else { return }
+            guard !self.observedChangeBeforeSeedCompleted else { return }
+            _ = self.contentDetector.seedIfNeeded(snapshot)
+        }
+        poller.start()
+    }
+
+    /// Takes a stable snapshot for the next spoken turn. This adds current visual context to a request
+    /// that was already going to happen, so the monitor incurs no extra coach call.
+    func takePendingSnapshotForSpeech() -> ScreenSnapshot? {
+        guard inFlightSnapshot == nil,
+              let snapshot = pendingSnapshot,
+              let candidateID = pendingCandidateID else { return nil }
+        fallbackTask?.cancel()
+        fallbackTask = nil
+        pendingSnapshot = nil
+        pendingCandidateID = nil
+        inFlightSnapshot = snapshot
+        inFlightCandidateID = candidateID
+        lastVisualRequestAt = Self.now()
+        piggybackCount += 1
+        return snapshot
+    }
+
+    /// Acknowledges any screen the coach actually consumed. Candidate IDs and monotonic capture
+    /// ordering prevent a late acknowledgement from clearing a newer dirty-frame burst.
+    func observe(_ snapshot: ScreenSnapshot) {
+        let inFlightID = inFlightCandidateID
+        let pendingID = pendingCandidateID
+        if !ScreenCaptureOrdering.canAcknowledge(
+            capturedAt: snapshot.capturedAt,
+            latestObservedChangeAt: latestObservedChangeAt,
+            isMonitorSnapshot: inFlightID != nil
+        ) {
+            // This ordinary screenshot was captured before the monitor observed its newest change.
+            // The request still counts against visual spend, but it must not acknowledge, baseline,
+            // or clear the newer candidate. Recompute an existing fallback from the new rate limit.
+            lastVisualRequestAt = Self.now()
+            if pendingSnapshot != nil { scheduleFallback() }
+            return
+        }
+        if let inFlightID {
+            _ = activityDetector.acknowledge(inFlightID)
+        } else if let pendingID {
+            _ = activityDetector.acknowledge(pendingID)
+        } else {
+            // A manual/silence/model-requested screenshot is a fresh baseline in its own right.
+            activityDetector.reset()
+        }
+        contentDetector.observe(snapshot)
+        pendingSnapshot = nil
+        pendingCandidateID = nil
+        inFlightSnapshot = nil
+        inFlightCandidateID = nil
+        fallbackTask?.cancel()
+        fallbackTask = nil
+        lastVisualRequestAt = Self.now()
+        resumeAwaitingCandidateIfPossible()
+    }
+
+    /// Re-arms the exact monitor snapshot after the first request carrying it failed or was displaced.
+    func retryUnacknowledgedChange() {
+        guard let snapshot = inFlightSnapshot, let candidateID = inFlightCandidateID else { return }
+        inFlightSnapshot = nil
+        inFlightCandidateID = nil
+        contentDetector.retryUnacknowledgedChange()
+        guard activityDetector.reject(candidateID) else {
+            // A newer native frame already superseded this screenshot; let that candidate win.
+            resumeAwaitingCandidateIfPossible()
+            return
+        }
+        pendingSnapshot = snapshot
+        pendingCandidateID = candidateID
+        scheduleFallback()
+    }
+
+    func stop() {
+        generation &+= 1
+        activityPoller?.stop()
+        activityPoller = nil
+        seedTask?.cancel(); seedTask = nil
+        captureTask?.cancel(); captureTask = nil
+        fallbackTask?.cancel(); fallbackTask = nil
+        pendingSnapshot = nil
+        pendingCandidateID = nil
+        inFlightSnapshot = nil
+        inFlightCandidateID = nil
+        lastVisualRequestAt = nil
+        latestObservedChangeAt = nil
+        observedChangeBeforeSeedCompleted = false
+        activityDetector.reset()
+        contentDetector.reset()
+    }
+
+    private func receive(_ event: ScreenActivityPoller.Event, generation: Int) {
+        guard generation == self.generation else { return }
+        let result: ScreenActivityDetector.ObservationResult
+        switch event {
+        case .changed(let areaRatio, let evidence):
+            let observedAt = Self.now()
+            latestObservedChangeAt = observedAt
+            observedChangeBeforeSeedCompleted = true
+            changedFrameCount += 1
+            switch evidence {
+            case .visualPixels: pixelChangeFrameCount += 1
+            case .boundedDirtyRegion: break
+            }
+            let observation = activityDetector.observe(
+                .contentChanged(changedAreaRatio: areaRatio), at: observedAt)
+            // A newer significant visual burst makes a not-yet-sent full capture stale. Re-arm the
+            // content detector before dropping it: if a caret/selection blink settles back to that
+            // same question or code, the exact content remains eligible instead of being stuck in
+            // awaiting-acknowledgement state. In-flight delivery is allowed to finish; its candidate
+            // ID cannot erase this newer burst.
+            if pendingSnapshot != nil, observation != .ignored {
+                contentDetector.retryUnacknowledgedChange()
+                pendingSnapshot = nil
+                pendingCandidateID = nil
+                fallbackTask?.cancel()
+                fallbackTask = nil
+            }
+            result = observation
+        case .idle:
+            idleFrameCount += 1
+            result = activityDetector.observe(.idle, at: Self.now())
+        case .unclassifiable:
+            unclassifiableFrameCount += 1
+            logDiagnosticsIfDue()
+            return
+        }
+
+        switch result {
+        case .ignored:
+            ignoredFrameCount += 1
+        case .stableChange(let candidateID):
+            captureStableCandidate(candidateID, generation: generation)
+        case .awaitingAcknowledgement(let candidateID):
+            // This can be a newer candidate that became stable while an older request was in flight.
+            // Re-offering it is idempotent: the capture guard preserves the single in-flight bound.
+            captureStableCandidate(candidateID, generation: generation)
+        case .idle, .waitingForQuiescence:
+            break
+        }
+        logDiagnosticsIfDue()
+    }
+
+    private func captureStableCandidate(_ candidateID: ScreenActivityDetector.CandidateID,
+                                        generation: Int) {
+        guard captureTask == nil, pendingSnapshot == nil, inFlightSnapshot == nil else { return }
+        let capture = capture
+        captureTask = Task { [weak self, capture] in
+            let snapshot = await capture()
+            guard let self else { return }
+            self.captureTask = nil
+            guard !Task.isCancelled, self.generation == generation else { return }
+            guard let snapshot else {
+                let rejected = self.activityDetector.reject(candidateID)
+                if !rejected { self.resumeAwaitingCandidateIfPossible() }
+                return
+            }
+            self.fullCaptureCount += 1
+
+            if !self.contentDetector.isSeeded {
+                // A failed startup seed must not hide the first actual dirty-frame burst.
+                self.contentDetector.observe(snapshot)
+                self.queue(snapshot, candidateID: candidateID)
+                return
+            }
+
+            switch self.contentDetector.poll(snapshot) {
+            case .stableChange:
+                self.queue(snapshot, candidateID: candidateID)
+            case .unchanged, .awaitingAcknowledgement:
+                self.duplicateCount += 1
+                let acknowledged = self.activityDetector.acknowledge(candidateID)
+                if !acknowledged { self.resumeAwaitingCandidateIfPossible() }
+            case .dormant:
+                self.contentDetector.observe(snapshot)
+                self.queue(snapshot, candidateID: candidateID)
+            case .waitingForStability:
+                // The monitor configures this detector for one observation; keep the branch explicit
+                // so a future configuration change fails safe by retrying the candidate.
+                _ = self.activityDetector.reject(candidateID)
+            }
+        }
+    }
+
+    private func queue(_ snapshot: ScreenSnapshot,
+                       candidateID: ScreenActivityDetector.CandidateID) {
+        pendingSnapshot = snapshot
+        pendingCandidateID = candidateID
+        scheduleFallback()
+    }
+
+    private func resumeAwaitingCandidateIfPossible() {
+        guard captureTask == nil, pendingSnapshot == nil, inFlightSnapshot == nil else { return }
+        let result = activityDetector.observe(.idle, at: Self.now())
+        switch result {
+        case .stableChange(let candidateID), .awaitingAcknowledgement(let candidateID):
+            captureStableCandidate(candidateID, generation: generation)
+        case .idle, .ignored, .waitingForQuiescence:
+            break
+        }
+    }
+
+    private func scheduleFallback() {
+        fallbackTask?.cancel()
+        let now = Self.now()
+        let deadline = ScreenRequestTiming.fallbackDeadline(
+            candidateAt: now,
+            lastVisualRequestAt: lastVisualRequestAt,
+            piggybackWait: piggybackWait,
+            minimumRequestInterval: minimumRequestInterval)
+        let delay = max(0, deadline - now)
+        fallbackTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard !Task.isCancelled, let self else { return }
+            self.emitScreenOnly()
+        }
+    }
+
+    private func emitScreenOnly() {
+        guard inFlightSnapshot == nil,
+              let snapshot = pendingSnapshot,
+              let candidateID = pendingCandidateID else { return }
+        pendingSnapshot = nil
+        pendingCandidateID = nil
+        inFlightSnapshot = snapshot
+        inFlightCandidateID = candidateID
+        fallbackTask = nil
+        lastVisualRequestAt = Self.now()
+        screenOnlyCount += 1
+        onChange(snapshot)
+    }
+
+    private func logDiagnosticsIfDue() {
+        let now = Self.now()
+        guard now - lastDiagnosticAt >= 60 else { return }
+        lastDiagnosticAt = now
+        jlog("Jarvis screen witness (60s): polls_changed=\(changedFrameCount), "
+             + "polls_idle=\(idleFrameCount), pixel_changes=\(pixelChangeFrameCount), "
+             + "poll_failures=\(unclassifiableFrameCount), "
+             + "ignored=\(ignoredFrameCount), full_captures=\(fullCaptureCount), "
+             + "duplicates=\(duplicateCount), piggybacks=\(piggybackCount), "
+             + "screen_only=\(screenOnlyCount)")
+        changedFrameCount = 0
+        idleFrameCount = 0
+        pixelChangeFrameCount = 0
+        unclassifiableFrameCount = 0
+        ignoredFrameCount = 0
+        fullCaptureCount = 0
+        duplicateCount = 0
+        piggybackCount = 0
+        screenOnlyCount = 0
+    }
+
+    private static func now() -> TimeInterval {
+        ProcessInfo.processInfo.systemUptime
+    }
+
+    deinit {
+        seedTask?.cancel()
+        captureTask?.cancel()
+        fallbackTask?.cancel()
+    }
+}

--- a/Sources/JarvisApp/Capture/ScreenPerceptualHash.swift
+++ b/Sources/JarvisApp/Capture/ScreenPerceptualHash.swift
@@ -1,0 +1,39 @@
+import CoreGraphics
+import Foundation
+import ImageIO
+
+/// A local 64-bit difference hash. Downsampling to 9x8 grayscale makes duplicate suppression
+/// tolerant of JPEG noise and tiny pixel drift while retaining large layout/diagram changes.
+enum ScreenPerceptualHash {
+    static func make(fromJPEG data: Data) -> UInt64? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let image = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }
+        return make(from: image)
+    }
+
+    static func make(from image: CGImage) -> UInt64? {
+        var pixels = [UInt8](repeating: 0, count: 9 * 8)
+        return pixels.withUnsafeMutableBytes { buffer in
+            let bytes = buffer.bindMemory(to: UInt8.self)
+            guard let context = CGContext(
+                data: buffer.baseAddress, width: 9, height: 8,
+                bitsPerComponent: 8, bytesPerRow: 9,
+                space: CGColorSpaceCreateDeviceGray(),
+                bitmapInfo: CGImageAlphaInfo.none.rawValue
+            ) else { return nil }
+            context.interpolationQuality = .medium
+            context.draw(image, in: CGRect(x: 0, y: 0, width: 9, height: 8))
+
+            var result: UInt64 = 0
+            for row in 0..<8 {
+                for column in 0..<8 {
+                    result <<= 1
+                    if bytes[row * 9 + column] > bytes[row * 9 + column + 1] {
+                        result |= 1
+                    }
+                }
+            }
+            return result
+        }
+    }
+}

--- a/Sources/JarvisApp/Capture/WindowScopedScreenCapture.swift
+++ b/Sources/JarvisApp/Capture/WindowScopedScreenCapture.swift
@@ -26,17 +26,34 @@ struct WindowScopedScreenCapture: ScreenCapturing {
     }
 
     func capture() -> ScreenSnapshot? {
-        guard preferences.scope == .activeWindow,   // read at capture time, like the display index
-              let windowID = Self.frontWindowID(),
-              let jpeg = ScreenCaptureCLI.runScreencapture(
-                  arguments: ["-x", "-o", "-t", "jpg", "-l", "\(windowID)"])
-        else { return fallback.capture() }
-        return ScreenSnapshot(imageBase64: jpeg.base64EncodedString(),
-                              recognizedText: recognizer.recognizedText(inJPEG: jpeg))
+        if preferences.scope == .activeWindow,   // read at capture time, like the display index
+           let windowID = Self.frontWindowID() {
+            let capturedAt = ProcessInfo.processInfo.systemUptime
+            if let jpeg = ScreenCaptureCLI.runScreencapture(
+               arguments: ["-x", "-o", "-t", "jpg", "-l", "\(windowID)"]) {
+                let recognizedText = recognizer.recognizedText(inJPEG: jpeg)
+                return ScreenSnapshot(
+                    capturedAt: capturedAt,
+                    imageBase64: jpeg.base64EncodedString(),
+                    recognizedText: recognizedText,
+                    changeFingerprint: recognizedText.flatMap(
+                        ScreenChangeDetector.privacyPreservingTextFingerprint),
+                    visualFingerprint: ScreenPerceptualHash.make(fromJPEG: jpeg))
+            }
+        }
+        guard let shot = fallback.capture() else { return nil }
+        let visualFingerprint = Data(base64Encoded: shot.imageBase64)
+            .flatMap { ScreenPerceptualHash.make(fromJPEG: $0) }
+        return ScreenSnapshot(
+            capturedAt: shot.capturedAt,
+            imageBase64: shot.imageBase64,
+            recognizedText: shot.recognizedText,
+            changeFingerprint: shot.changeFingerprint,
+            visualFingerprint: visualFingerprint)
     }
 
     /// Dumps the on-screen window list (front-to-back, all displays) into Core's selector.
-    private static func frontWindowID() -> Int? {
+    static func frontWindowID() -> Int? {
         guard let entries = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements],
                                                        kCGNullWindowID) as? [[String: Any]]
         else { return nil }

--- a/Sources/JarvisCore/Audio/AdaptiveAudioActivityDetector.swift
+++ b/Sources/JarvisCore/Audio/AdaptiveAudioActivityDetector.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Small, stateful PCM16 activity detector for continuity diagnostics. It keeps only an adaptive
+/// RMS noise floor and a hysteresis bit; input samples never escape `observe`.
+struct AdaptiveAudioActivityDetector {
+    struct Observation {
+        let sampleCount: Int
+        let isActive: Bool
+    }
+
+    private let configuration: AudioContinuityWitness.ActivityConfiguration
+    private(set) var noiseFloorRMS: Double
+    private(set) var isActive = false
+
+    init(configuration: AudioContinuityWitness.ActivityConfiguration) {
+        self.configuration = configuration
+        noiseFloorRMS = configuration.initialNoiseFloorRMS
+    }
+
+    mutating func observe(pcm16: Data) -> Observation {
+        let levels = Self.levels(in: pcm16)
+        guard levels.sampleCount > 0 else {
+            isActive = false
+            return Observation(sampleCount: 0, isActive: false)
+        }
+
+        let activationRMS = max(configuration.minimumActiveRMS,
+                                noiseFloorRMS * configuration.activationMultiplier)
+        let releaseRMS = max(configuration.minimumActiveRMS * 0.6,
+                             noiseFloorRMS * configuration.releaseMultiplier)
+        if isActive {
+            isActive = levels.rms >= releaseRMS
+                && levels.peak >= configuration.minimumActivePeak * 0.5
+        } else {
+            isActive = levels.rms >= activationRMS
+                && levels.peak >= configuration.minimumActivePeak
+        }
+
+        if !isActive {
+            // Let the floor follow ordinary background changes, but cap one observation's upward
+            // influence so a voice onset cannot immediately redefine itself as noise.
+            let cappedRMS = min(levels.rms, max(configuration.minimumNoiseFloorRMS,
+                                                noiseFloorRMS * 1.5))
+            noiseFloorRMS += configuration.noiseAdaptationRate * (cappedRMS - noiseFloorRMS)
+            noiseFloorRMS = max(configuration.minimumNoiseFloorRMS, noiseFloorRMS)
+        }
+        return Observation(sampleCount: levels.sampleCount, isActive: isActive)
+    }
+
+    private static func levels(in pcm16: Data) -> (sampleCount: Int, rms: Double, peak: Double) {
+        pcm16.withUnsafeBytes { raw in
+            let bytes = raw.bindMemory(to: UInt8.self)
+            let count = bytes.count / 2
+            guard count > 0 else { return (0, 0, 0) }
+            var squaredSum = 0.0
+            var peak = 0.0
+            for index in 0..<count {
+                let offset = index * 2
+                let bits = UInt16(bytes[offset]) | (UInt16(bytes[offset + 1]) << 8)
+                let magnitude = abs(Double(Int16(bitPattern: bits)))
+                squaredSum += magnitude * magnitude
+                peak = max(peak, magnitude)
+            }
+            return (count, sqrt(squaredSum / Double(count)), peak)
+        }
+    }
+}

--- a/Sources/JarvisCore/Audio/EchoReferenceAlignment.swift
+++ b/Sources/JarvisCore/Audio/EchoReferenceAlignment.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Builds the frame-aligned far-end copy AEC needs without altering the system-audio samples that
+/// are sent to transcription. The capture and reference framers must advance by the same count, but
+/// that transport requirement must never truncate an interviewer's audio.
+public enum EchoReferenceAlignment {
+    public static func aligned(_ reference: [Int16], toFrameCount frameCount: Int) -> [Int16] {
+        precondition(frameCount >= 0, "Frame count cannot be negative")
+        if reference.count == frameCount { return reference }
+        if reference.count > frameCount { return Array(reference.prefix(frameCount)) }
+        return reference + repeatElement(0, count: frameCount - reference.count)
+    }
+}

--- a/Sources/JarvisCore/Audio/PCMBuffer.swift
+++ b/Sources/JarvisCore/Audio/PCMBuffer.swift
@@ -1,44 +1,235 @@
 import Foundation
 
-/// A byte-capped FIFO of PCM audio chunks. While the realtime socket is down, captured audio is
-/// buffered here instead of being discarded, then flushed into the new session on reconnect — so a
-/// mid-sentence drop doesn't lose the user's words. Bounded by `maxBytes` (the oldest audio is
-/// evicted past the cap) so a long outage can't grow memory without limit. Lock-guarded and pure, so
-/// the eviction policy is unit-testable outside the app target.
+/// A byte-capped FIFO of PCM audio chunks plus an in-memory recovery tail.
+///
+/// A successful WebSocket send callback proves only that the local transport accepted a message;
+/// Realtime deliberately sends no acknowledgement for `input_audio_buffer.append`. Locally-sent
+/// chunks therefore remain in `sentChunks` until a server audio-clock event proves that prefix is no
+/// longer needed. On reconnect, the unconfirmed tail moves back ahead of audio that was never sent.
+///
+/// Both stores are bounded by `maxBytes`, raw PCM never leaves memory, and every mutation is
+/// lock-guarded so the recovery contract is unit-testable outside the app target.
 public final class PCMBuffer: @unchecked Sendable {
+    public struct Chunk: Equatable, Sendable {
+        public let data: Data
+        public let sequenceNumber: UInt64?
+        /// Session-relative capture time. Nil is supported for callers that do not need timeline
+        /// reconciliation (principally small unit-test fixtures).
+        public let capturedAt: TimeInterval?
+        public let duration: TimeInterval
+
+        public init(data: Data, sequenceNumber: UInt64? = nil,
+                    capturedAt: TimeInterval? = nil, duration: TimeInterval = 0) {
+            precondition(duration >= 0)
+            self.data = data
+            self.sequenceNumber = sequenceNumber
+            self.capturedAt = capturedAt
+            self.duration = duration
+        }
+
+        fileprivate var capturedEnd: TimeInterval? { capturedAt.map { $0 + duration } }
+    }
+
+    /// One exclusive send claim. The chunk remains in the pending FIFO until `completeSend(_:)`;
+    /// a failed/stale transport callback can only release its own claim, never remove a newer one.
+    public struct Claim: Equatable, Sendable {
+        fileprivate let id: UInt64
+        public let chunk: Chunk
+    }
+
     private let lock = NSLock()
-    private var chunks: [Data] = []
-    private var byteCount = 0
+    private var chunks: [Chunk] = []
+    /// Chunks accepted by the local WebSocket stack but not yet covered by server audio progress.
+    private var sentChunks: [Chunk] = []
+    /// Sequence numbers whose append was accepted by a local WebSocket. After reconnect those
+    /// chunks re-enter `chunks`, so this preserves the distinction between normal recovery-window
+    /// expiry and actual loss of audio that has never reached any socket.
+    private var locallySentSequences: Set<UInt64> = []
+    private var queuedByteCount = 0
+    private var sentByteCount = 0
+    private var activeClaim: Claim?
+    private var nextClaimID: UInt64 = 1
     private let maxBytes: Int
 
     public init(maxBytes: Int) { self.maxBytes = max(0, maxBytes) }
 
     /// Append a chunk, evicting the oldest chunks if the cap is exceeded. The most recently appended
-    /// chunk is always retained (an in-progress utterance matters more than stale audio).
-    public func append(_ data: Data) {
-        guard !data.isEmpty else { return }
+    /// chunk is always retained (an in-progress utterance matters more than stale audio). The return
+    /// value contains only evicted chunks that had never completed a local send; expiry of an older
+    /// recovery-tail chunk is the normal behavior of the bounded rolling window, not a new gap.
+    @discardableResult
+    public func append(_ data: Data, sequenceNumber: UInt64? = nil,
+                       capturedAt: TimeInterval? = nil, duration: TimeInterval = 0) -> [Chunk] {
+        guard !data.isEmpty else { return [] }
         lock.lock(); defer { lock.unlock() }
-        chunks.append(data)
-        byteCount += data.count
-        while byteCount > maxBytes, chunks.count > 1 {
-            byteCount -= chunks.removeFirst().count
+        chunks.append(Chunk(data: data, sequenceNumber: sequenceNumber,
+                            capturedAt: capturedAt, duration: duration))
+        queuedByteCount += data.count
+        // The recovery tail and never-sent queue share one memory budget. Retire the oldest local
+        // send first; the newest captured audio is more valuable during a prolonged outage.
+        trimSentTailLocked()
+        var evicted: [Chunk] = []
+        // Never evict the chunk URLSession may currently be sending. While it is claimed, apply the
+        // cap to the waiting tail; the FIFO can exceed `maxBytes` by at most that one in-flight chunk.
+        let claimedBytes = activeClaim?.chunk.data.count ?? 0
+        while queuedByteCount - claimedBytes > maxBytes, chunks.count > 1 {
+            let index = activeClaim == nil ? 0 : 1
+            let removed = chunks.remove(at: index)
+            queuedByteCount -= removed.data.count
+            recordEvictionIfNeverSentLocked(removed, in: &evicted)
         }
+        return evicted
+    }
+
+    /// Exclusively claims the oldest chunk without removing it. A second producer/ready transition
+    /// sees the active claim and cannot send a later chunk ahead of it.
+    public func claimNext() -> Claim? {
+        lock.lock(); defer { lock.unlock() }
+        guard activeClaim == nil, let chunk = chunks.first else { return nil }
+        let claim = Claim(id: nextClaimID, chunk: chunk)
+        nextClaimID &+= 1
+        activeClaim = claim
+        return claim
+    }
+
+    /// Moves a chunk into the recovery tail after the exact asynchronous *local* send succeeds.
+    /// This is intentionally not called an acknowledgement: the Realtime server does not confirm
+    /// append events, so the chunk must remain replayable until `discardSent(through:)` advances it.
+    @discardableResult
+    public func completeSend(_ claim: Claim) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard activeClaim?.id == claim.id, chunks.first == claim.chunk else { return false }
+        let sent = chunks.removeFirst()
+        queuedByteCount -= sent.data.count
+        sentChunks.append(sent)
+        sentByteCount += sent.data.count
+        if let sequence = sent.sequenceNumber { locallySentSequences.insert(sequence) }
+        activeClaim = nil
+        trimSentTailLocked()
+        return true
+    }
+
+    /// Makes the exact failed claim available for ordered retry. Stale callbacks are harmless.
+    @discardableResult
+    public func retry(_ claim: Claim) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard activeClaim?.id == claim.id else { return false }
+        activeClaim = nil
+        return true
+    }
+
+    /// Releases whichever send was active when the current socket failed. The chunk stays first.
+    public func retryInFlight() {
+        lock.lock(); activeClaim = nil; lock.unlock()
+    }
+
+    public struct ReplayPreparation: Equatable, Sendable {
+        public let replayedChunks: Int
+        public let oldestCapturedAt: TimeInterval?
+        public let evicted: [Chunk]
+    }
+
+    /// Requeues everything that was accepted only by the local transport. TCP preserves order, so
+    /// this tail belongs before chunks captured after the connection became visibly unavailable.
+    /// A stale callback's claim is invalidated and cannot remove a replayed chunk later.
+    @discardableResult
+    public func prepareForReconnect() -> ReplayPreparation {
+        lock.lock(); defer { lock.unlock() }
+        let replayed = sentChunks.count
+        chunks = sentChunks + chunks
+        queuedByteCount += sentByteCount
+        sentChunks.removeAll(keepingCapacity: true)
+        sentByteCount = 0
+        activeClaim = nil
+
+        var evicted: [Chunk] = []
+        while queuedByteCount > maxBytes, chunks.count > 1 {
+            let removed = chunks.removeFirst()
+            queuedByteCount -= removed.data.count
+            recordEvictionIfNeverSentLocked(removed, in: &evicted)
+        }
+        return ReplayPreparation(replayedChunks: replayed,
+                                 oldestCapturedAt: chunks.first?.capturedAt,
+                                 evicted: evicted)
+    }
+
+    /// Discards the locally-sent prefix whose capture timeline is covered by a server VAD /
+    /// transcription lifecycle boundary. Pending chunks are never affected.
+    @discardableResult
+    public func discardSent(through capturedTime: TimeInterval) -> [Chunk] {
+        lock.lock(); defer { lock.unlock() }
+        var discarded: [Chunk] = []
+        while let first = sentChunks.first,
+              let end = first.capturedEnd, end <= capturedTime {
+            let removed = sentChunks.removeFirst()
+            sentByteCount -= removed.data.count
+            if let sequence = removed.sequenceNumber { locallySentSequences.remove(sequence) }
+            discarded.append(removed)
+        }
+        return discarded
     }
 
     /// Remove and return all buffered chunks in arrival order.
     public func drain() -> [Data] {
+        drainChunks().map(\.data)
+    }
+
+    /// Sequenced drain used by Realtime reconnect replay so the continuity witness can prove which
+    /// captured chunks were attempted on the replacement socket.
+    public func drainChunks() -> [Chunk] {
         lock.lock(); defer { lock.unlock() }
-        let out = chunks
-        chunks = []; byteCount = 0
+        let out = sentChunks + chunks
+        chunks = []; sentChunks = []
+        locallySentSequences.removeAll(keepingCapacity: true)
+        queuedByteCount = 0; sentByteCount = 0; activeClaim = nil
         return out
     }
 
     public func clear() {
-        lock.lock(); chunks = []; byteCount = 0; lock.unlock()
+        lock.lock()
+        chunks = []; sentChunks = []
+        locallySentSequences.removeAll(keepingCapacity: true)
+        queuedByteCount = 0; sentByteCount = 0; activeClaim = nil
+        lock.unlock()
     }
 
     public var bufferedBytes: Int {
         lock.lock(); defer { lock.unlock() }
-        return byteCount
+        return queuedByteCount + sentByteCount
+    }
+
+    public var bufferedChunkCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return chunks.count + sentChunks.count
+    }
+
+    public var queuedChunkCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return chunks.count
+    }
+
+    public var oldestQueuedCaptureTime: TimeInterval? {
+        lock.lock(); defer { lock.unlock() }
+        return chunks.first?.capturedAt
+    }
+
+    private func trimSentTailLocked() {
+        while sentByteCount + queuedByteCount > maxBytes, !sentChunks.isEmpty,
+              sentChunks.count > 1 || !chunks.isEmpty {
+            let removed = sentChunks.removeFirst()
+            sentByteCount -= removed.data.count
+            if let sequence = removed.sequenceNumber { locallySentSequences.remove(sequence) }
+        }
+    }
+
+    /// Dropping an already-locally-sent chunk merely advances the configured recovery horizon. A
+    /// dropped never-sent chunk is different: no replacement socket can recover its words, so the
+    /// caller must surface that continuity gap.
+    private func recordEvictionIfNeverSentLocked(_ chunk: Chunk, in report: inout [Chunk]) {
+        guard let sequence = chunk.sequenceNumber else {
+            report.append(chunk)
+            return
+        }
+        if locallySentSequences.remove(sequence) == nil { report.append(chunk) }
     }
 }

--- a/Sources/JarvisCore/Audio/SystemAudioTimeline.swift
+++ b/Sources/JarvisCore/Audio/SystemAudioTimeline.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Preserves every captured far-end sample while keeping the transcription stream's audio clock
+/// moving through tap silence. Core Audio may return a short or empty system tap for a mic callback;
+/// padding that missing tail lets server VAD observe trailing silence and finalize the interviewer.
+public enum SystemAudioTimeline {
+    public static func preservingSamples(_ samples: [Int16],
+                                         minimumFrameCount: Int) -> [Int16] {
+        precondition(minimumFrameCount >= 0, "Frame count cannot be negative")
+        guard samples.count < minimumFrameCount else { return samples }
+        return samples + repeatElement(0, count: minimumFrameCount - samples.count)
+    }
+}

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -133,7 +133,7 @@ public final class CoachDriver: @unchecked Sendable {
         // would re-bill the whole working set just to decide "stay silent". The unsent lines ride
         // along on the next substantive turn (sentCount only advances on a send); silence and
         // manual-hint triggers always go through. Logged so gate misfires are auditable.
-        if reason == .turnEnd && !delta.lines.contains(where: { TurnSubstance.isSubstantive($0.text) }) {
+        if reason == .turnEnd && !delta.lines.contains(where: TurnSubstance.isSubstantive) {
             // Log WHAT was skipped (not just that a skip happened) so a gate misfire — a real remark
             // wrongly classified as filler — is visible in the activity viewer, not silent.
             let preview = delta.lines.isEmpty

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 /// The event loop. On a trigger, calls the brain with the timestamped transcript + timing context
-/// and the tool set, and routes tool calls (capture_screen, speak, stay_silent). All judgment lives
-/// in the model — including when to stay quiet and when to answer a direct address — so this just
-/// wires events to tool calls. There is no cooldown or rate cap: every substantive utterance (from
-/// either speaker — an interviewer question can draw a proactive tip) reaches the brain and the brain
-/// decides whether it has anything worth saying (the system prompt carries that restraint). The one
-/// client-side skip is the substance gate: a turn-end whose delta is pure back-channel filler
-/// ("Hmm", "嗯") never becomes a request — see `TurnSubstance`.
+/// and the tool set, and routes tool calls (capture_screen, speak, stay_silent). Response judgment
+/// lives in the model. Manual, silence, and locally observed visual-change triggers arrive with a
+/// fresh capture; ordinary speech leaves the decision to the model's general screen-freshness policy.
+/// There is no cooldown or rate cap: every
+/// substantive utterance (from either speaker — an interviewer question can draw a proactive tip)
+/// reaches the brain and the brain decides whether it has anything worth saying (the system prompt
+/// carries that restraint). The one client-side skip is the substance gate: a turn-end whose delta
+/// is pure back-channel filler ("Hmm", "嗯") never becomes a request — see `TurnSubstance`.
 ///
 /// Session memory is CLIENT-managed (`CoachHistory`): each request is `[system] + history + turn`,
 /// built append-only for prompt-cache hits, and compacted into a summary when it grows past the
@@ -29,6 +30,11 @@ public final class CoachDriver: @unchecked Sendable {
     private let overlay: OverlayRendering
     private let clock: Clock
     private let sessionStart: TimeInterval
+    /// Acknowledges snapshots the coach can use: immediately for ordinary captures, and only after
+    /// the first brain request succeeds for a monitor-supplied stable change.
+    private let onScreenCaptured: (@Sendable (ScreenSnapshot) -> Void)?
+    /// Re-arms a stable monitor candidate when its first brain request did not succeed.
+    private let onScreenCaptureRejected: (@Sendable () -> Void)?
     private let history = CoachHistory()
 
     /// Safety backstop against a pathological model that loops on capture_screen forever.
@@ -39,14 +45,35 @@ public final class CoachDriver: @unchecked Sendable {
     /// Number of transcript lines already sent to the brain. Each turn sends `lines[sentCount...]`
     /// and advances this ONLY after the input reached the server, so a failed turn re-sends its speech.
     private var sentCount = 0
+    private struct AuditedMonitorSnapshotID: Hashable {
+        let hash: UInt64
+        let byteCount: Int
+    }
+    /// Monitor retries reuse the same in-memory image. Persist it before the first network attempt,
+    /// then keep a content-free ID so later attempts remain auditable without duplicating JPEGs.
+    private var auditedMonitorSnapshots: Set<AuditedMonitorSnapshotID> = []
+    // FNV-1a constants. The hash is only a content-free, in-memory retry identity; byte count is
+    // included as an additional collision discriminator and no screen-derived digest is persisted.
+    private static let fnv1a64OffsetBasis: UInt64 = 14_695_981_039_346_656_037
+    private static let fnv1a64Prime: UInt64 = 1_099_511_628_211
+    private struct TurnRequest: Sendable {
+        let reason: TriggerReason
+        /// A stable snapshot supplied by the local monitor. Using this exact image avoids a second
+        /// capture race/failure between detecting a change and sending it to the brain.
+        let suppliedSnapshot: ScreenSnapshot?
+    }
+
     /// A trigger that arrived while a turn was running — coalesced into the running turn's follow-up so
-    /// nothing is dropped and turns don't pile up. The first such trigger is kept and the batched
-    /// speech rides along via the sent-index, so a later trigger needn't displace it.
-    private var pendingTrigger: TriggerReason?
+    /// nothing is dropped and turns don't pile up. Speech rides along via the sent-index; if several
+    /// trigger reasons compete, keep the one carrying the strongest behavior (manual request, then
+    /// visual change, then silence) rather than losing a required fresh-screen capture.
+    private var pendingTrigger: TurnRequest?
 
     public init(config: Config, transcript: RollingTranscript,
                 brain: BrainClient, summarizer: BrainClient? = nil,
-                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock) {
+                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock,
+                onScreenCaptured: (@Sendable (ScreenSnapshot) -> Void)? = nil,
+                onScreenCaptureRejected: (@Sendable () -> Void)? = nil) {
         self.config = config
         self.transcript = transcript
         self.brain = brain
@@ -55,6 +82,8 @@ public final class CoachDriver: @unchecked Sendable {
         self.overlay = overlay
         self.clock = clock
         self.sessionStart = clock.now()
+        self.onScreenCaptured = onScreenCaptured
+        self.onScreenCaptureRejected = onScreenCaptureRejected
     }
 
     // Synchronous lock accessors — NSLock can't be held across an `await`, so all critical sections
@@ -69,21 +98,52 @@ public final class CoachDriver: @unchecked Sendable {
 
     /// Atomically claim the single in-flight slot, OR (if busy) record the trigger as pending. One
     /// critical section so a trigger can never slip between "am I busy?" and "set pending" and be lost.
-    /// Returns true if this call now owns the turn loop. The first pending trigger is kept; the
-    /// coalesced speech rides along regardless, so a later trigger needn't displace it.
-    private func claimOrPend(_ reason: TriggerReason) -> Bool {
-        stateLock.lock(); defer { stateLock.unlock() }
+    /// Returns true if this call now owns the turn loop. The highest-priority pending reason is kept;
+    /// coalesced speech rides along regardless via the transcript delta.
+    private func claimOrPend(_ request: TurnRequest) -> Bool {
+        var rejectedDisplacedMonitorSnapshot = false
+        var rejectedIncomingMonitorSnapshot = false
+        stateLock.lock()
         if isHandling {
-            if pendingTrigger == nil { pendingTrigger = reason }
+            if let pendingTrigger {
+                let incomingPriority = Self.coalescingPriority(request)
+                let pendingPriority = Self.coalescingPriority(pendingTrigger)
+                if incomingPriority > pendingPriority
+                    || (incomingPriority == pendingPriority
+                        && request.reason == .screenChanged
+                        && request.suppliedSnapshot != nil) {
+                    // A manual hint can supersede a queued monitor turn because it takes its own
+                    // fresh screenshot. Re-arm the displaced stable candidate in case that capture
+                    // fails; otherwise the detector would wait forever for an acknowledgement that
+                    // can no longer arrive. A newer monitor snapshot replacing an older one needs no
+                    // rejection because the replacement itself still carries the visual update.
+                    rejectedDisplacedMonitorSnapshot = pendingTrigger.suppliedSnapshot != nil
+                        && request.reason != .screenChanged
+                    self.pendingTrigger = request
+                } else {
+                    // The supplied monitor snapshot was not queued (currently only because a manual
+                    // hint is already pending). Tell the detector it lost this coalescing race so it
+                    // can keep retrying until either that hint observes a fresh screen or the visual
+                    // turn eventually gets a slot.
+                    rejectedIncomingMonitorSnapshot = request.suppliedSnapshot != nil
+                }
+            } else {
+                pendingTrigger = request
+            }
+            stateLock.unlock()
+            if rejectedDisplacedMonitorSnapshot || rejectedIncomingMonitorSnapshot {
+                onScreenCaptureRejected?()
+            }
             return false
         }
         isHandling = true
+        stateLock.unlock()
         return true
     }
 
     /// Atomically take the next pending trigger (keeping the slot) OR release the slot. One critical
     /// section so a trigger arriving exactly as a turn finishes is never orphaned.
-    private func finishTurnOrTakeNext() -> TriggerReason? {
+    private func finishTurnOrTakeNext() -> TurnRequest? {
         stateLock.lock(); defer { stateLock.unlock() }
         if let next = pendingTrigger { pendingTrigger = nil; return next }   // keep isHandling = true
         isHandling = false
@@ -92,14 +152,32 @@ public final class CoachDriver: @unchecked Sendable {
 
     @discardableResult
     public func handleTrigger(_ reason: TriggerReason) async -> TurnOutcome {
+        await handle(TurnRequest(reason: reason, suppliedSnapshot: nil))
+    }
+
+    /// Entry point for the local visual monitor. The stable snapshot it observed is the exact image
+    /// logged and sent; CoachDriver does not take a second screenshot that could fail or race ahead.
+    @discardableResult
+    public func handleScreenChange(_ snapshot: ScreenSnapshot) async -> TurnOutcome {
+        await handle(TurnRequest(reason: .screenChanged, suppliedSnapshot: snapshot))
+    }
+
+    /// Audio turn carrying a stable monitor snapshot. The speech request was already going to happen,
+    /// so attaching this image gives the model current visual context without an extra coach request.
+    @discardableResult
+    public func handleTurnEnd(screenSnapshot: ScreenSnapshot) async -> TurnOutcome {
+        await handle(TurnRequest(reason: .turnEnd, suppliedSnapshot: screenSnapshot))
+    }
+
+    private func handle(_ request: TurnRequest) async -> TurnOutcome {
         // Single-in-flight, but we COALESCE rather than drop: a trigger arriving while a turn runs is
         // recorded as pending and picked up by the running turn when it finishes — so nothing is lost
         // and turns can't pile up. The batched speech rides along automatically via the sent-index.
-        guard claimOrPend(reason) else {
-            jlog("… busy; batching this \(reason) into the running turn")
+        guard claimOrPend(request) else {
+            jlog("… busy; batching this \(request.reason) into the running turn")
             return .busy
         }
-        var current = reason
+        var current = request
         var outcome: TurnOutcome = .silentByModel
         while true {
             outcome = await runTurn(current)
@@ -108,21 +186,24 @@ public final class CoachDriver: @unchecked Sendable {
         }
     }
 
-    /// Run one coaching turn for `reason`.
-    private func runTurn(_ reason: TriggerReason) async -> TurnOutcome {
+    /// Run one coaching turn for `request`.
+    private func runTurn(_ request: TurnRequest) async -> TurnOutcome {
+        let reason = request.reason
         // Stop may have cancelled this turn before it got the slot.
         if Task.isCancelled { jlog("… turn cancelled (stopped) before handling"); return .cancelled }
 
         // Turn-end already shows up as the "🗣 heard:" line from the transcriber; only the silence
-        // trigger needs its own marker.
+        // and screen-only triggers need their own markers.
         if case .silence(let secs) = reason { jlog("🤫 quiet for \(Int(secs))s") }
+        if reason == .screenChanged {
+            jlog("🖥 stable screen change detected — checking current context")
+        }
 
         let now = clock.now()
         let ctx = TriggerContext(reason: reason, sessionElapsedSeconds: now - sessionStart)
 
         // A hotkey trigger leaves no "🗣 heard:" line (the user pressed a key, didn't speak), so record
         // it — with the synthetic request we pre-fill as the user's message — so the activity viewer
-        // shows what the shortcut sent to the brain.
         if reason == .manualHint, let line = ctx.promptLine { jlog("⌨️ hint shortcut — \(line)") }
 
         // The delta: only the lines the brain hasn't seen yet (the rest live in `history`).
@@ -131,9 +212,10 @@ public final class CoachDriver: @unchecked Sendable {
         // The substance gate: a turn-end whose delta is pure back-channel filler (from EITHER
         // speaker) or empty never becomes a request — filler can't produce a tip, and the request
         // would re-bill the whole working set just to decide "stay silent". The unsent lines ride
-        // along on the next substantive turn (sentCount only advances on a send); silence and
-        // manual-hint triggers always go through. Logged so gate misfires are auditable.
-        if reason == .turnEnd && !delta.lines.contains(where: TurnSubstance.isSubstantive) {
+        // along on the next substantive turn (sentCount only advances on a send); silence,
+        // screen-change, and manual-hint triggers always go through. Logged so gate misfires are auditable.
+        if reason == .turnEnd && request.suppliedSnapshot == nil
+            && !delta.lines.contains(where: TurnSubstance.isSubstantive) {
             // Log WHAT was skipped (not just that a skip happened) so a gate misfire — a real remark
             // wrongly classified as filler — is visible in the activity viewer, not silent.
             let preview = delta.lines.isEmpty
@@ -149,30 +231,42 @@ public final class CoachDriver: @unchecked Sendable {
         let historyBase: [ChatMessage] = [.system(coachSystemPrompt)] + history.snapshot()
         // New speech (when there is any) followed by the trigger note (when there is one — a
         // turn-end has none, the stamped delta already carries that signal). Never both empty:
-        // an empty turn-end delta is gated above, and silence/manual-hint always have a note.
+        // an empty turn-end delta is gated above, and silence/screen-change/manual-hint have a note.
         let userText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
                         ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
         var turnMessages: [ChatMessage] = [.user(userText)]
+        var pendingMonitorSnapshot: ScreenSnapshot?
+        var pendingMonitorSnapshotWasAudited = false
+        var pendingOrdinarySnapshot: ScreenSnapshot?
 
-        // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and
-        // inject it into THIS first request — no waiting for the model to call capture_screen.
-        // Forcing `speak` (below) then guarantees a visible hint in a single round trip. Same
-        // off-pool capture + post-capture cancellation guard as the capture_screen tool branch.
-        if reason == .manualHint {
-            let screen = self.screen
-            let shot = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+        // Harness-owned fresh visuals: manual requests, silence checks, and visual-monitor changes
+        // capture HERE and inject the image + OCR into THIS first request. Ordinary speech is not
+        // phrase-matched; the model applies the general screen-freshness policy and can call the
+        // capture tool when the meaning of the turn says the screen may have changed.
+        if request.suppliedSnapshot != nil || Self.needsFreshScreen(reason: reason) {
+            let shot: ScreenSnapshot?
+            if let suppliedSnapshot = request.suppliedSnapshot {
+                if Task.isCancelled {
+                    jlog("… turn cancelled (stopped) before accepting screen change")
+                    return .cancelled
+                }
+                shot = suppliedSnapshot
+                pendingMonitorSnapshot = suppliedSnapshot
+            } else {
+                shot = await captureScreen()
+                pendingOrdinarySnapshot = shot
+            }
             if Task.isCancelled { jlog("… turn cancelled (stopped) after capture"); return .cancelled }
             if let shot {
-                jlog("👁 looking at your screen", image: shot.imageBase64)
+                turnMessages.append(.user(Self.freshSnapshotBlock))
                 turnMessages.append(.userImage(shot.imageBase64))
                 // OCR sidecar: the same window as exact text, so the model reads code instead of
                 // deciphering pixels. Rides as its own user message — there's no tool result to
                 // carry it on this pre-injected path.
                 if let text = shot.recognizedText {
-                    jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
                     turnMessages.append(.user(Self.recognizedTextBlock(text)))
                 }
-            } else { jlog("👁 screenshot failed") }   // still force a hint from transcript/history
+            }
         }
 
         // Force `speak` ONLY for an explicit manual hint; audio-driven turns use `.required` — SOME
@@ -186,34 +280,60 @@ public final class CoachDriver: @unchecked Sendable {
         var iterations = 0
         while iterations < maxToolIterations {
             iterations += 1
+            if let snapshot = pendingMonitorSnapshot, !pendingMonitorSnapshotWasAudited {
+                guard auditMonitorSnapshotBeforeSend(snapshot) else {
+                    onScreenCaptureRejected?()
+                    jlog("Jarvis coach: aborting screen-change request because its audit copy "
+                         + "could not be persisted")
+                    return .screenAuditError
+                }
+                pendingMonitorSnapshotWasAudited = true
+            }
             let response: BrainResponse
             do {
                 response = try await brain.respond(messages: historyBase + turnMessages,
                                                    tools: coachTools, toolChoice: turnToolChoice)
             } catch {
+                if pendingMonitorSnapshot != nil { onScreenCaptureRejected?() }
                 // A cancellation (barge-in / Stop) is expected — report it quietly, not as a failure.
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
                 jlog("Jarvis coach: brain request failed on \(reason): \(error.localizedDescription)")
                 // Speech already marked sent (a later-iteration failure) must not vanish from memory —
                 // commit what this turn accumulated. A first-request failure commits nothing; the
                 // un-advanced sentCount re-sends the delta next turn instead.
-                if committed { commitIfWorthKeeping(turnMessages, deltaText: delta.text) }
+                if committed {
+                    commitIfWorthKeeping(turnMessages, deltaText: delta.text, reason: reason)
+                }
                 return .brainError
             }
+
             // The input provably reached the server — NOW mark the delta as sent.
             if !committed { advanceSentCount(to: delta.upTo); committed = true }
 
             if Task.isCancelled {
+                if pendingMonitorSnapshot != nil { onScreenCaptureRejected?() }
                 jlog("… turn cancelled (stopped) mid-think")
-                commitIfWorthKeeping(turnMessages, deltaText: delta.text)   // the delta was sent; keep memory consistent with it
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text, reason: reason)
                 return .cancelled
+            }
+
+            // A monitor snapshot is acknowledged only after its first request succeeds. Until this
+            // point the detector retains its prior baseline, so a transport failure can retry the
+            // same stable question/code instead of silently losing it.
+            if let snapshot = pendingMonitorSnapshot {
+                onScreenCaptured?(snapshot)
+                pendingMonitorSnapshot = nil
+            }
+            if let snapshot = pendingOrdinarySnapshot {
+                onScreenCaptured?(snapshot)
+                pendingOrdinarySnapshot = nil
             }
 
             // No tool call → a TRUNCATED run (zero items because reasoning blew the token cap), or a
             // model ignoring `tool_choice: required`. Treat the latter as silence — rendering nothing
             // is the safe interpretation. Either way the sent delta must land in memory.
             guard let call = response.toolCalls.first else {
-                commitIfWorthKeeping(turnMessages, deltaText: delta.text)
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text, reason: reason)
                 if let reasonText = response.incompleteReason {
                     jlog("⚠️ response truncated (\(reasonText)) — not deliberate silence")
                     return .truncated
@@ -225,10 +345,7 @@ public final class CoachDriver: @unchecked Sendable {
 
             switch call {
             case .captureScreen(let callId):
-                // ScreenCaptureCLI shells out to `screencapture` and blocks for 100s of ms; run it
-                // off the cooperative pool so it doesn't stall a pool thread while holding the slot.
-                let screen = self.screen
-                let shot = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+                let shot = await captureScreen()
                 // Stop may have fired during the (un-cancellable, detached) capture. Bail before
                 // emitting: otherwise this screenshot — and the reasoning that follows — would be
                 // logged into whatever session is now current (a Start rotates the log mid-turn).
@@ -237,12 +354,6 @@ public final class CoachDriver: @unchecked Sendable {
                     history.commit(turnMessages)
                     return .cancelled
                 }
-                if let shot {
-                    jlog("👁 looking at your screen", image: shot.imageBase64)   // thumbnail in the activity viewer
-                    if let text = shot.recognizedText {
-                        jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
-                    }
-                } else { jlog("👁 screenshot failed") }
                 // Thread the call + its result into this turn's messages; the next iteration's
                 // request carries them (and they land in history at commit, where the screenshot
                 // becomes a text stub — only the OCR text outlives the turn). The OCR sidecar
@@ -262,6 +373,7 @@ public final class CoachDriver: @unchecked Sendable {
                     turnMessages.append(.assistantToolCalls(response.rawToolCalls))
                 }
                 if let shot {
+                    pendingOrdinarySnapshot = shot
                     turnMessages.append(.init(role: .tool, text: Self.captureResultText(shot), toolCallId: callId))
                     turnMessages.append(.userImage(shot.imageBase64))
                 } else {
@@ -288,7 +400,7 @@ public final class CoachDriver: @unchecked Sendable {
                 // The model's explicit stay-quiet decision. Deliberately NOT recorded: the call and
                 // its non-answer would only bloat every later request — silence needs no memory.
                 jlog("… nothing useful to add, staying silent")
-                commitIfWorthKeeping(turnMessages, deltaText: delta.text)
+                commitIfWorthKeeping(turnMessages, deltaText: delta.text, reason: reason)
                 await compactIfNeeded()
                 return .silentByModel
             }
@@ -299,29 +411,110 @@ public final class CoachDriver: @unchecked Sendable {
         return .exhausted
     }
 
-    /// Commit a finished turn to session memory ONLY when it left something a later turn can use —
-    /// new transcript lines, or tool activity (a capture the model may refer back to). A turn that
-    /// was just a trigger note the model shrugged at (a silence check → stay_silent) is dropped
-    /// whole: committing it would pile up answerless user messages in memory, re-billed on every
-    /// later request and confusing to read back.
-    private func commitIfWorthKeeping(_ turn: [ChatMessage], deltaText: String) {
-        guard !deltaText.isEmpty || turn.count > 1 else { return }
+    /// A monitor-only request that produced no tip is an acknowledged freshness probe, not useful
+    /// conversation memory. Keeping its OCR and trigger note would make every later request larger
+    /// during active typing. Speech, spoken tips, and non-monitor tool turns retain their existing
+    /// history behavior.
+    private func commitIfWorthKeeping(_ turn: [ChatMessage], deltaText: String,
+                                      reason: TriggerReason) {
+        guard !deltaText.isEmpty || (reason != .screenChanged && turn.count > 1) else { return }
         history.commit(turn)
     }
+
+    private static func needsFreshScreen(reason: TriggerReason) -> Bool {
+        switch reason {
+        case .manualHint, .silence, .screenChanged:
+            return true
+        case .turnEnd:
+            return false
+        }
+    }
+
+    private static func coalescingPriority(_ request: TurnRequest) -> Int {
+        if request.suppliedSnapshot != nil { return 2 }
+        return switch request.reason {
+        case .turnEnd: 0
+        case .silence: 1
+        case .screenChanged: 2
+        case .manualHint: 3
+        }
+    }
+
+    /// ScreenCaptureCLI shells out to `screencapture` and blocks for 100s of ms; run it off the
+    /// cooperative pool. The image is logged immediately, but the caller acknowledges it to the
+    /// visual monitor only after the brain request carrying it succeeds.
+    private func captureScreen() async -> ScreenSnapshot? {
+        let screen = self.screen
+        let shot = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
+        guard !Task.isCancelled else { return shot }
+
+        if let shot {
+            acceptScreenSnapshot(shot)
+        } else {
+            jlog("👁 screenshot failed")
+        }
+        return shot
+    }
+
+    /// Persists the exact snapshot the brain will consume. Monitor acknowledgement is deliberately a
+    /// separate success-only callback; ordinary captures acknowledge immediately after this call.
+    private func acceptScreenSnapshot(_ shot: ScreenSnapshot) {
+        jlog("👁 looking at your screen", image: shot.imageBase64)
+        if let text = shot.recognizedText {
+            jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
+        }
+    }
+
+    /// The traffic log redacts image bytes, so the owner-only activity log must receive a monitor
+    /// screenshot before the request can leave the machine. A successful response separately
+    /// acknowledges the monitor baseline; transport failure keeps the candidate retryable.
+    private func auditMonitorSnapshotBeforeSend(_ shot: ScreenSnapshot) -> Bool {
+        let id = Self.auditedSnapshotID(for: shot.imageBase64)
+        stateLock.lock()
+        let alreadyAudited = auditedMonitorSnapshots.contains(id)
+        stateLock.unlock()
+        if !alreadyAudited {
+            guard jlogSynchronously(
+                "👁 looking at your screen", image: shot.imageBase64
+            ) else { return false }
+            stateLock.lock(); auditedMonitorSnapshots.insert(id); stateLock.unlock()
+            if let text = shot.recognizedText {
+                jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
+            }
+        } else {
+            jlog("👁 reusing previously logged screen capture for retry")
+        }
+        return true
+    }
+
+    private static func auditedSnapshotID(for base64: String) -> AuditedMonitorSnapshotID {
+        var hash = fnv1a64OffsetBasis
+        var byteCount = 0
+        for byte in base64.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= fnv1a64Prime
+            byteCount += 1
+        }
+        return AuditedMonitorSnapshotID(hash: hash, byteCount: byteCount)
+    }
+    private static let freshSnapshotBlock = """
+    Fresh point-in-time screen capture taken for this turn. It shows the screen only at capture time
+    and may become stale after any typing, navigation, or newly displayed question.
+    """
 
     /// The capture_screen tool-result text: the OCR sidecar rides here when present, so exact text
     /// and the image arrive as one result the model reasons over together.
     private static func captureResultText(_ shot: ScreenSnapshot) -> String {
-        guard let text = shot.recognizedText else { return "screenshot captured" }
-        return "screenshot captured\n\n\(recognizedTextBlock(text))"
+        guard let text = shot.recognizedText else { return "fresh point-in-time screenshot captured" }
+        return "fresh point-in-time screenshot captured\n\n\(recognizedTextBlock(text))"
     }
 
     /// Framed so the model treats OCR as a reading aid, not gospel — recognition mangles the odd
     /// identifier, and the screenshot stays the ground truth to verify against.
     private static func recognizedTextBlock(_ text: String) -> String {
         """
-        Text recognized on the captured window (on-device OCR — may contain errors; \
-        the screenshot image is ground truth):
+        Text recognized on this point-in-time captured window (on-device OCR — may contain errors; \
+        the same screenshot image is ground truth, and both may become stale after the screen changes):
         \(text)
         """
     }
@@ -383,5 +576,6 @@ public enum TurnOutcome: Sendable, Equatable {
     case busy             // a turn was in flight; this trigger was coalesced into it (not dropped)
     case cancelled        // Stop cancelled the turn
     case brainError       // the brain request threw (401/429/network)
+    case screenAuditError // request was aborted because its screenshot could not be persisted
     case exhausted        // ran the tool loop to the cap without a terminal speak
 }

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -5,7 +5,7 @@ import Foundation
 // below is valid under strict (no properties, none required).
 public let captureScreenTool = ToolDef(
     name: "capture_screen",
-    description: "Take a screenshot of the user's screen to see the LeetCode problem and their code. Call this only when you need to see the screen to give a useful, specific tip. Returns an image.",
+    description: "Take a fresh point-in-time screenshot of the user's screen to see the interview question and their current code. Screenshots become stale after typing, navigation, or newly displayed content, so call this whenever the current visual state matters and no fresh screenshot is already attached. Returns an image.",
     parametersJSON: #"{"type":"object","properties":{},"required":[],"additionalProperties":false}"#
 )
 
@@ -36,8 +36,17 @@ the interviewer asks "me" a question, sets a new requirement, or points out a pr
 proactively offer "me" a short tip for handling it. Only "me" can trigger the must-reply rule below;
 for "them:" lines you decide, and staying quiet remains the default when "me" is doing fine.
 
-You cannot see the screen unless you call capture_screen — do that when you need to read the problem or
-their code to be specific and correct.
+You do not receive a live screen feed. You can see the screen only by calling capture_screen or when
+a screenshot is attached to the CURRENT request. Every screenshot and its OCR are point-in-time
+observations: they can become stale as soon as someone types, navigates, or displays a question. After
+a turn ends, screenshot pixels are discarded; only its capture marker and OCR text may remain in
+conversation history, and those historical observations never prove the current screen. When the
+current request already contains a fresh screenshot, reason from it directly; do not capture the same
+unchanged screen again. When new speech means that a question, prompt, code, or solution may have
+appeared, may be about to appear, or may have changed, and no current screenshot proves the state,
+call capture_screen before giving screen-specific advice. If the capture happens before the expected
+update and still looks blank or unchanged, call stay_silent; a later stable screen-change turn will
+carry the updated screen.
 
 Each turn you get timing context. New speech arrives under "New since last turn", each line stamped
 [mm:ss] with session time — its presence means someone just finished speaking. A quiet stretch

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -58,6 +58,20 @@ public struct Config: Sendable {
     public var realtimePingIntervalSeconds: TimeInterval
     /// Maximum time to receive a pong before declaring the apparently-open socket unhealthy.
     public var realtimePongTimeoutSeconds: TimeInterval
+    /// Cadence for low-resolution, memory-only one-shot screen observations. Full-resolution capture
+    /// and OCR happen after visual quiescence, not per poll.
+    public var screenMonitorFrameIntervalSeconds: TimeInterval
+    /// How long the native stream must report no meaningful changes before the screen is considered
+    /// stable enough for one full capture.
+    public var screenMonitorQuiescenceSeconds: TimeInterval
+    /// Hard cost bound for monitor-originated coach requests. A pending snapshot may still piggyback
+    /// on an audio-triggered request inside this interval because that adds no request.
+    public var screenMonitorMinimumRequestIntervalSeconds: TimeInterval
+    /// Brief window for a stable snapshot to join the next spoken turn before a screen-only request.
+    public var screenMonitorPiggybackWaitSeconds: TimeInterval
+    /// Ignore visible pixel deltas smaller than this fraction of the captured surface
+    /// (caret/compositor noise).
+    public var screenMonitorMinimumChangedAreaRatio: Double
 
     public init(
         silenceTimeoutSeconds: TimeInterval = 120,
@@ -74,7 +88,12 @@ public struct Config: Sendable {
         maxBufferedAudioSeconds: TimeInterval = 60,
         realtimeReadyTimeoutSeconds: TimeInterval = 10,
         realtimePingIntervalSeconds: TimeInterval = 20,
-        realtimePongTimeoutSeconds: TimeInterval = 10
+        realtimePongTimeoutSeconds: TimeInterval = 10,
+        screenMonitorFrameIntervalSeconds: TimeInterval = 1,
+        screenMonitorQuiescenceSeconds: TimeInterval = 1.25,
+        screenMonitorMinimumRequestIntervalSeconds: TimeInterval = 60,
+        screenMonitorPiggybackWaitSeconds: TimeInterval = 2,
+        screenMonitorMinimumChangedAreaRatio: Double = 0.0001
     ) {
         self.silenceTimeoutSeconds = silenceTimeoutSeconds
         self.silenceMaxIntervalSeconds = silenceMaxIntervalSeconds
@@ -91,6 +110,11 @@ public struct Config: Sendable {
         self.realtimeReadyTimeoutSeconds = realtimeReadyTimeoutSeconds
         self.realtimePingIntervalSeconds = realtimePingIntervalSeconds
         self.realtimePongTimeoutSeconds = realtimePongTimeoutSeconds
+        self.screenMonitorFrameIntervalSeconds = screenMonitorFrameIntervalSeconds
+        self.screenMonitorQuiescenceSeconds = screenMonitorQuiescenceSeconds
+        self.screenMonitorMinimumRequestIntervalSeconds = screenMonitorMinimumRequestIntervalSeconds
+        self.screenMonitorPiggybackWaitSeconds = screenMonitorPiggybackWaitSeconds
+        self.screenMonitorMinimumChangedAreaRatio = screenMonitorMinimumChangedAreaRatio
     }
 
     // Overlay appearance: defaults + allowed ranges. The persisted values live in UserDefaults via

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -86,16 +86,44 @@ public final class ActivityLog: @unchecked Sendable {
     /// reference always points at a file that exists.
     public func record(_ message: String, imageBase64: String? = nil, at date: Date = Date()) {
         queue.async { [self] in
-            guard let dir else { return }
-            let shotName = imageBase64.flatMap { saveShot($0, in: dir) }
-            let entry = Entry(time: df.string(from: date), message: message, imageFile: shotName)
-            appendJSONL(entry, in: dir)
-            entries.append(entry)
-            totalCount += 1
-            if entries.count > maxLines { entries.removeFirst(entries.count - maxLines) }
-            // Push with the live bytes in hand (no disk read on the hot path).
-            onAppend?(Self.rowScript(time: entry.time, message: entry.message, imageBase64: imageBase64))
+            _ = recordLocked(message, imageBase64: imageBase64, at: date,
+                             requirePersistence: false)
         }
+    }
+
+    /// Audit-critical variant used immediately before a monitor screenshot can leave the machine.
+    /// Returns true only after the owner-only JPEG and its JSONL reference have reached the
+    /// filesystem. A false result lets the caller abort network transmission rather than create an
+    /// unaudited screen request.
+    @discardableResult
+    public func recordSynchronously(_ message: String, imageBase64: String? = nil,
+                                    at date: Date = Date()) -> Bool {
+        queue.sync {
+            recordLocked(message, imageBase64: imageBase64, at: date,
+                         requirePersistence: true)
+        }
+    }
+
+    private func recordLocked(_ message: String, imageBase64: String?, at date: Date,
+                              requirePersistence: Bool) -> Bool {
+        guard let dir else { return false }
+        let shotName = imageBase64.flatMap { saveShot($0, in: dir) }
+        if requirePersistence, imageBase64 != nil, shotName == nil { return false }
+        let entry = Entry(time: df.string(from: date), message: message, imageFile: shotName)
+        let jsonPersisted = appendJSONL(entry, in: dir)
+        if requirePersistence, !jsonPersisted {
+            if let shotName {
+                try? FileManager.default.removeItem(at: dir.appendingPathComponent(shotName))
+            }
+            return false
+        }
+        entries.append(entry)
+        totalCount += 1
+        if entries.count > maxLines { entries.removeFirst(entries.count - maxLines) }
+        // Push with the live bytes in hand (no disk read on the hot path).
+        onAppend?(Self.rowScript(time: entry.time, message: entry.message,
+                                 imageBase64: imageBase64))
+        return jsonPersisted && (imageBase64 == nil || shotName != nil)
     }
 
     /// Atomically register the live observer and capture the current snapshot, so every subsequent
@@ -132,15 +160,20 @@ public final class ActivityLog: @unchecked Sendable {
 
     /// Append one JSON line to `jarvis-activity.jsonl`. Best-effort; a failed write just means that
     /// line won't survive into history (the live push already happened). Must run on `queue`.
-    private func appendJSONL(_ entry: Entry, in dir: URL) {
+    private func appendJSONL(_ entry: Entry, in dir: URL) -> Bool {
         let pe = PersistedEntry(t: entry.time, m: entry.message, s: entry.imageFile)
-        guard let data = try? JSONEncoder().encode(pe) else { return }
+        guard let data = try? JSONEncoder().encode(pe) else { return false }
         let url = dir.appendingPathComponent("jarvis-activity.jsonl")
-        guard let fh = try? FileHandle(forWritingTo: url) else { return }
+        guard let fh = try? FileHandle(forWritingTo: url) else { return false }
         defer { try? fh.close() }
-        _ = try? fh.seekToEnd()
-        try? fh.write(contentsOf: data)
-        try? fh.write(contentsOf: Data([0x0A]))   // newline
+        do {
+            _ = try fh.seekToEnd()
+            try fh.write(contentsOf: data)
+            try fh.write(contentsOf: Data([0x0A]))   // newline
+            return true
+        } catch {
+            return false
+        }
     }
 
     // MARK: - Pure rendering (testable without a WebView)
@@ -172,7 +205,7 @@ public final class ActivityLog: @unchecked Sendable {
     static func cssClass(for message: String) -> String {
         let m = message.trimmingCharacters(in: .whitespaces)
         if m.hasPrefix("💬") { return "say" }
-        if m.hasPrefix("👁") { return "see" }
+        if m.hasPrefix("👁") || m.hasPrefix("🖥") { return "see" }
         if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
         if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
         let low = m.lowercased()

--- a/Sources/JarvisCore/Diagnostics/AudioContinuityWitness+Types.swift
+++ b/Sources/JarvisCore/Diagnostics/AudioContinuityWitness+Types.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+extension AudioContinuityWitness {
+    public struct ActivityConfiguration: Equatable, Sendable {
+        public let initialNoiseFloorRMS: Double
+        public let minimumNoiseFloorRMS: Double
+        public let minimumActiveRMS: Double
+        public let minimumActivePeak: Double
+        public let activationMultiplier: Double
+        public let releaseMultiplier: Double
+        public let noiseAdaptationRate: Double
+
+        public init(initialNoiseFloorRMS: Double = 80,
+                    minimumNoiseFloorRMS: Double = 20,
+                    minimumActiveRMS: Double = 220,
+                    minimumActivePeak: Double = 600,
+                    activationMultiplier: Double = 3,
+                    releaseMultiplier: Double = 1.6,
+                    noiseAdaptationRate: Double = 0.05) {
+            precondition(initialNoiseFloorRMS >= minimumNoiseFloorRMS)
+            precondition(minimumNoiseFloorRMS >= 0 && minimumActiveRMS > 0 && minimumActivePeak > 0)
+            precondition(activationMultiplier > releaseMultiplier && releaseMultiplier > 0)
+            precondition((0...1).contains(noiseAdaptationRate))
+            self.initialNoiseFloorRMS = initialNoiseFloorRMS
+            self.minimumNoiseFloorRMS = minimumNoiseFloorRMS
+            self.minimumActiveRMS = minimumActiveRMS
+            self.minimumActivePeak = minimumActivePeak
+            self.activationMultiplier = activationMultiplier
+            self.releaseMultiplier = releaseMultiplier
+            self.noiseAdaptationRate = noiseAdaptationRate
+        }
+    }
+
+    public struct Configuration: Equatable, Sendable {
+        public let snapshotInterval: TimeInterval
+        public let captureStallThreshold: TimeInterval
+        public let deliveryLagThreshold: TimeInterval
+        public let sustainedActivityDuration: TimeInterval
+        public let activityHangover: TimeInterval
+        public let serverSpeechGrace: TimeInterval
+        public let maximumPendingCaptures: Int
+        public let activity: ActivityConfiguration
+
+        public init(snapshotInterval: TimeInterval = 15,
+                    captureStallThreshold: TimeInterval = 2,
+                    deliveryLagThreshold: TimeInterval = 0.25,
+                    sustainedActivityDuration: TimeInterval = 0.75,
+                    activityHangover: TimeInterval = 0.5,
+                    serverSpeechGrace: TimeInterval = 3,
+                    maximumPendingCaptures: Int = 4_096,
+                    activity: ActivityConfiguration = .init()) {
+            precondition(snapshotInterval > 0 && captureStallThreshold > 0)
+            precondition(deliveryLagThreshold > 0 && sustainedActivityDuration >= 0)
+            precondition(activityHangover >= 0 && serverSpeechGrace >= 0
+                         && maximumPendingCaptures > 0)
+            self.snapshotInterval = snapshotInterval
+            self.captureStallThreshold = captureStallThreshold
+            self.deliveryLagThreshold = deliveryLagThreshold
+            self.sustainedActivityDuration = sustainedActivityDuration
+            self.activityHangover = activityHangover
+            self.serverSpeechGrace = serverSpeechGrace
+            self.maximumPendingCaptures = maximumPendingCaptures
+            self.activity = activity
+        }
+    }
+
+    public enum ServerSpeechSignal: Equatable, Sendable {
+        case speechStarted
+        case speechStopped
+        case transcriptionDelta
+        case transcriptionCompleted
+        case transcriptionFailed
+    }
+
+    public enum SequenceStage: Equatable, Sendable {
+        case capture
+        case delivery
+    }
+
+    public enum Anomaly: Equatable, Sendable {
+        case captureStalled(lastCaptureAt: TimeInterval?, duration: TimeInterval)
+        case sequenceGap(stage: SequenceStage, expected: UInt64, observed: UInt64)
+        case deliveryWithoutCapture(sequence: UInt64)
+        case deliverySampleCountMismatch(sequence: UInt64, captured: Int, delivered: Int)
+        case captureToDeliveryLag(sequence: UInt64, lag: TimeInterval)
+        case reconnectBufferOverflow(evictedChunks: Int, firstSequence: UInt64?,
+                                     lastSequence: UInt64?)
+        case localActivityUnmatched(activeSince: TimeInterval, duration: TimeInterval)
+        case serverSpeechObservedAfterUnmatchedActivity(activeSince: TimeInterval,
+                                                        serverObservedAt: TimeInterval)
+    }
+
+    public struct SocketGenerationSnapshot: Equatable, Sendable {
+        public let generation: Int
+        public let sendAttempts: Int
+        public let sendSuccesses: Int
+        public let sendFailures: Int
+        public let lastSendSequence: UInt64?
+        public let lastSendAttemptAt: TimeInterval?
+        public let lastSendSuccessAt: TimeInterval?
+        public let lastSendFailureAt: TimeInterval?
+        public let serverSpeechSignals: Int
+        public let lastServerSignal: ServerSpeechSignal?
+        public let lastServerObservedAt: TimeInterval?
+        public let lastServerAudioTimeMilliseconds: Int?
+    }
+
+    public struct Snapshot: Equatable, Sendable {
+        public let emittedAt: TimeInterval
+        public let capturedChunks: Int
+        public let capturedSamples: Int
+        public let deliveredChunks: Int
+        public let deliveredSamples: Int
+        public let lastCapturedSequence: UInt64?
+        public let lastDeliveredSequence: UInt64?
+        public let lastCaptureAt: TimeInterval?
+        public let lastDeliveryAt: TimeInterval?
+        public let pendingCapturedChunks: Int
+        public let localActivityDetected: Bool
+        public let localActivitySince: TimeInterval?
+        public let lastLocalActivityAt: TimeInterval?
+        public let latestSocketGeneration: Int?
+        public let socketGenerations: [SocketGenerationSnapshot]
+    }
+
+    public struct Output: Equatable, Sendable {
+        public let snapshot: Snapshot?
+        public let anomalies: [Anomaly]
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift
+++ b/Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift
@@ -1,0 +1,416 @@
+import Foundation
+
+/// Privacy-preserving evidence that captured audio is continuing through local delivery and into a
+/// Realtime socket. It retains only content-free metadata: sequence/sample counts, timestamps,
+/// counters, socket generations, server audio-clock values, and one local activity bit.
+///
+/// Callers provide all timestamps and call `poll` while idle, so behavior is deterministic and this
+/// type owns no timer. PCM passed to `recordDelivery` is synchronously reduced to an activity decision
+/// and is never stored, returned, logged, or converted to text.
+///
+/// `@unchecked Sendable`: every mutable field, including the activity detector, is protected by
+/// `lock`; no borrowed PCM escapes the locked `recordDelivery` call.
+public final class AudioContinuityWitness: @unchecked Sendable {
+    private struct CapturedChunk {
+        let sampleCount: Int
+        let capturedAt: TimeInterval
+    }
+
+    private struct SocketStats {
+        var sendAttempts = 0
+        var sendSuccesses = 0
+        var sendFailures = 0
+        var lastSendSequence: UInt64?
+        var lastSendAttemptAt: TimeInterval?
+        var lastSendSuccessAt: TimeInterval?
+        var lastSendFailureAt: TimeInterval?
+        var serverSpeechSignals = 0
+        var lastServerSignal: ServerSpeechSignal?
+        var lastServerObservedAt: TimeInterval?
+        var lastServerAudioTimeMilliseconds: Int?
+    }
+
+    private let configuration: Configuration
+    private let startedAt: TimeInterval
+    private let lock = NSLock()
+    private var activityDetector: AdaptiveAudioActivityDetector
+    private var nextSnapshotAt: TimeInterval
+
+    private var capturedChunks = 0
+    private var capturedSamples = 0
+    private var deliveredChunks = 0
+    private var deliveredSamples = 0
+    private var lastCapturedSequence: UInt64?
+    private var lastDeliveredSequence: UInt64?
+    private var lastCaptureAt: TimeInterval?
+    private var lastDeliveryAt: TimeInterval?
+    private var pendingCaptures: [UInt64: CapturedChunk] = [:]
+    private var pendingCaptureOrder: [UInt64] = []
+    private var pendingCaptureCursor = 0
+
+    private var socketStats: [Int: SocketStats] = [:]
+    private var latestSocketGeneration: Int?
+    private var serverSpeechActive = false
+    /// Session-relative audio-clock position of the latest active server VAD start. Observed arrival
+    /// time is insufficient: a delayed terminal/start event for older audio must not match a newer
+    /// local-activity episode merely because it arrived later.
+    private var activeServerSpeechStartedAt: TimeInterval?
+
+    private var localActivitySince: TimeInterval?
+    private var lastLocalActivityAt: TimeInterval?
+    private var localActivityMatched = false
+    private var captureStallReported = false
+    private var deliveryLagReported = false
+    private var unmatchedActivityReported = false
+
+    /// All subsequent timestamps must use the same session-relative monotonic clock as `startedAt`.
+    public init(configuration: Configuration = .init(), startedAt: TimeInterval) {
+        self.configuration = configuration
+        self.startedAt = startedAt
+        activityDetector = AdaptiveAudioActivityDetector(configuration: configuration.activity)
+        nextSnapshotAt = startedAt + configuration.snapshotInterval
+    }
+
+    @discardableResult
+    public func recordCapture(sequence: UInt64, sampleCount: Int,
+                              at timestamp: TimeInterval) -> Output {
+        precondition(sampleCount >= 0)
+        lock.lock(); defer { lock.unlock() }
+        var anomalies: [Anomaly] = []
+        let stallReference = lastCaptureAt ?? startedAt
+        let stalledFor = max(0, timestamp - stallReference)
+        if !captureStallReported, stalledFor >= configuration.captureStallThreshold {
+            anomalies.append(.captureStalled(lastCaptureAt: lastCaptureAt, duration: stalledFor))
+        }
+        captureStallReported = false
+        if let previous = lastCapturedSequence, sequence != previous &+ 1 {
+            anomalies.append(.sequenceGap(stage: .capture, expected: previous &+ 1,
+                                          observed: sequence))
+        }
+        lastCapturedSequence = sequence
+        lastCaptureAt = timestamp
+        capturedChunks += 1
+        capturedSamples += sampleCount
+        if pendingCaptures[sequence] == nil { pendingCaptureOrder.append(sequence) }
+        pendingCaptures[sequence] = CapturedChunk(sampleCount: sampleCount, capturedAt: timestamp)
+        trimPendingCapturesLocked()
+        return finishLocked(at: timestamp, immediate: anomalies)
+    }
+
+    /// `pcm16` must be little-endian mono PCM16 for the chunk identified by `sequence`. The bytes are
+    /// inspected synchronously for activity and are not assigned to any retained field.
+    @discardableResult
+    public func recordDelivery(sequence: UInt64, pcm16: Data,
+                               at timestamp: TimeInterval) -> Output {
+        lock.lock(); defer { lock.unlock() }
+        var anomalies: [Anomaly] = []
+        let expected = lastDeliveredSequence.map { $0 &+ 1 }
+            ?? oldestPendingCaptureLocked()?.sequence
+        if let expected, sequence != expected {
+            anomalies.append(.sequenceGap(stage: .delivery, expected: expected,
+                                          observed: sequence))
+        }
+        lastDeliveredSequence = sequence
+        lastDeliveryAt = timestamp
+        deliveredChunks += 1
+
+        let activity = activityDetector.observe(pcm16: pcm16)
+        deliveredSamples += activity.sampleCount
+        let captured = pendingCaptures.removeValue(forKey: sequence)
+        prunePendingCaptureOrderLocked()
+        if let captured {
+            if captured.sampleCount != activity.sampleCount {
+                anomalies.append(.deliverySampleCountMismatch(sequence: sequence,
+                                                               captured: captured.sampleCount,
+                                                               delivered: activity.sampleCount))
+            }
+            let lag = max(0, timestamp - captured.capturedAt)
+            if lag >= configuration.deliveryLagThreshold {
+                if !deliveryLagReported {
+                    anomalies.append(.captureToDeliveryLag(sequence: sequence, lag: lag))
+                    deliveryLagReported = true
+                }
+            } else {
+                deliveryLagReported = false
+            }
+            updateLocalActivityLocked(isActive: activity.isActive, at: captured.capturedAt)
+        } else {
+            anomalies.append(.deliveryWithoutCapture(sequence: sequence))
+            updateLocalActivityLocked(isActive: activity.isActive, at: timestamp)
+        }
+        return finishLocked(at: timestamp, immediate: anomalies)
+    }
+
+    @discardableResult
+    public func recordSendAttempt(sequence: UInt64, socketGeneration: Int,
+                                  at timestamp: TimeInterval) -> Output {
+        lock.lock(); defer { lock.unlock() }
+        selectSocketGenerationLocked(socketGeneration)
+        var stats = socketStats[socketGeneration] ?? SocketStats()
+        stats.sendAttempts += 1
+        stats.lastSendSequence = sequence
+        stats.lastSendAttemptAt = timestamp
+        socketStats[socketGeneration] = stats
+        return finishLocked(at: timestamp)
+    }
+
+    @discardableResult
+    public func recordSendSuccess(sequence: UInt64, socketGeneration: Int,
+                                  at timestamp: TimeInterval) -> Output {
+        lock.lock(); defer { lock.unlock() }
+        selectSocketGenerationLocked(socketGeneration)
+        var stats = socketStats[socketGeneration] ?? SocketStats()
+        stats.sendSuccesses += 1
+        stats.lastSendSequence = sequence
+        stats.lastSendSuccessAt = timestamp
+        socketStats[socketGeneration] = stats
+        return finishLocked(at: timestamp)
+    }
+
+    @discardableResult
+    public func recordSendFailure(sequence: UInt64, socketGeneration: Int,
+                                  at timestamp: TimeInterval) -> Output {
+        lock.lock(); defer { lock.unlock() }
+        selectSocketGenerationLocked(socketGeneration)
+        var stats = socketStats[socketGeneration] ?? SocketStats()
+        stats.sendFailures += 1
+        stats.lastSendSequence = sequence
+        stats.lastSendFailureAt = timestamp
+        socketStats[socketGeneration] = stats
+        return finishLocked(at: timestamp)
+    }
+
+    /// Records intentional bounded-buffer eviction without retaining any PCM. This is the point at
+    /// which exact replay is no longer possible after an unusually long outage, so it must be visible
+    /// in the same continuity evidence as capture, delivery, and transport.
+    @discardableResult
+    public func recordReconnectBufferOverflow(evictedSequences: [UInt64],
+                                              at timestamp: TimeInterval) -> Output {
+        guard !evictedSequences.isEmpty else { return poll(at: timestamp) }
+        lock.lock(); defer { lock.unlock() }
+        return finishLocked(at: timestamp, immediate: [
+            .reconnectBufferOverflow(
+                evictedChunks: evictedSequences.count,
+                firstSequence: evictedSequences.first,
+                lastSequence: evictedSequences.last),
+        ])
+    }
+
+    @discardableResult
+    public func recordServerSpeech(_ signal: ServerSpeechSignal,
+                                   audioTimeMilliseconds: Int?, socketGeneration: Int,
+                                   sessionAudioTime: TimeInterval? = nil,
+                                   observedAt timestamp: TimeInterval) -> Output {
+        precondition(audioTimeMilliseconds == nil || audioTimeMilliseconds! >= 0)
+        precondition(sessionAudioTime == nil || sessionAudioTime!.isFinite)
+        lock.lock(); defer { lock.unlock() }
+        selectSocketGenerationLocked(socketGeneration)
+        var stats = socketStats[socketGeneration] ?? SocketStats()
+        stats.serverSpeechSignals += 1
+        stats.lastServerSignal = signal
+        stats.lastServerObservedAt = timestamp
+        if let audioTimeMilliseconds { stats.lastServerAudioTimeMilliseconds = audioTimeMilliseconds }
+        socketStats[socketGeneration] = stats
+
+        var anomalies: [Anomaly] = []
+        if latestSocketGeneration == socketGeneration {
+            switch signal {
+            case .speechStarted:
+                serverSpeechActive = true
+                activeServerSpeechStartedAt = sessionAudioTime
+                if let activeSince = localActivitySince,
+                   serverStartMatchesCurrentActivityLocked(sessionAudioTime) {
+                    if unmatchedActivityReported {
+                        anomalies.append(.serverSpeechObservedAfterUnmatchedActivity(
+                            activeSince: activeSince, serverObservedAt: timestamp))
+                    }
+                    localActivityMatched = true
+                    unmatchedActivityReported = false
+                }
+            case .speechStopped:
+                serverSpeechActive = false
+                activeServerSpeechStartedAt = nil
+            case .transcriptionDelta, .transcriptionCompleted, .transcriptionFailed:
+                // Terminal/delta events may arrive late for an earlier item. They remain useful
+                // transport metadata but are not evidence that the current local episode matched.
+                break
+            }
+        }
+        return finishLocked(at: timestamp, immediate: anomalies)
+    }
+
+    /// Call while no other observations are arriving so stalls, grace-window anomalies, and periodic
+    /// snapshots still advance. `forceSnapshot` is useful for a final session summary.
+    public func poll(at timestamp: TimeInterval, forceSnapshot: Bool = false) -> Output {
+        lock.lock(); defer { lock.unlock() }
+        return finishLocked(at: timestamp, forceSnapshot: forceSnapshot)
+    }
+
+    private func updateLocalActivityLocked(isActive: Bool, at timestamp: TimeInterval) {
+        if isActive {
+            // Start a new episode after a reported/matched one even if no explicit quiet chunk was
+            // delivered between them. Short sub-threshold gaps remain inside one spoken phrase.
+            if let activeSince = localActivitySince, let lastActiveAt = lastLocalActivityAt,
+               timestamp - lastActiveAt > configuration.activityHangover {
+                let observed = lastActiveAt - activeSince
+                if localActivityMatched || unmatchedActivityReported
+                    || observed < configuration.sustainedActivityDuration {
+                    localActivitySince = nil
+                    lastLocalActivityAt = nil
+                    localActivityMatched = false
+                    unmatchedActivityReported = false
+                }
+            }
+            if localActivitySince == nil {
+                localActivitySince = timestamp
+                lastLocalActivityAt = timestamp
+                localActivityMatched = serverSpeechActive
+                    && serverStartMatchesCurrentActivityLocked(activeServerSpeechStartedAt)
+                unmatchedActivityReported = false
+            }
+            lastLocalActivityAt = timestamp
+        } else {
+            // Do not erase an unmatched episode as soon as speech ends: the whole purpose of the
+            // grace window is to notice that local activity ended without any server speech event.
+            // Matched/reported episodes can be released once their short hangover has elapsed.
+            if let lastLocalActivityAt,
+               timestamp - lastLocalActivityAt >= configuration.activityHangover,
+               localActivityMatched || unmatchedActivityReported {
+                localActivitySince = nil
+                self.lastLocalActivityAt = nil
+                localActivityMatched = false
+                unmatchedActivityReported = false
+            }
+        }
+    }
+
+    private func selectSocketGenerationLocked(_ generation: Int) {
+        guard latestSocketGeneration == nil || generation > latestSocketGeneration! else { return }
+        latestSocketGeneration = generation
+        serverSpeechActive = false
+        activeServerSpeechStartedAt = nil
+        if localActivitySince != nil {
+            localActivityMatched = false
+            // Keep an already-reported warning latched across reconnects so one continuous local
+            // activity episode cannot add duplicate transcript markers for each socket generation.
+        }
+    }
+
+    private func serverStartMatchesCurrentActivityLocked(_ serverStart: TimeInterval?) -> Bool {
+        guard let serverStart, let activeSince = localActivitySince,
+              let lastActiveAt = lastLocalActivityAt else { return false }
+        let tolerance = configuration.activityHangover
+        return serverStart >= activeSince - tolerance
+            && serverStart <= lastActiveAt + tolerance
+    }
+
+    private func finishLocked(at timestamp: TimeInterval, immediate: [Anomaly] = [],
+                              forceSnapshot: Bool = false) -> Output {
+        var anomalies = immediate
+        let captureReference = lastCaptureAt ?? startedAt
+        let stalledFor = max(0, timestamp - captureReference)
+        if stalledFor >= configuration.captureStallThreshold, !captureStallReported {
+            anomalies.append(.captureStalled(lastCaptureAt: lastCaptureAt, duration: stalledFor))
+            captureStallReported = true
+        }
+
+        if let pending = oldestPendingCaptureLocked(), !deliveryLagReported {
+            let lag = max(0, timestamp - pending.chunk.capturedAt)
+            if lag >= configuration.deliveryLagThreshold {
+                anomalies.append(.captureToDeliveryLag(sequence: pending.sequence, lag: lag))
+                deliveryLagReported = true
+            }
+        }
+
+        if let activeSince = localActivitySince, let lastActiveAt = lastLocalActivityAt,
+           !localActivityMatched,
+           !unmatchedActivityReported {
+            let duration = max(0, timestamp - activeSince)
+            let observedActivityDuration = max(0, lastActiveAt - activeSince)
+            if observedActivityDuration >= configuration.sustainedActivityDuration,
+               timestamp - lastActiveAt >= configuration.serverSpeechGrace {
+                anomalies.append(.localActivityUnmatched(activeSince: activeSince, duration: duration))
+                unmatchedActivityReported = true
+            }
+        }
+
+        let snapshot: Snapshot?
+        if forceSnapshot || timestamp >= nextSnapshotAt {
+            snapshot = snapshotLocked(at: timestamp)
+            if timestamp >= nextSnapshotAt {
+                let elapsed = max(0, timestamp - startedAt)
+                let periods = floor(elapsed / configuration.snapshotInterval) + 1
+                nextSnapshotAt = startedAt + periods * configuration.snapshotInterval
+            }
+        } else {
+            snapshot = nil
+        }
+        return Output(snapshot: snapshot, anomalies: anomalies)
+    }
+
+    private func snapshotLocked(at timestamp: TimeInterval) -> Snapshot {
+        let generations = socketStats.keys.sorted().map { generation in
+            let stats = socketStats[generation]!
+            return SocketGenerationSnapshot(
+                generation: generation,
+                sendAttempts: stats.sendAttempts,
+                sendSuccesses: stats.sendSuccesses,
+                sendFailures: stats.sendFailures,
+                lastSendSequence: stats.lastSendSequence,
+                lastSendAttemptAt: stats.lastSendAttemptAt,
+                lastSendSuccessAt: stats.lastSendSuccessAt,
+                lastSendFailureAt: stats.lastSendFailureAt,
+                serverSpeechSignals: stats.serverSpeechSignals,
+                lastServerSignal: stats.lastServerSignal,
+                lastServerObservedAt: stats.lastServerObservedAt,
+                lastServerAudioTimeMilliseconds: stats.lastServerAudioTimeMilliseconds
+            )
+        }
+        return Snapshot(
+            emittedAt: timestamp,
+            capturedChunks: capturedChunks,
+            capturedSamples: capturedSamples,
+            deliveredChunks: deliveredChunks,
+            deliveredSamples: deliveredSamples,
+            lastCapturedSequence: lastCapturedSequence,
+            lastDeliveredSequence: lastDeliveredSequence,
+            lastCaptureAt: lastCaptureAt,
+            lastDeliveryAt: lastDeliveryAt,
+            pendingCapturedChunks: pendingCaptures.count,
+            localActivityDetected: activityDetector.isActive,
+            localActivitySince: localActivitySince,
+            lastLocalActivityAt: lastLocalActivityAt,
+            latestSocketGeneration: latestSocketGeneration,
+            socketGenerations: generations
+        )
+    }
+
+    private func trimPendingCapturesLocked() {
+        prunePendingCaptureOrderLocked()
+        while pendingCaptures.count > configuration.maximumPendingCaptures,
+              pendingCaptureCursor < pendingCaptureOrder.count {
+            pendingCaptures.removeValue(forKey: pendingCaptureOrder[pendingCaptureCursor])
+            pendingCaptureCursor += 1
+            prunePendingCaptureOrderLocked()
+        }
+    }
+
+    private func oldestPendingCaptureLocked() -> (sequence: UInt64, chunk: CapturedChunk)? {
+        prunePendingCaptureOrderLocked()
+        guard pendingCaptureCursor < pendingCaptureOrder.count else { return nil }
+        let sequence = pendingCaptureOrder[pendingCaptureCursor]
+        guard let chunk = pendingCaptures[sequence] else { return nil }
+        return (sequence, chunk)
+    }
+
+    private func prunePendingCaptureOrderLocked() {
+        while pendingCaptureCursor < pendingCaptureOrder.count,
+              pendingCaptures[pendingCaptureOrder[pendingCaptureCursor]] == nil {
+            pendingCaptureCursor += 1
+        }
+        if pendingCaptureCursor >= 1_024 {
+            pendingCaptureOrder.removeFirst(pendingCaptureCursor)
+            pendingCaptureCursor = 0
+        }
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/Log.swift
+++ b/Sources/JarvisCore/Diagnostics/Log.swift
@@ -32,12 +32,31 @@ public enum JarvisLog {
 /// `image`, when set, is a base64-encoded JPEG screenshot to show as a thumbnail in the activity
 /// viewer (the file log and unified log stay text-only).
 public func jlog(_ message: String, image base64JPEG: String? = nil) {
-    NSLog("%@", message)
-    ActivityLog.shared.record(message, imageBase64: base64JPEG)  // HTML activity viewer (no-op until enabled)
+    _ = writeLog(message, image: base64JPEG, synchronousActivityWrite: false)
+}
 
-    guard let url = JarvisLog.debugLogURL else { return }
+/// Audit-critical logging path. Normal logging stays asynchronous; this blocks only for the one
+/// unique monitor screenshot immediately before its first network request.
+@discardableResult
+public func jlogSynchronously(_ message: String, image base64JPEG: String? = nil) -> Bool {
+    writeLog(message, image: base64JPEG, synchronousActivityWrite: true)
+}
+
+private func writeLog(_ message: String, image base64JPEG: String?,
+                      synchronousActivityWrite: Bool) -> Bool {
+    NSLog("%@", message)
+    let activityPersisted: Bool
+    if synchronousActivityWrite {
+        activityPersisted = ActivityLog.shared.recordSynchronously(
+            message, imageBase64: base64JPEG)
+    } else {
+        ActivityLog.shared.record(message, imageBase64: base64JPEG)
+        activityPersisted = true
+    }
+
+    guard let url = JarvisLog.debugLogURL else { return activityPersisted }
     let line = "\(logTimestamp()) \(message)\n"
-    guard let data = line.data(using: .utf8) else { return }
+    guard let data = line.data(using: .utf8) else { return activityPersisted }
     if let fh = try? FileHandle(forWritingTo: url) {
         defer { try? fh.close() }
         _ = try? fh.seekToEnd()
@@ -47,6 +66,7 @@ public func jlog(_ message: String, image base64JPEG: String? = nil) {
         FileManager.default.createFile(atPath: url.path, contents: data,
                                        attributes: [.posixPermissions: 0o600])
     }
+    return activityPersisted
 }
 
 private func logTimestamp() -> String {

--- a/Sources/JarvisCore/Screen/ScreenActivityDetector.swift
+++ b/Sources/JarvisCore/Screen/ScreenActivityDetector.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Coalesces frame-level screen activity into one stable change after a quiet interval.
+///
+/// Callers provide monotonic timestamps and classify each frame as either a content change or idle.
+/// Significant changes start or restart a candidate; only an idle observation after `quiescenceInterval`
+/// reports it. Candidate IDs make asynchronous acknowledgement/rejection safe when a newer visual
+/// state appears before an older delivery finishes.
+public struct ScreenActivityDetector: Sendable {
+    public struct CandidateID: Hashable, Sendable {
+        fileprivate let rawValue: UInt64
+    }
+
+    public enum FrameSignal: Sendable, Equatable {
+        case contentChanged(changedAreaRatio: Double)
+        case idle
+    }
+
+    public enum ObservationResult: Sendable, Equatable {
+        case idle
+        case ignored
+        case waitingForQuiescence
+        case stableChange(CandidateID)
+        case awaitingAcknowledgement(CandidateID)
+    }
+
+    private enum DeliveryState: Sendable, Equatable {
+        case collecting
+        case awaitingAcknowledgement
+    }
+
+    private struct Candidate: Sendable {
+        let id: CandidateID
+        let lastSignificantChangeAt: TimeInterval
+        var deliveryState: DeliveryState
+    }
+
+    private let quiescenceInterval: TimeInterval
+    private let minimumChangedAreaRatio: Double
+    private var candidate: Candidate?
+    private var lastObservationAt: TimeInterval?
+    private var nextCandidateRawValue: UInt64 = 1
+
+    public init(quiescenceInterval: TimeInterval, minimumChangedAreaRatio: Double) {
+        precondition(quiescenceInterval >= 0 && quiescenceInterval.isFinite,
+                     "Quiescence interval must be finite and nonnegative")
+        precondition((0...1).contains(minimumChangedAreaRatio),
+                     "Minimum changed-area ratio must be between zero and one")
+        self.quiescenceInterval = quiescenceInterval
+        self.minimumChangedAreaRatio = minimumChangedAreaRatio
+    }
+
+    public mutating func observe(_ signal: FrameSignal,
+                                 at timestamp: TimeInterval) -> ObservationResult {
+        precondition(timestamp.isFinite, "Observation timestamp must be finite")
+        if let lastObservationAt {
+            precondition(timestamp >= lastObservationAt,
+                         "Observation timestamps must be monotonic")
+        }
+        lastObservationAt = timestamp
+
+        switch signal {
+        case .contentChanged(let changedAreaRatio):
+            precondition((0...1).contains(changedAreaRatio),
+                         "Changed-area ratio must be between zero and one")
+            guard changedAreaRatio >= minimumChangedAreaRatio else { return .ignored }
+
+            candidate = Candidate(
+                id: makeCandidateID(),
+                lastSignificantChangeAt: timestamp,
+                deliveryState: .collecting)
+            return .waitingForQuiescence
+
+        case .idle:
+            guard var candidate else { return .idle }
+            if candidate.deliveryState == .awaitingAcknowledgement {
+                return .awaitingAcknowledgement(candidate.id)
+            }
+            guard timestamp - candidate.lastSignificantChangeAt >= quiescenceInterval else {
+                return .waitingForQuiescence
+            }
+
+            candidate.deliveryState = .awaitingAcknowledgement
+            self.candidate = candidate
+            return .stableChange(candidate.id)
+        }
+    }
+
+    /// Commits the reported candidate. Returns false for a stale ID or a candidate not yet reported.
+    @discardableResult
+    public mutating func acknowledge(_ id: CandidateID) -> Bool {
+        guard candidate?.id == id,
+              candidate?.deliveryState == .awaitingAcknowledgement else { return false }
+        candidate = nil
+        return true
+    }
+
+    /// Re-arms a failed delivery without requiring another content change or quiet interval.
+    @discardableResult
+    public mutating func reject(_ id: CandidateID) -> Bool {
+        guard candidate?.id == id,
+              candidate?.deliveryState == .awaitingAcknowledgement else { return false }
+        candidate?.deliveryState = .collecting
+        return true
+    }
+
+    public mutating func reset() {
+        candidate = nil
+        lastObservationAt = nil
+    }
+
+    private mutating func makeCandidateID() -> CandidateID {
+        let id = CandidateID(rawValue: nextCandidateRawValue)
+        nextCandidateRawValue &+= 1
+        return id
+    }
+}

--- a/Sources/JarvisCore/Screen/ScreenCapture.swift
+++ b/Sources/JarvisCore/Screen/ScreenCapture.swift
@@ -25,13 +25,19 @@ public struct ScreenCaptureCLI: ScreenCapturing {
     public func capture() -> ScreenSnapshot? {
         // Which display (if any) needs explicit targeting is the preferences' decision; a stale
         // -D pointing at a disconnected display fails, and we fall through to the plain capture.
-        if let display = preferences.explicitDisplay,
-           let jpeg = Self.runScreencapture(arguments: ["-x", "-t", "jpg", "-D", "\(display)"]) {
-            return ScreenSnapshot(imageBase64: jpeg.base64EncodedString())
+        if let display = preferences.explicitDisplay {
+            let capturedAt = ProcessInfo.processInfo.systemUptime
+            if let jpeg = Self.runScreencapture(
+                arguments: ["-x", "-t", "jpg", "-D", "\(display)"]
+            ) {
+                return ScreenSnapshot(capturedAt: capturedAt,
+                                      imageBase64: jpeg.base64EncodedString())
+            }
         }
         // A plain capture IS the main display — no -D needed.
+        let capturedAt = ProcessInfo.processInfo.systemUptime
         guard let jpeg = Self.runScreencapture(arguments: ["-x", "-t", "jpg"]) else { return nil }
-        return ScreenSnapshot(imageBase64: jpeg.base64EncodedString())
+        return ScreenSnapshot(capturedAt: capturedAt, imageBase64: jpeg.base64EncodedString())
     }
 
     /// Runs `screencapture` with `arguments` + a tmpfile path, returning the captured image bytes.

--- a/Sources/JarvisCore/Screen/ScreenCaptureOrdering.swift
+++ b/Sources/JarvisCore/Screen/ScreenCaptureOrdering.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Decides whether a successfully consumed screenshot is fresh enough to acknowledge local screen
+/// activity. Monitor-owned snapshots use candidate IDs to reconcile later changes; an ordinary
+/// screenshot may acknowledge only changes observed no later than when its capture began.
+public enum ScreenCaptureOrdering {
+    public static func canAcknowledge(
+        capturedAt: TimeInterval,
+        latestObservedChangeAt: TimeInterval?,
+        isMonitorSnapshot: Bool
+    ) -> Bool {
+        precondition(capturedAt.isFinite)
+        precondition(latestObservedChangeAt?.isFinite != false)
+        return isMonitorSnapshot
+            || latestObservedChangeAt.map { capturedAt >= $0 } != false
+    }
+}

--- a/Sources/JarvisCore/Screen/ScreenChangeDetector.swift
+++ b/Sources/JarvisCore/Screen/ScreenChangeDetector.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Pure state machine for deciding when a polled screen capture represents a stable change.
+///
+/// The session monitor seeds a baseline from its first local poll. A changed fingerprint must then
+/// be present in consecutive polls before it is reported, so a stream of intermediate typing states
+/// coalesces into one stable change. Reporting does not advance the baseline: only `observe(_:)`,
+/// called when CoachDriver accepts the snapshot, acknowledges that the coach actually saw it.
+public struct ScreenChangeDetector: Sendable {
+    public enum PollResult: Sendable, Equatable {
+        case dormant
+        case unchanged
+        case waitingForStability
+        case awaitingAcknowledgement
+        case stableChange
+    }
+
+    private struct ContentHash: Sendable, Equatable {
+        enum Source: Sendable, Equatable {
+            case recognizedText
+            case image
+        }
+
+        let source: Source
+        let hash: UInt64
+        let byteCount: Int
+    }
+
+    private enum VisualHash: Sendable, Equatable {
+        case perceptual(UInt64)
+        case exact(ContentHash)
+    }
+
+    private struct Fingerprint: Sendable, Equatable {
+        let text: ContentHash?
+        let visual: VisualHash
+    }
+
+    private let requiredStablePollCount: Int
+    private var baseline: Fingerprint?
+    private var candidate: Fingerprint?
+    private var candidatePollCount = 0
+    private var candidateWasReported = false
+
+    public init(requiredStablePollCount: Int = 2) {
+        precondition(requiredStablePollCount >= 1,
+                     "A screen change needs at least one observation")
+        self.requiredStablePollCount = requiredStablePollCount
+    }
+
+    public var isSeeded: Bool { baseline != nil }
+
+    /// Seeds the first local observation without treating it as a change. Returns true only when it
+    /// established the baseline; later calls leave current detector state untouched.
+    @discardableResult
+    public mutating func seedIfNeeded(_ snapshot: ScreenSnapshot) -> Bool {
+        guard baseline == nil else { return false }
+        observe(snapshot)
+        return true
+    }
+
+    /// Replaces the baseline with a screenshot the coach actually consumed. Any pending candidate
+    /// is obsolete because the coach is now up to date with this newer screen state.
+    public mutating func observe(_ snapshot: ScreenSnapshot) {
+        baseline = Self.fingerprint(for: snapshot)
+        clearCandidate()
+    }
+
+    /// Evaluates one background poll. A stable change remains pending until `observe(_:)`
+    /// acknowledges the snapshot that CoachDriver accepted.
+    public mutating func poll(_ snapshot: ScreenSnapshot) -> PollResult {
+        guard let baseline else { return .dormant }
+        let fingerprint = Self.fingerprint(for: snapshot)
+
+        guard !Self.matches(fingerprint, baseline) else {
+            clearCandidate()
+            return .unchanged
+        }
+
+        if candidate.map({ Self.matches($0, fingerprint) }) == true {
+            candidatePollCount += 1
+        } else {
+            candidate = fingerprint
+            candidatePollCount = 1
+            candidateWasReported = false
+        }
+
+        guard candidatePollCount >= requiredStablePollCount else {
+            return .waitingForStability
+        }
+
+        guard !candidateWasReported else { return .awaitingAcknowledgement }
+        candidateWasReported = true
+        return .stableChange
+    }
+
+    /// Returns to the dormant state, for example when a coaching session stops.
+    public mutating func reset() {
+        baseline = nil
+        clearCandidate()
+    }
+
+    /// Allows a stable candidate to be emitted again after the consumer reports that delivery
+    /// failed. It does not change the acknowledged baseline or the candidate's stability count.
+    public mutating func retryUnacknowledgedChange() {
+        candidateWasReported = false
+    }
+
+    private mutating func clearCandidate() {
+        candidate = nil
+        candidatePollCount = 0
+        candidateWasReported = false
+    }
+
+    private static func fingerprint(for snapshot: ScreenSnapshot) -> Fingerprint {
+        let text: ContentHash?
+        if let recognizedText = snapshot.recognizedText {
+            let normalized = recognizedText.precomposedStringWithCanonicalMapping
+                .split(whereSeparator: { $0.isWhitespace })
+                .joined(separator: " ")
+            if !normalized.isEmpty {
+                text = contentHash(normalized, source: .recognizedText)
+            } else {
+                text = nil
+            }
+        } else if let token = snapshot.changeFingerprint, !token.isEmpty {
+            // Whole-display OCR is intentionally not sent with the snapshot; its content-free token
+            // is still useful for local duplicate suppression.
+            text = contentHash(token, source: .recognizedText)
+        } else {
+            text = nil
+        }
+        let visual = snapshot.visualFingerprint.map(VisualHash.perceptual)
+            ?? .exact(contentHash(snapshot.imageBase64, source: .image))
+        return Fingerprint(text: text, visual: visual)
+    }
+
+    private static func matches(_ lhs: Fingerprint, _ rhs: Fingerprint) -> Bool {
+        // OCR can transiently fail, so the visual signal decides when only one side has text. When
+        // both have OCR, require equality so small but semantically important code edits are kept.
+        if let leftText = lhs.text, let rightText = rhs.text, leftText != rightText { return false }
+        switch (lhs.visual, rhs.visual) {
+        case (.perceptual(let left), .perceptual(let right)):
+            return (left ^ right).nonzeroBitCount <= 8
+        case (.exact(let left), .exact(let right)):
+            return left == right
+        case (.perceptual, .exact), (.exact, .perceptual):
+            return false
+        }
+    }
+
+    /// Makes a deterministic, content-free token from screen-derived text. The raw OCR remains only
+    /// in the capture call; the monitor retains this hash + byte count for local duplicate detection.
+    public static func privacyPreservingTextFingerprint(_ text: String) -> String? {
+        let normalized = text.precomposedStringWithCanonicalMapping
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !normalized.isEmpty else { return nil }
+        let value = contentHash(normalized, source: .recognizedText)
+        return "ocr:\(value.hash):\(value.byteCount)"
+    }
+
+    /// FNV-1a keeps the detector Foundation-only and avoids retaining duplicate screenshot/OCR
+    /// strings. Including both the source and byte count makes accidental equivalence still less
+    /// likely without persisting any screen-derived content.
+    private static func contentHash(_ value: String,
+                                    source: ContentHash.Source) -> ContentHash {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        var byteCount = 0
+        for byte in value.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+            byteCount += 1
+        }
+        return ContentHash(source: source, hash: hash, byteCount: byteCount)
+    }
+}

--- a/Sources/JarvisCore/Screen/ScreenFrameActivityClassifier.swift
+++ b/Sources/JarvisCore/Screen/ScreenFrameActivityClassifier.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Classifies low-resolution screen frames without trusting compositor redraws as user-visible
+/// changes. Browsers can continuously produce full-surface frames for an otherwise static page;
+/// comparing the actual pixels lets those redraws advance quiescence instead of blocking it.
+public struct ScreenFrameActivityClassifier: Sendable {
+    public enum ChangeEvidence: Sendable, Equatable {
+        case visualPixels
+        case boundedDirtyRegion
+    }
+
+    public enum Observation: Sendable, Equatable {
+        case idle
+        case changed(areaRatio: Double, evidence: ChangeEvidence)
+    }
+
+    private let minimumChangedAreaRatio: Double
+    private let maximumMetadataOnlyAreaRatio: Double
+    private let minimumPixelDelta: UInt8
+    private var previousPixels: [UInt8]?
+
+    public init(minimumChangedAreaRatio: Double,
+                maximumMetadataOnlyAreaRatio: Double = 0.25,
+                minimumPixelDelta: UInt8 = 16) {
+        precondition((0...1).contains(minimumChangedAreaRatio),
+                     "Minimum changed-area ratio must be between zero and one")
+        precondition((0...1).contains(maximumMetadataOnlyAreaRatio),
+                     "Maximum metadata-only area ratio must be between zero and one")
+        self.minimumChangedAreaRatio = minimumChangedAreaRatio
+        self.maximumMetadataOnlyAreaRatio = max(
+            minimumChangedAreaRatio, maximumMetadataOnlyAreaRatio)
+        self.minimumPixelDelta = minimumPixelDelta
+    }
+
+    /// `pixels` is one byte of grayscale intensity per pixel from the monitor's already-downscaled
+    /// frame. Dirty-region metadata remains useful for tiny edits, but only while it describes a
+    /// bounded region. A full-surface dirty rectangle is common compositor behavior and cannot, by
+    /// itself, prove that visible content changed.
+    public mutating func observe(pixels: [UInt8],
+                                 dirtyAreaRatio: Double?) -> Observation {
+        precondition(!pixels.isEmpty, "A screen frame must contain pixels")
+        if let dirtyAreaRatio {
+            precondition((0...1).contains(dirtyAreaRatio),
+                         "Dirty-area ratio must be between zero and one")
+        }
+
+        guard let previousPixels else {
+            self.previousPixels = pixels
+            return .idle
+        }
+        guard previousPixels.count == pixels.count else {
+            self.previousPixels = pixels
+            return .changed(areaRatio: 1, evidence: .visualPixels)
+        }
+
+        var changedPixelCount = 0
+        for index in pixels.indices {
+            let previous = previousPixels[index]
+            let current = pixels[index]
+            let delta = previous > current ? previous - current : current - previous
+            if delta >= minimumPixelDelta { changedPixelCount += 1 }
+        }
+        self.previousPixels = pixels
+
+        let pixelRatio = Double(changedPixelCount) / Double(pixels.count)
+        if pixelRatio > 0, pixelRatio >= minimumChangedAreaRatio {
+            return .changed(areaRatio: pixelRatio, evidence: .visualPixels)
+        }
+
+        if let dirtyAreaRatio,
+           dirtyAreaRatio > 0,
+           dirtyAreaRatio >= minimumChangedAreaRatio,
+           dirtyAreaRatio <= maximumMetadataOnlyAreaRatio {
+            return .changed(areaRatio: dirtyAreaRatio, evidence: .boundedDirtyRegion)
+        }
+
+        return .idle
+    }
+
+    public mutating func reset() {
+        previousPixels = nil
+    }
+}

--- a/Sources/JarvisCore/Screen/ScreenRequestTiming.swift
+++ b/Sources/JarvisCore/Screen/ScreenRequestTiming.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Pure timing policy for the monitor's cost-bearing screen-only fallback.
+public enum ScreenRequestTiming {
+    public static func fallbackDeadline(
+        candidateAt: TimeInterval,
+        lastVisualRequestAt: TimeInterval?,
+        piggybackWait: TimeInterval,
+        minimumRequestInterval: TimeInterval
+    ) -> TimeInterval {
+        precondition(candidateAt.isFinite)
+        precondition(lastVisualRequestAt?.isFinite != false)
+        precondition(piggybackWait >= 0 && piggybackWait.isFinite)
+        precondition(minimumRequestInterval >= 0 && minimumRequestInterval.isFinite)
+
+        let afterPiggybackWindow = candidateAt + piggybackWait
+        guard let lastVisualRequestAt else { return afterPiggybackWindow }
+        return max(
+            afterPiggybackWindow,
+            lastVisualRequestAt + minimumRequestInterval)
+    }
+}

--- a/Sources/JarvisCore/Screen/ScreenSnapshot.swift
+++ b/Sources/JarvisCore/Screen/ScreenSnapshot.swift
@@ -4,15 +4,38 @@ import Foundation
 /// captures — an on-device OCR of that same image, so the model can read exact text instead of
 /// deciphering pixels (reasoning models are far stronger on text; see wiki/decisions.md).
 public struct ScreenSnapshot: Sendable, Equatable {
-    /// Base64-encoded JPEG, as `screencapture` produced it.
+    /// Monotonic time when capture began. The visual monitor uses this content-free ordering token
+    /// to avoid letting an older, slow brain request acknowledge a screen change observed later.
+    public let capturedAt: TimeInterval
+    /// Base64-encoded JPEG produced by the capture edge.
     public let imageBase64: String
     /// Reading-ordered OCR of the captured image, or nil when unavailable (full-display fallback
     /// captures skip OCR — a whole display's text would feed the clutter back as tokens — and
     /// recognition can fail). Derived from the screen, so it goes only where the image goes.
     public let recognizedText: String?
+    /// Content-free token used only by the local change monitor to suppress duplicate full captures.
+    /// The capture edge derives it in memory from normalized OCR (including whole-display OCR that
+    /// is intentionally not sent to the model). It is never written to the activity/traffic logs.
+    public let changeFingerprint: String?
+    /// Local perceptual image hash used alongside OCR so diagrams, highlighting, and OCR-missed
+    /// edits remain detectable. It contains no pixels and is never sent to the model or logs.
+    public let visualFingerprint: UInt64?
 
-    public init(imageBase64: String, recognizedText: String? = nil) {
+    public init(capturedAt: TimeInterval = ProcessInfo.processInfo.systemUptime,
+                imageBase64: String, recognizedText: String? = nil,
+                changeFingerprint: String? = nil, visualFingerprint: UInt64? = nil) {
+        self.capturedAt = capturedAt
         self.imageBase64 = imageBase64
         self.recognizedText = recognizedText
+        self.changeFingerprint = changeFingerprint
+        self.visualFingerprint = visualFingerprint
+    }
+
+    /// Capture time orders monitor acknowledgements; it is not part of screenshot content identity.
+    public static func == (lhs: ScreenSnapshot, rhs: ScreenSnapshot) -> Bool {
+        lhs.imageBase64 == rhs.imageBase64
+            && lhs.recognizedText == rhs.recognizedText
+            && lhs.changeFingerprint == rhs.changeFingerprint
+            && lhs.visualFingerprint == rhs.visualFingerprint
     }
 }

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -67,8 +67,13 @@ public enum RealtimeSession {
         return error["code"] as? String == "session_expired"
     }
 
+    public static let speechStartedType = "input_audio_buffer.speech_started"
+    public static let speechStoppedType = "input_audio_buffer.speech_stopped"
+    public static let deltaTranscriptionType = "conversation.item.input_audio_transcription.delta"
+
     /// The event type the server emits when an utterance's transcription is final.
     public static let completedTranscriptionType = "conversation.item.input_audio_transcription.completed"
+    public static let failedTranscriptionType = "conversation.item.input_audio_transcription.failed"
 
     /// The transcript text from a parsed realtime event, if it is a **completed** input-audio
     /// transcription carrying real speech — otherwise nil. Pure and unit-testable; the live socket

--- a/Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift
@@ -129,9 +129,11 @@ public final class RealtimeTranscriptionLedger: @unchecked Sendable {
     }
 
     /// A failed transcription still represents detected speech. Preserve streamed text when there
-    /// is any; otherwise emit an explicit marker so downstream coaching knows its context is partial.
+    /// is any; otherwise emit an explicit marker only for VAD-confirmed speech long enough to be
+    /// conversational. Short or untimed empty failures remain ordinary noise blips.
     public func recordFailed(itemID: String, speaker: Speaker) -> FinalizedItem? {
-        finalizeInterruptedItem(itemID: itemID, requireSpeechStopped: false, speaker: speaker)
+        finalizeInterruptedItem(itemID: itemID, requireSpeechStopped: false,
+                                suppressShortEmptyItem: true, speaker: speaker)
     }
 
     /// Resolves a speech-stopped item whose completed/failed event never arrived. The caller owns the

--- a/Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+/// Reconciles the independent events emitted for each Realtime input-audio item.
+///
+/// Realtime can finish items out of order, and a failed or missing terminal event must not make an
+/// entire spoken turn disappear. The ledger therefore keeps streamed deltas and VAD timing keyed by
+/// `item_id` until the item completes, fails, or the caller declares its terminal event overdue.
+// @unchecked Sendable: all mutable state is guarded by `lock`.
+public final class RealtimeTranscriptionLedger: @unchecked Sendable {
+    public static let contextGapMarker =
+        "[context gap: speech was detected, but its transcript is unavailable]"
+    private static let minimumContextGapDurationMilliseconds = 750
+
+    public struct FinalizedItem: Equatable, Sendable {
+        public let itemID: String
+        public let text: String
+        public let spokenAt: TimeInterval?
+        public let spokenEndAt: TimeInterval?
+        public let recoveredFromDeltas: Bool
+        public let isContextGap: Bool
+    }
+
+    private struct Item {
+        var audioStartMilliseconds: Int?
+        var audioEndMilliseconds: Int?
+        var timelineOrigin: TimeInterval?
+        var deltas = ""
+        var speechStopped = false
+
+        var spokenAt: TimeInterval? {
+            guard let audioStartMilliseconds, let timelineOrigin else { return nil }
+            return timelineOrigin + (TimeInterval(audioStartMilliseconds) / 1_000)
+        }
+
+        var spokenEndAt: TimeInterval? {
+            guard let audioEndMilliseconds, let timelineOrigin else { return nil }
+            return timelineOrigin + (TimeInterval(audioEndMilliseconds) / 1_000)
+        }
+
+        var detectedSpeechDurationMilliseconds: Int? {
+            guard let audioStartMilliseconds, let audioEndMilliseconds,
+                  audioEndMilliseconds >= audioStartMilliseconds else { return nil }
+            return audioEndMilliseconds - audioStartMilliseconds
+        }
+    }
+
+    private let lock = NSLock()
+    private var items: [String: Item] = [:]
+    /// Makes late duplicate terminal events harmless. In particular, a final transcript arriving
+    /// after the stopped-without-terminal deadline must not append a second copy of the same turn.
+    private var finalizedItemIDs: Set<String> = []
+    /// Highest audio-clock boundary belonging to a terminal item in this socket generation. Kept
+    /// separately because transcription completions may arrive out of spoken order.
+    private var latestFinalizedAudioEndAt: TimeInterval?
+
+    public init() {}
+
+    @discardableResult
+    public func recordSpeechStarted(itemID: String, audioStartMilliseconds: Int,
+                                    timelineOrigin: TimeInterval) -> Bool {
+        guard !itemID.isEmpty, audioStartMilliseconds >= 0 else { return false }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID) else { return false }
+        var item = items[itemID] ?? Item()
+        item.audioStartMilliseconds = audioStartMilliseconds
+        item.timelineOrigin = timelineOrigin
+        item.speechStopped = false
+        items[itemID] = item
+        return true
+    }
+
+    /// Returns true when the item is still awaiting a completed/failed event and therefore needs a
+    /// caller-owned deadline. A stop event can arrive without a start event, so it creates the item.
+    @discardableResult
+    public func recordSpeechStopped(itemID: String, audioEndMilliseconds: Int? = nil) -> Bool {
+        guard !itemID.isEmpty else { return false }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID) else { return false }
+        var item = items[itemID] ?? Item()
+        if let audioEndMilliseconds, audioEndMilliseconds >= 0 {
+            item.audioEndMilliseconds = audioEndMilliseconds
+        }
+        item.speechStopped = true
+        items[itemID] = item
+        return true
+    }
+
+    @discardableResult
+    public func recordDelta(itemID: String, delta: String) -> Bool {
+        guard !itemID.isEmpty, !delta.isEmpty else { return false }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID) else { return false }
+        var item = items[itemID] ?? Item()
+        item.deltas += delta
+        items[itemID] = item
+        return true
+    }
+
+    /// Final text is authoritative. If it is empty/unusable but streamed text is available, retain
+    /// that partial text rather than dropping the spoken turn. A long VAD-confirmed item with neither
+    /// becomes an explicit gap; very short/no-timing items stay ignored as ordinary noise blips.
+    public func recordCompleted(itemID: String, transcript: String,
+                                speaker: Speaker) -> FinalizedItem? {
+        guard !itemID.isEmpty else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID) else { return nil }
+        let item = items.removeValue(forKey: itemID) ?? Item()
+        finalizedItemIDs.insert(itemID)
+        recordFinalizedAudioEndLocked(item.spokenEndAt)
+
+        if let final = RealtimeSession.meaningfulTranscript(transcript, speaker: speaker) {
+            return FinalizedItem(itemID: itemID, text: final, spokenAt: item.spokenAt,
+                                 spokenEndAt: item.spokenEndAt,
+                                 recoveredFromDeltas: false, isContextGap: false)
+        }
+        guard let partial = RealtimeSession.meaningfulTranscript(item.deltas, speaker: speaker) else {
+            guard let duration = item.detectedSpeechDurationMilliseconds,
+                  duration >= Self.minimumContextGapDurationMilliseconds else {
+                return nil
+            }
+            return FinalizedItem(itemID: itemID, text: Self.contextGapMarker,
+                                 spokenAt: item.spokenAt, spokenEndAt: item.spokenEndAt,
+                                 recoveredFromDeltas: false,
+                                 isContextGap: true)
+        }
+        return FinalizedItem(itemID: itemID, text: partial, spokenAt: item.spokenAt,
+                             spokenEndAt: item.spokenEndAt,
+                             recoveredFromDeltas: true, isContextGap: false)
+    }
+
+    /// A failed transcription still represents detected speech. Preserve streamed text when there
+    /// is any; otherwise emit an explicit marker so downstream coaching knows its context is partial.
+    public func recordFailed(itemID: String, speaker: Speaker) -> FinalizedItem? {
+        finalizeInterruptedItem(itemID: itemID, requireSpeechStopped: false, speaker: speaker)
+    }
+
+    /// Resolves a speech-stopped item whose completed/failed event never arrived. The caller owns the
+    /// timer so this Core type stays Foundation-only and deterministic in tests.
+    public func resolveStoppedItemTimeout(itemID: String, speaker: Speaker) -> FinalizedItem? {
+        finalizeInterruptedItem(itemID: itemID, requireSpeechStopped: true,
+                                suppressShortEmptyItem: true, speaker: speaker)
+    }
+
+    /// Resolves a speech-started item whose VAD stop and transcription terminal both disappeared.
+    /// This is a much longer caller-owned deadline than the stopped-item deadline because a genuine
+    /// utterance can last for minutes.
+    public func resolveActiveItemTimeout(itemID: String, speaker: Speaker) -> FinalizedItem? {
+        guard !itemID.isEmpty else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID), let item = items[itemID], !item.speechStopped else {
+            return nil
+        }
+        return finalizeInterruptedItemLocked(itemID: itemID, item: item,
+                                              suppressShortEmptyItem: false,
+                                              speaker: speaker)
+    }
+
+    /// A socket cannot deliver any more events after it fails. Finalize every item still owned by
+    /// that socket immediately so no stale "active speech" state leaks into the replacement session.
+    public func resolveAllInterruptedItems(speaker: Speaker) -> [FinalizedItem] {
+        lock.lock(); defer { lock.unlock() }
+        let pending = items
+        return pending.compactMap { itemID, item in
+            finalizeInterruptedItemLocked(itemID: itemID, item: item,
+                                           suppressShortEmptyItem: false,
+                                           speaker: speaker)
+        }.sorted {
+            ($0.spokenAt ?? .greatestFiniteMagnitude) < ($1.spokenAt ?? .greatestFiniteMagnitude)
+        }
+    }
+
+    public var hasPendingItems: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return !items.isEmpty
+    }
+
+    public var pendingItemCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return items.count
+    }
+
+    /// Session-relative capture boundary that can leave the reconnect tail safely.
+    ///
+    /// If any item remains unresolved, retain audio from the earliest such speech start. Once every
+    /// earlier item is terminal, advance through the furthest terminal end even when completions
+    /// arrived out of order. An item with no start time blocks advancement because its position is
+    /// unknowable.
+    public var safeReplayDiscardTime: TimeInterval? {
+        lock.lock(); defer { lock.unlock() }
+        if items.values.contains(where: { $0.spokenAt == nil }) { return nil }
+        if let earliestPending = items.values.compactMap(\.spokenAt).min() {
+            return earliestPending
+        }
+        return latestFinalizedAudioEndAt
+    }
+
+    public func clear() {
+        lock.lock(); defer { lock.unlock() }
+        items.removeAll(keepingCapacity: false)
+        finalizedItemIDs.removeAll(keepingCapacity: false)
+        latestFinalizedAudioEndAt = nil
+    }
+
+    private func finalizeInterruptedItem(itemID: String, requireSpeechStopped: Bool,
+                                         suppressShortEmptyItem: Bool = false,
+                                         speaker: Speaker) -> FinalizedItem? {
+        guard !itemID.isEmpty else { return nil }
+        lock.lock(); defer { lock.unlock() }
+        guard !finalizedItemIDs.contains(itemID) else { return nil }
+        let item = items[itemID] ?? Item()
+        guard !requireSpeechStopped || item.speechStopped else { return nil }
+        return finalizeInterruptedItemLocked(itemID: itemID, item: item,
+                                              suppressShortEmptyItem: suppressShortEmptyItem,
+                                              speaker: speaker)
+    }
+
+    private func finalizeInterruptedItemLocked(itemID: String, item: Item,
+                                                suppressShortEmptyItem: Bool,
+                                                speaker: Speaker) -> FinalizedItem? {
+        items.removeValue(forKey: itemID)
+        finalizedItemIDs.insert(itemID)
+        recordFinalizedAudioEndLocked(item.spokenEndAt)
+
+        if let partial = RealtimeSession.meaningfulTranscript(item.deltas, speaker: speaker) {
+            return FinalizedItem(itemID: itemID, text: partial, spokenAt: item.spokenAt,
+                                 spokenEndAt: item.spokenEndAt,
+                                 recoveredFromDeltas: true, isContextGap: false)
+        }
+        // A missing terminal event does not turn a click/typing blip into missing conversational
+        // context. Match the completed-event path: only a VAD-confirmed duration long enough to be
+        // plausible speech gets a gap marker. The item is still finalized above, so a late terminal
+        // event cannot append a duplicate.
+        if suppressShortEmptyItem {
+            guard let duration = item.detectedSpeechDurationMilliseconds,
+                  duration >= Self.minimumContextGapDurationMilliseconds else { return nil }
+        }
+        return FinalizedItem(itemID: itemID, text: Self.contextGapMarker,
+                             spokenAt: item.spokenAt, spokenEndAt: item.spokenEndAt,
+                             recoveredFromDeltas: false, isContextGap: true)
+    }
+
+    private func recordFinalizedAudioEndLocked(_ end: TimeInterval?) {
+        guard let end else { return }
+        latestFinalizedAudioEndAt = max(latestFinalizedAudioEndAt ?? end, end)
+    }
+}

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -5,6 +5,7 @@ import Foundation
 public enum TriggerReason: Sendable, Equatable {
     case turnEnd                              // server VAD: the speaker finished an utterance
     case silence(secondsQuiet: TimeInterval)  // no speech for the current backoff interval
+    case screenChanged                        // visual monitor: meaningful change since the last capture
     case manualHint                           // user pressed the hint hotkey — capture + force a hint, one trip
 }
 
@@ -20,8 +21,8 @@ public struct TriggerContext: Sendable {
     /// The trigger note appended to the user message — or nil when the message already says it all.
     /// A turn-end adds nothing: the "New since last turn" block IS the signal, its [mm:ss] stamps
     /// carry the timing, and a boilerplate sentence on top would be committed to memory and re-billed
-    /// on every later request. The notes that remain (silence, manual hint) open with the same
-    /// [mm:ss] session stamp as transcript lines, so the model reads all timing in one idiom.
+    /// on every later request. The notes that remain (silence, screen change, manual hint) open with
+    /// the same [mm:ss] session stamp as transcript lines, so the model reads all timing in one idiom.
     public var promptLine: String? {
         let stamp = RollingTranscript.stamp(sessionElapsedSeconds)
         switch reason {
@@ -29,6 +30,8 @@ public struct TriggerContext: Sendable {
             return nil
         case .silence(let secs):
             return "[\(stamp)] (no speech for \(Self.durationPhrase(secs)))"
+        case .screenChanged:
+            return "[\(stamp)] (the screen changed since the last capture; use the attached fresh point-in-time screenshot)"
         case .manualHint:
             return "[\(stamp)] The user pressed the hint shortcut. They want your single most useful hint about what's on their screen right now — answer using the attached screenshot and the recent transcript."
         }

--- a/Sources/JarvisCore/Triggers/TurnSubstance.swift
+++ b/Sources/JarvisCore/Triggers/TurnSubstance.swift
@@ -12,6 +12,11 @@ import Foundation
 /// short-fragment fallback. Everything else FAILS OPEN to the brain — the model stays the judge of
 /// meaning; this is punctuation-level hygiene, not a wake-word gate.
 public enum TurnSubstance {
+    /// A bare rejection from the interviewer is not a back-channel: it corrects the user's current
+    /// understanding and needs an immediate coaching turn. The same words from the user remain
+    /// filler ("no, no" while thinking aloud), so this override must see the speaker label.
+    private static let interviewerCorrections: Set<String> = ["no", "nope"]
+
     /// Normalized (lowercased, punctuation-stripped, repeats-collapsed) back-channel forms.
     /// To add a language, add its dozen closed-class forms in normalized shape.
     private static let fillers: Set<String> = [
@@ -34,15 +39,29 @@ public enum TurnSubstance {
 
         // Keep only letters/digits (CJK ideographs are letters), dropping punctuation, whitespace,
         // and symbols; then collapse consecutive repeats so elongations match their base form.
-        var collapsed = ""
-        for scalar in lower.unicodeScalars where CharacterSet.alphanumerics.contains(scalar) {
-            let ch = Character(scalar)
-            if collapsed.last != ch { collapsed.append(ch) }
-        }
+        let collapsed = normalized(lower)
 
         if collapsed.isEmpty { return false }              // pure punctuation / noise
         if fillers.contains(collapsed) { return false }    // closed-class back-channel
         if collapsed.count <= 2 { return false }           // short fragment in ANY language
         return true
+    }
+
+    /// Speaker-aware entry point used by the coach's delta gate. Most filler behavior stays neutral,
+    /// but a terse interviewer rejection is a correction, not conversational noise.
+    public static func isSubstantive(_ line: TranscriptLine) -> Bool {
+        if line.speaker == .them, interviewerCorrections.contains(normalized(line.text.lowercased())) {
+            return true
+        }
+        return isSubstantive(line.text)
+    }
+
+    private static func normalized(_ lower: String) -> String {
+        var collapsed = ""
+        for scalar in lower.unicodeScalars where CharacterSet.alphanumerics.contains(scalar) {
+            let ch = Character(scalar)
+            if collapsed.last != ch { collapsed.append(ch) }
+        }
+        return collapsed
     }
 }

--- a/Tests/JarvisCoreTests/Audio/AdaptiveAudioActivityDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Audio/AdaptiveAudioActivityDetectorTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct AdaptiveAudioActivityDetectorTests {
+    @Test func adaptiveFloorRejectsBackgroundAndHysteresisReleasesActivity() {
+        let configuration = AudioContinuityWitness.ActivityConfiguration(
+            initialNoiseFloorRMS: 100,
+            minimumNoiseFloorRMS: 20,
+            minimumActiveRMS: 300,
+            minimumActivePeak: 600,
+            activationMultiplier: 3,
+            releaseMultiplier: 1.5,
+            noiseAdaptationRate: 0.2
+        )
+        var detector = AdaptiveAudioActivityDetector(configuration: configuration)
+
+        for _ in 0..<20 {
+            #expect(!detector.observe(pcm16: pcm(amplitude: 150)).isActive)
+        }
+        #expect(detector.noiseFloorRMS > 100)
+        #expect(detector.observe(pcm16: pcm(amplitude: 1_000)).isActive)
+        #expect(detector.observe(pcm16: pcm(amplitude: 700)).isActive)
+        #expect(!detector.observe(pcm16: pcm(amplitude: 100)).isActive)
+    }
+
+    @Test func emptyAndOddTrailingBytesRetainNoSamples() {
+        var detector = AdaptiveAudioActivityDetector(configuration: .init())
+        #expect(detector.observe(pcm16: Data()).sampleCount == 0)
+        #expect(detector.observe(pcm16: Data([0x01])).sampleCount == 0)
+        #expect(detector.observe(pcm16: Data([0xE8, 0x03, 0xFF])).sampleCount == 1)
+    }
+
+    private func pcm(amplitude: Int16, count: Int = 480) -> Data {
+        let samples = (0..<count).map { $0.isMultiple(of: 2) ? amplitude : -amplitude }
+        return samples.withUnsafeBytes { Data($0) }
+    }
+}

--- a/Tests/JarvisCoreTests/Audio/EchoReferenceAlignmentTests.swift
+++ b/Tests/JarvisCoreTests/Audio/EchoReferenceAlignmentTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct EchoReferenceAlignmentTests {
+    @Test func equalLengthReferencePassesThrough() {
+        #expect(EchoReferenceAlignment.aligned([1, 2, 3], toFrameCount: 3) == [1, 2, 3])
+    }
+
+    @Test func shortReferenceIsPaddedOnlyInTheAECCopy() {
+        let systemAudio: [Int16] = [10, 20]
+
+        let aecReference = EchoReferenceAlignment.aligned(systemAudio, toFrameCount: 4)
+
+        #expect(aecReference == [10, 20, 0, 0])
+        #expect(systemAudio == [10, 20])
+    }
+
+    @Test func longReferenceIsTruncatedOnlyInTheAECCopy() {
+        let systemAudio: [Int16] = [10, 20, 30, 40]
+
+        let aecReference = EchoReferenceAlignment.aligned(systemAudio, toFrameCount: 2)
+
+        #expect(aecReference == [10, 20])
+        #expect(systemAudio == [10, 20, 30, 40])
+    }
+
+    @Test func emptyMicFrameProducesEmptyAECReferenceWithoutTouchingSystemAudio() {
+        let systemAudio: [Int16] = [10, 20]
+
+        #expect(EchoReferenceAlignment.aligned(systemAudio, toFrameCount: 0).isEmpty)
+        #expect(systemAudio == [10, 20])
+    }
+}

--- a/Tests/JarvisCoreTests/Audio/PCMBufferTests.swift
+++ b/Tests/JarvisCoreTests/Audio/PCMBufferTests.swift
@@ -36,4 +36,149 @@ import Testing
         #expect(b.bufferedBytes == 0)
         #expect(b.drain().isEmpty)
     }
+
+    @Test func sequencedChunksSurviveReconnectBuffering() {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1, 2]), sequenceNumber: 41)
+        b.append(Data([3, 4]), sequenceNumber: 42)
+
+        #expect(b.drainChunks() == [
+            .init(data: Data([1, 2]), sequenceNumber: 41),
+            .init(data: Data([3, 4]), sequenceNumber: 42),
+        ])
+    }
+
+    @Test func claimedChunkRemainsFirstUntilLocalSendCompletes() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1]), sequenceNumber: 1)
+        b.append(Data([2]), sequenceNumber: 2)
+
+        let first = try #require(b.claimNext())
+        #expect(first.chunk.sequenceNumber == 1)
+        #expect(b.claimNext() == nil)
+        #expect(b.completeSend(first))
+
+        let second = try #require(b.claimNext())
+        #expect(second.chunk.sequenceNumber == 2)
+    }
+
+    @Test func failedSendRetriesExactChunkBeforeLaterAudio() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1]), sequenceNumber: 41)
+        let failed = try #require(b.claimNext())
+        b.append(Data([2]), sequenceNumber: 42)
+
+        #expect(b.retry(failed))
+        let retry = try #require(b.claimNext())
+        #expect(retry.chunk.sequenceNumber == 41)
+        #expect(retry != failed) // a stale callback cannot complete the replacement claim
+        #expect(!b.completeSend(failed))
+        #expect(b.completeSend(retry))
+        #expect(b.claimNext()?.chunk.sequenceNumber == 42)
+    }
+
+    @Test func appendAfterEmptyReadyBoundaryCannotBeStranded() throws {
+        let b = PCMBuffer(maxBytes: 100)
+
+        #expect(b.claimNext() == nil) // readiness found the queue empty
+        b.append(Data([9]), sequenceNumber: 9) // producer races immediately after that check
+
+        let claim = try #require(b.claimNext())
+        #expect(claim.chunk.sequenceNumber == 9)
+    }
+
+    @Test func capNeverEvictsInFlightChunk() throws {
+        let b = PCMBuffer(maxBytes: 3)
+        b.append(Data([1, 1, 1]), sequenceNumber: 1)
+        let inFlight = try #require(b.claimNext())
+        let evicted = b.append(Data([2, 2, 2, 2]), sequenceNumber: 2)
+
+        #expect(evicted.map(\.sequenceNumber) == [2])
+        #expect(b.retry(inFlight))
+        #expect(b.claimNext()?.chunk.sequenceNumber == 1)
+    }
+
+    /// URLSession can report a successful local send while a half-open socket has delivered no
+    /// bytes to the server. The chunk therefore remains available to the replacement connection.
+    @Test func localSendCompletionDoesNotRemoveChunkFromReconnectReplay() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1, 2]), sequenceNumber: 41, capturedAt: 10, duration: 0.01)
+        let locallySent = try #require(b.claimNext())
+        #expect(b.completeSend(locallySent))
+        #expect(b.claimNext() == nil)
+
+        let recovery = b.prepareForReconnect()
+        #expect(recovery.replayedChunks == 1)
+        #expect(recovery.oldestCapturedAt == 10)
+        #expect(try #require(b.claimNext()).chunk.sequenceNumber == 41)
+    }
+
+    @Test func reconnectReplaysLocalTailBeforeNeverSentAudio() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1]), sequenceNumber: 1, capturedAt: 1, duration: 0.01)
+        let sent = try #require(b.claimNext())
+        #expect(b.completeSend(sent))
+        b.append(Data([2]), sequenceNumber: 2, capturedAt: 2, duration: 0.01)
+
+        b.prepareForReconnect()
+        #expect(b.drainChunks().map(\.sequenceNumber) == [1, 2])
+    }
+
+    @Test func serverProgressDiscardsOnlyCoveredLocalSendPrefix() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        for sequence in 1...3 {
+            b.append(Data([UInt8(sequence)]), sequenceNumber: UInt64(sequence),
+                     capturedAt: TimeInterval(sequence), duration: 0.5)
+            let claim = try #require(b.claimNext())
+            #expect(b.completeSend(claim))
+        }
+
+        #expect(b.discardSent(through: 2.5).map(\.sequenceNumber) == [1, 2])
+        b.prepareForReconnect()
+        #expect(b.drainChunks().map(\.sequenceNumber) == [3])
+    }
+
+    @Test func staleLocalCompletionCannotRemoveRequeuedChunk() throws {
+        let b = PCMBuffer(maxBytes: 100)
+        b.append(Data([1]), sequenceNumber: 1, capturedAt: 1, duration: 0.01)
+        let oldClaim = try #require(b.claimNext())
+
+        b.prepareForReconnect()
+        let replacementClaim = try #require(b.claimNext())
+        #expect(!b.completeSend(oldClaim))
+        #expect(b.completeSend(replacementClaim))
+
+        b.prepareForReconnect()
+        #expect(b.claimNext()?.chunk.sequenceNumber == 1)
+    }
+
+    @Test func localRecoveryTailAndPendingAudioShareTheMemoryCap() throws {
+        let b = PCMBuffer(maxBytes: 3)
+        b.append(Data([1, 1]), sequenceNumber: 1, capturedAt: 1, duration: 0.01)
+        let sent = try #require(b.claimNext())
+        #expect(b.completeSend(sent))
+
+        b.append(Data([2, 2]), sequenceNumber: 2, capturedAt: 2, duration: 0.01)
+        #expect(b.bufferedBytes <= 3)
+        b.prepareForReconnect()
+        #expect(b.drainChunks().map(\.sequenceNumber) == [2])
+    }
+
+    /// A full rolling recovery tail is expected to age out its oldest, already-locally-sent chunk
+    /// as fresh outage audio arrives. Only eviction of audio that has never reached a socket is an
+    /// unrecoverable continuity gap worth reporting to the coach.
+    @Test func reportsOverflowOnlyAfterNeverSentAudioAgesOut() throws {
+        let b = PCMBuffer(maxBytes: 2)
+        for sequence in 1...2 {
+            b.append(Data([UInt8(sequence)]), sequenceNumber: UInt64(sequence))
+            let claim = try #require(b.claimNext())
+            #expect(b.completeSend(claim))
+        }
+        b.prepareForReconnect()
+
+        #expect(b.append(Data([3]), sequenceNumber: 3).isEmpty)
+        #expect(b.append(Data([4]), sequenceNumber: 4).isEmpty)
+        #expect(b.append(Data([5]), sequenceNumber: 5).map(\.sequenceNumber) == [3])
+        #expect(b.drainChunks().map(\.sequenceNumber) == [4, 5])
+    }
 }

--- a/Tests/JarvisCoreTests/Audio/SystemAudioTimelineTests.swift
+++ b/Tests/JarvisCoreTests/Audio/SystemAudioTimelineTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct SystemAudioTimelineTests {
+    @Test func emptyTapStillAdvancesRealtimeVADClock() {
+        #expect(SystemAudioTimeline.preservingSamples([], minimumFrameCount: 480)
+            == Array(repeating: 0, count: 480))
+    }
+
+    @Test func shortTapPreservesSamplesAndPadsOnlyMissingSilence() {
+        #expect(SystemAudioTimeline.preservingSamples([10, 20], minimumFrameCount: 4)
+            == [10, 20, 0, 0])
+    }
+
+    @Test func longTapIsNeverTruncatedForTranscription() {
+        #expect(SystemAudioTimeline.preservingSamples([10, 20, 30, 40], minimumFrameCount: 2)
+            == [10, 20, 30, 40])
+    }
+}

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -60,6 +60,20 @@ final class GatedScreen: ScreenCapturing, @unchecked Sendable {
     }
 }
 
+// @unchecked Sendable: `storedCaptureCount` is guarded by `lock`.
+final class PipelineFailingScreen: ScreenCapturing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCaptureCount = 0
+    func capture() -> ScreenSnapshot? {
+        lock.lock(); storedCaptureCount += 1; lock.unlock()
+        return nil
+    }
+
+    var captureCount: Int {
+        lock.lock(); defer { lock.unlock() }; return storedCaptureCount
+    }
+}
+
 final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// One entry per `render` call: the lines the brain returned, passed straight through (no splitting).
     var rendered: [[String]] = []
@@ -71,18 +85,61 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 }
 
+// @unchecked Sendable: `stored` is guarded by `lock`.
+final class ScreenCaptureRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: [ScreenSnapshot] = []
+
+    func record(_ snapshot: ScreenSnapshot) {
+        lock.lock(); stored.append(snapshot); lock.unlock()
+    }
+
+    var snapshots: [ScreenSnapshot] {
+        lock.lock(); defer { lock.unlock() }; return stored
+    }
+}
+
+// @unchecked Sendable: `storedCount` is guarded by `lock`.
+final class RejectionRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedCount = 0
+
+    func record() {
+        lock.lock(); storedCount += 1; lock.unlock()
+    }
+
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }; return storedCount
+    }
+}
+
 // `.serialized`: two tests here drive the shared `ActivityLog` singleton (the screenshot e2e and the
 // manual-hint trigger-log e2e). Serializing the suite keeps their enable()/disable() from racing each
 // other — they are the only code that enables the shared log, so no other suite can collide.
 @Suite(.serialized) struct CoachDriverPipelineTests {
+    private func enableMonitorAuditLog() throws -> URL {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "jarvis-monitor-audit-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        ActivityLog.shared.enable(directory: directory)
+        return directory
+    }
+
     private func makeDriver(brain: BrainClient, summarizer: BrainClient? = nil,
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
-                            clock: Clock, config: Config = .default) -> (CoachDriver, RollingTranscript) {
+                            clock: Clock, config: Config = .default,
+                            onScreenCaptured: (@Sendable (ScreenSnapshot) -> Void)? = nil,
+                            onScreenCaptureRejected: (@Sendable () -> Void)? = nil) -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
         let driver = CoachDriver(
             config: config, transcript: transcript,
-            brain: brain, summarizer: summarizer, screen: screen, overlay: overlay, clock: clock
+            brain: brain, summarizer: summarizer, screen: screen, overlay: overlay, clock: clock,
+            onScreenCaptured: onScreenCaptured,
+            onScreenCaptureRejected: onScreenCaptureRejected
         )
         return (driver, transcript)
     }
@@ -117,7 +174,163 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls[1].contains { $0.role == .tool && $0.toolCallId == "c1" })
         #expect(brain.calls[1].contains { $0.imageBase64JPEG != nil })
         // No OCR text on this snapshot → the tool result stays the plain marker.
-        #expect(brain.calls[1].first { $0.role == .tool }?.text == "screenshot captured")
+        #expect(brain.calls[1].first { $0.role == .tool }?.text == "fresh point-in-time screenshot captured")
+    }
+
+    /// Interviewer language is interpreted by the model rather than a finite phrase matcher. The
+    /// first request carries the general freshness instructions; when the model decides the screen
+    /// is relevant, its normal tool loop obtains the current image and OCR.
+    @Test func interviewerScreenUpdateUsesTheGeneralModelCapturePolicy() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "c1")],
+                  rawToolCalls: [RawToolCall(id: "c1", name: "capture_screen", argumentsJSON: "{}")]),
+            .init(toolCalls: [.staySilent(callId: "q1")],
+                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")]),
+        ])
+        let snapshot = ScreenSnapshot(imageBase64: "fresh-question", recognizedText: "Reverse a linked list")
+        let screen = FakeScreen(payload: snapshot.imageBase64, recognizedText: snapshot.recognizedText)
+        let recorder = ScreenCaptureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: brain, screen: screen, clock: ManualClock(now: 40),
+            onScreenCaptured: recorder.record)
+        transcript.append(.init(speaker: .them, text: "Okay, I'll put the question here.", at: 40))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
+
+        #expect(screen.captureCount == 1)
+        #expect(brain.calls.count == 2)
+        #expect(brain.toolChoices == [.required, .required])
+        #expect(!brain.calls[0].contains { $0.imageBase64JPEG != nil })
+        let firstRequestText = brain.calls[0].compactMap(\.text).joined(separator: "\n")
+        #expect(firstRequestText.contains("historical observations never prove the current screen"))
+        #expect(firstRequestText.contains("Okay, I'll put the question here."))
+        #expect(brain.calls[1].contains { $0.imageBase64JPEG == "fresh-question" })
+        #expect(brain.calls[1].contains { ($0.text ?? "").contains("Reverse a linked list") })
+        #expect(recorder.snapshots == [snapshot])
+    }
+
+    /// Silence is itself a reason to inspect progress. It no longer asks a screen-blind model to
+    /// decide whether to capture; the first request already carries the current screen.
+    @Test func silencePreCapturesIntoFirstRequestWithoutForcingSpeech() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "q1")],
+                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")]),
+        ])
+        let screen = FakeScreen(recognizedText: "int answer = 0;")
+        let (driver, _) = makeDriver(brain: brain, screen: screen, clock: ManualClock(now: 120))
+
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 120)) == .silentByModel)
+
+        #expect(screen.captureCount == 1)
+        #expect(brain.calls.count == 1)
+        #expect(brain.toolChoices == [.required])
+        #expect(brain.calls[0].contains { $0.imageBase64JPEG != nil })
+        #expect(brain.calls[0].contains { ($0.text ?? "").contains("int answer = 0;") })
+    }
+
+    /// The app's visual monitor supplies the stable snapshot it observed after typing/navigation.
+    /// CoachDriver sends that exact image without a second capture race; only a hotkey forces speak.
+    @Test func screenChangedUsesSuppliedSnapshotWithoutRecapturingOrForcingSpeech() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "q1")],
+                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")]),
+        ])
+        let screen = FakeScreen(recognizedText: "stale fallback")
+        let snapshot = ScreenSnapshot(imageBase64: TestFixtures.tinyJpegBase64,
+                                      recognizedText: "return left + right;")
+        let recorder = ScreenCaptureRecorder()
+        let (driver, _) = makeDriver(brain: brain, screen: screen, clock: ManualClock(now: 15),
+                                     onScreenCaptured: recorder.record)
+
+        #expect(await driver.handleScreenChange(snapshot) == .silentByModel)
+
+        #expect(screen.captureCount == 0)
+        #expect(brain.calls.count == 1)
+        #expect(brain.toolChoices == [.required])
+        #expect(brain.calls[0].contains {
+            $0.imageBase64JPEG == TestFixtures.tinyJpegBase64
+        })
+        let firstRequestText = brain.calls[0].compactMap(\.text).joined(separator: "\n")
+        #expect(firstRequestText.contains("screen changed"))
+        #expect(firstRequestText.contains("return left + right;"))
+        #expect(recorder.snapshots == [snapshot])
+
+        _ = ActivityLog.shared.attach { _ in }
+        let jsonl = try String(
+            contentsOf: directory.appendingPathComponent("jarvis-activity.jsonl"),
+            encoding: .utf8)
+        #expect(jsonl.contains("stable screen change detected"))
+    }
+
+    @Test func silentScreenChangeDoesNotInflateLaterRequestHistory() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "q1")]),
+            .init(toolCalls: [.staySilent(callId: "q2")]),
+        ])
+        let first = ScreenSnapshot(
+            imageBase64: TestFixtures.tinyJpegBase64,
+            recognizedText: "FIRST_TRANSIENT_SCREEN_ONLY_TEXT")
+        let second = ScreenSnapshot(
+            imageBase64: TestFixtures.tinyJpegBase64,
+            recognizedText: "SECOND_CURRENT_SCREEN_TEXT")
+        let (driver, _) = makeDriver(brain: brain, clock: ManualClock(now: 15))
+
+        #expect(await driver.handleScreenChange(first) == .silentByModel)
+        #expect(await driver.handleScreenChange(second) == .silentByModel)
+
+        #expect(brain.calls.count == 2)
+        let nextRequestText = brain.calls[1].compactMap(\.text).joined(separator: "\n")
+        #expect(!nextRequestText.contains("FIRST_TRANSIENT_SCREEN_ONLY_TEXT"))
+        #expect(nextRequestText.contains("SECOND_CURRENT_SCREEN_TEXT"))
+    }
+
+    @Test func audioTurnPiggybacksStableSnapshotWithoutAnExtraCaptureOrVisualTriggerNote() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "q1")],
+                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")]),
+        ])
+        let screen = FakeScreen(recognizedText: "stale fallback")
+        let snapshot = ScreenSnapshot(imageBase64: TestFixtures.tinyJpegBase64,
+                                      recognizedText: "return frequencies.size();")
+        let recorder = ScreenCaptureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: brain, screen: screen, clock: ManualClock(now: 15),
+            onScreenCaptured: recorder.record)
+        transcript.append(.init(speaker: .them, text: "Can you improve the complexity?", at: 14))
+
+        #expect(await driver.handleTurnEnd(screenSnapshot: snapshot) == .silentByModel)
+        #expect(screen.captureCount == 0)
+        #expect(brain.calls.count == 1)
+        #expect(brain.calls[0].contains {
+            $0.imageBase64JPEG == TestFixtures.tinyJpegBase64
+        })
+        let text = brain.calls[0].compactMap(\.text).joined(separator: "\n")
+        #expect(text.contains("Can you improve the complexity?"))
+        #expect(text.contains("return frequencies.size();"))
+        #expect(!text.contains("screen changed"))
+        #expect(recorder.snapshots == [snapshot])
+    }
+
+    @Test func stableSnapshotMakesAFillerAudioTurnWorthSending() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "q")])])
+        let snapshot = ScreenSnapshot(imageBase64: TestFixtures.tinyJpegBase64,
+                                      recognizedText: "for (int value : values)")
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 1))
+        transcript.append(.init(speaker: .me, text: "Hmm.", at: 1))
+
+        #expect(await driver.handleTurnEnd(screenSnapshot: snapshot) == .silentByModel)
+        #expect(brain.calls.count == 1)
+        #expect(brain.calls[0].contains {
+            $0.imageBase64JPEG == TestFixtures.tinyJpegBase64
+        })
     }
 
     /// D2 (OCR sidecar): when the capture carries recognized text, it rides in the capture_screen
@@ -289,20 +502,21 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(!second.contains { $0.role == .tool })                                       // no dangling result
     }
 
-    /// A silence check the model shrugs at (stay_silent, nothing new said) leaves NO trace in the
-    /// session memory: committing its bare trigger note would pile up answerless user messages,
-    /// re-billed on every later request and confusing to read back in the request log.
-    @Test func silentSilenceCheckLeavesNoTriggerNoteInHistory() async {
+    /// A silence check pre-captures fresh pixels for its own request. Once that turn commits, the
+    /// trigger note and observation stub remain useful context, but stale pixels are not re-billed.
+    @Test func silentSilenceCheckStubsScreenPixelsAfterTheirTurn() async {
         let clock = ManualClock(now: 0)
         let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "q1")],
                                                  rawToolCalls: [RawToolCall(id: "q1", name: "stay_silent", argumentsJSON: "{}")])])
         let (driver, transcript) = makeDriver(brain: brain, clock: clock)
         #expect(await driver.handleTrigger(.silence(secondsQuiet: 120)) == .silentByModel)
+        #expect(brain.calls[0].contains { $0.imageBase64JPEG != nil })
 
         transcript.append(.init(speaker: .me, text: "ok here is an idea", at: 5))
         await driver.handleTrigger(.turnEnd)
-        // Scoped to user messages: the system prompt legitimately shows a "(no speech for …)" example.
-        #expect(!brain.calls[1].contains { $0.role == .user && ($0.text ?? "").contains("no speech for") })
+        #expect(brain.calls[1].contains { $0.role == .user && ($0.text ?? "").contains("no speech for") })
+        #expect(!brain.calls[1].contains { $0.imageBase64JPEG != nil })
+        #expect(brain.calls[1].contains { ($0.text ?? "").contains("no longer available") })
     }
 
     /// But a silence check where the model DID look at the screen keeps the whole turn in memory —
@@ -620,6 +834,104 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .brainError)
     }
 
+    @Test func failedMonitorSnapshotRequestIsRejectedInsteadOfAcknowledged() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let accepted = ScreenCaptureRecorder()
+        let rejected = RejectionRecorder()
+        let snapshot = ScreenSnapshot(
+            imageBase64: TestFixtures.tinyJpegBase64, recognizedText: "Two Sum")
+        let (driver, _) = makeDriver(
+            brain: ThrowingBrain(), clock: ManualClock(now: 0),
+            onScreenCaptured: accepted.record,
+            onScreenCaptureRejected: rejected.record)
+
+        #expect(await driver.handleScreenChange(snapshot) == .brainError)
+        #expect(accepted.snapshots.isEmpty)
+        #expect(rejected.count == 1)
+    }
+
+    @Test func monitorAuditFailureAbortsTheBrainRequestAndRearmsTheCandidate() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "q")])])
+        let accepted = ScreenCaptureRecorder()
+        let rejected = RejectionRecorder()
+        // One base64 character cannot form a decodable payload, so no owner-only JPEG can be saved.
+        let snapshot = ScreenSnapshot(imageBase64: "A", recognizedText: "Two Sum")
+        let (driver, _) = makeDriver(
+            brain: brain, clock: ManualClock(now: 0),
+            onScreenCaptured: accepted.record,
+            onScreenCaptureRejected: rejected.record)
+
+        #expect(await driver.handleScreenChange(snapshot) == .screenAuditError)
+        #expect(brain.calls.isEmpty)
+        #expect(accepted.snapshots.isEmpty)
+        #expect(rejected.count == 1)
+    }
+
+    @Test func ordinaryCaptureDoesNotAdvanceTheMonitorBaselineWhenItsRequestFails() async {
+        let brain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "c")],
+                  rawToolCalls: [RawToolCall(
+                    id: "c", name: "capture_screen", argumentsJSON: "{}")]),
+            nil,
+        ])
+        let accepted = ScreenCaptureRecorder()
+        let screen = FakeScreen(
+            payload: TestFixtures.tinyJpegBase64, recognizedText: "new question")
+        let (driver, transcript) = makeDriver(
+            brain: brain, screen: screen, clock: ManualClock(now: 0),
+            onScreenCaptured: accepted.record)
+        transcript.append(.init(speaker: .me, text: "check this problem", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .brainError)
+        #expect(screen.captureCount == 1)
+        #expect(brain.calls.count == 2)
+        #expect(accepted.snapshots.isEmpty)
+    }
+
+    @Test func monitorSnapshotIsPersistedBeforeFailedSendAndNotDuplicatedOnRetry() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jarvis-monitor-audit-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
+        ActivityLog.shared.enable(directory: dir)
+
+        let success = BrainResponse(toolCalls: [.staySilent(callId: "q")])
+        let brain = ScriptedThrowBrain(script: [nil, success])
+        let accepted = ScreenCaptureRecorder()
+        let rejected = RejectionRecorder()
+        let snapshot = ScreenSnapshot(
+            imageBase64: TestFixtures.tinyJpegBase64, recognizedText: "Two Sum")
+        let (driver, _) = makeDriver(
+            brain: brain, clock: ManualClock(now: 0),
+            onScreenCaptured: accepted.record,
+            onScreenCaptureRejected: rejected.record)
+
+        #expect(await driver.handleScreenChange(snapshot) == .brainError)
+        // No ActivityLog barrier here: the audit-critical path must have completed before the brain
+        // was allowed to throw from its first request.
+        let afterFailure = try FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("shot-") && $0.pathExtension == "jpg" }
+        let persistedBeforeFailureReturned = try afterFailure.filter {
+            try Data(contentsOf: $0) == TestFixtures.tinyJpeg
+        }
+        #expect(persistedBeforeFailureReturned.count == 1)
+
+        #expect(await driver.handleScreenChange(snapshot) == .silentByModel)
+        _ = ActivityLog.shared.attach { _ in } // serial-queue persistence barrier
+
+        let shots = try FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil
+        ).filter { $0.lastPathComponent.hasPrefix("shot-") && $0.pathExtension == "jpg" }
+        let matching = try shots.filter { try Data(contentsOf: $0) == TestFixtures.tinyJpeg }
+        #expect(matching.count == 1)
+        #expect(rejected.count == 1)
+        #expect(accepted.snapshots == [snapshot])
+    }
+
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
     /// prompt — reply, look at the screen, or stay_silent — but must answer with one of them.
     @Test func everyAudioTurnRequiresAToolCall() async {
@@ -647,6 +959,77 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         await gate.release()
         _ = await first
         #expect(brain.callCount >= 2)                      // the original AND the coalesced turn ran
+    }
+
+    /// A visual-change event must not disappear behind an already-pending ordinary turn-end. The
+    /// speech itself rides in the delta, so replacing the pending reason preserves both inputs and
+    /// guarantees the follow-up first request contains a fresh screenshot.
+    @Test func pendingScreenChangeTakesPriorityOverPendingTurnEnd() async {
+        let gate = AsyncGate()
+        let brain = GatedBrain(
+            gate: gate,
+            response: .init(toolCalls: [.staySilent(callId: "q")]))
+        let screen = FakeScreen(recognizedText: "newly typed solution")
+        let (driver, transcript) = makeDriver(
+            brain: brain, screen: screen, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "first idea about the grid", at: 0))
+
+        async let first = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+        transcript.append(.init(speaker: .me, text: "second idea about the rows", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .busy)
+        #expect(await driver.handleTrigger(.screenChanged) == .busy)
+        await gate.release()
+        _ = await first
+
+        #expect(brain.callCount >= 2)
+        #expect(screen.captureCount == 1)
+    }
+
+    /// A manual hint outranks a queued monitor change and normally supersedes it with an even fresher
+    /// capture. If that capture fails, the displaced stable snapshot must be rejected so the monitor
+    /// can emit it again instead of waiting forever for an acknowledgement that cannot arrive.
+    @Test func manualHintDisplacingPendingScreenChangeRearmsMonitorWhenCaptureFails() async throws {
+        let directory = try enableMonitorAuditLog()
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: directory) }
+        let gate = AsyncGate()
+        let brain = GatedBrain(
+            gate: gate,
+            response: .init(toolCalls: [.staySilent(callId: "q")]))
+        let screen = PipelineFailingScreen()
+        let accepted = ScreenCaptureRecorder()
+        let rejected = RejectionRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: brain, screen: screen, clock: ManualClock(now: 0),
+            onScreenCaptured: accepted.record,
+            onScreenCaptureRejected: rejected.record)
+        transcript.append(.init(speaker: .me, text: "first idea about the grid", at: 0))
+
+        async let first = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+        let stableQuestion = ScreenSnapshot(
+            imageBase64: TestFixtures.tinyJpegBase64, recognizedText: "Two Sum")
+        #expect(await driver.handleScreenChange(stableQuestion) == .busy)
+        #expect(await driver.handleTrigger(.manualHint) == .busy)
+
+        // Replacement happens synchronously while the first turn owns the slot.
+        #expect(rejected.count == 1)
+        // A monitor retry while the manual hint is still pending also loses coalescing. It must be
+        // rejected again, not left awaiting an acknowledgement from a turn that never queued it.
+        #expect(await driver.handleScreenChange(stableQuestion) == .busy)
+        #expect(rejected.count == 2)
+        await gate.release()
+        _ = await first
+
+        #expect(screen.captureCount == 1)
+        #expect(accepted.snapshots.isEmpty)
+        #expect(rejected.count == 2)
+
+        // After the failed manual capture drains, the next monitor retry gets the slot and is
+        // acknowledged after its first successful brain request.
+        #expect(await driver.handleScreenChange(stableQuestion) == .silentByModel)
+        #expect(accepted.snapshots == [stableQuestion])
+        #expect(rejected.count == 2)
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -25,6 +25,21 @@ import Testing
         #expect(coachSystemPrompt.contains("line"))   // brevity is now framed as overlay lines
     }
 
+    @Test func screenObservationsAreExplicitlyPointInTimeAndCanBecomeStale() {
+        #expect(captureScreenTool.description.contains("point-in-time"))
+        #expect(captureScreenTool.description.contains("stale"))
+        #expect(coachSystemPrompt.contains("point-in-time"))
+        #expect(coachSystemPrompt.contains("stale"))
+    }
+
+    @Test func screenFreshnessPolicyTreatsHistoryAsStale() {
+        #expect(coachSystemPrompt.contains("CURRENT request"))
+        #expect(coachSystemPrompt.contains("historical observations never prove the current screen"))
+        #expect(coachSystemPrompt.contains("appeared, may be about to appear, or may have changed"))
+        #expect(!coachSystemPrompt.contains("Apply this by meaning"))
+        #expect(coachSystemPrompt.contains("later stable screen-change turn"))
+    }
+
     /// Silence is a TOOL now: the prompt must direct the model to stay_silent (never free text),
     /// or a required tool_choice would leave it no sanctioned way to stay quiet.
     @Test func coachPromptDirectsSilenceToTheStaySilentTool() {

--- a/Tests/JarvisCoreTests/Config/ConfigTests.swift
+++ b/Tests/JarvisCoreTests/Config/ConfigTests.swift
@@ -18,6 +18,11 @@ import Testing
         #expect(c.realtimeReadyTimeoutSeconds == 10)
         #expect(c.realtimePingIntervalSeconds == 20)
         #expect(c.realtimePongTimeoutSeconds == 10)
+        #expect(c.screenMonitorFrameIntervalSeconds == 1)
+        #expect(c.screenMonitorQuiescenceSeconds == 1.25)
+        #expect(c.screenMonitorMinimumRequestIntervalSeconds == 60)
+        #expect(c.screenMonitorPiggybackWaitSeconds == 2)
+        #expect(c.screenMonitorMinimumChangedAreaRatio == 0.0001)
     }
 
     @Test func overlayAppearanceConstants() {
@@ -59,6 +64,14 @@ import Testing
         #expect(c.realtimeReadyTimeoutSeconds > 0)
         #expect(c.realtimePingIntervalSeconds > 0)
         #expect(c.realtimePongTimeoutSeconds > 0)
+    }
+
+    @Test func screenMonitorConstantsAreCoherent() {
+        let c = Config.default
+        #expect(c.screenMonitorFrameIntervalSeconds > 0)
+        #expect(c.screenMonitorQuiescenceSeconds >= c.screenMonitorFrameIntervalSeconds)
+        #expect(c.screenMonitorMinimumRequestIntervalSeconds >= c.screenMonitorPiggybackWaitSeconds)
+        #expect((0..<1).contains(c.screenMonitorMinimumChangedAreaRatio))
     }
 
     @Test func envSecretStoreReadsKey() {

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -6,6 +6,7 @@ import Foundation
     @Test func cssClassKeysOnLeadingMarker() {
         #expect(ActivityLog.cssClass(for: "💬 use a hash map") == "say")
         #expect(ActivityLog.cssClass(for: "👁 looking at your screen") == "see")
+        #expect(ActivityLog.cssClass(for: "🖥 stable screen change detected") == "see")
         #expect(ActivityLog.cssClass(for: "🗣 heard: \"hello\"") == "hear")
         #expect(ActivityLog.cssClass(for: "🤫 quiet for 8s") == "hear")
         #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
@@ -89,6 +90,21 @@ import Foundation
         let snap = log.attach { _ in }
         #expect(snap.total == 0)
         #expect(snap.rows.isEmpty)
+    }
+
+    @Test func synchronousRecordReportsWhetherTheAuditImageWasPersisted() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+
+        #expect(log.recordSynchronously(
+            "👁 looking", imageBase64: TestFixtures.tinyJpegBase64))
+        #expect(!log.recordSynchronously("👁 invalid", imageBase64: "A"))
+
+        let snapshot = log.attach { _ in }
+        #expect(snapshot.total == 1)
+        let files = try FileManager.default.contentsOfDirectory(
+            at: dir, includingPropertiesForKeys: nil)
+        #expect(files.filter { $0.pathExtension == "jpg" }.count == 1)
     }
 
     /// Shared temp-dir helper (also used by SessionStoreTests). Owner-only dir, like the real app.

--- a/Tests/JarvisCoreTests/Diagnostics/AudioContinuityWitnessTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/AudioContinuityWitnessTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct AudioContinuityWitnessTests {
+    @Test func periodicSnapshotContainsOnlyContentFreeContinuityMetadata() throws {
+        let witness = makeWitness(snapshotInterval: 1)
+        #expect(witness.recordCapture(sequence: 10, sampleCount: 480, at: 0).snapshot == nil)
+        _ = witness.recordDelivery(sequence: 10, pcm16: pcm(amplitude: 1_000), at: 0.05)
+        _ = witness.recordSendAttempt(sequence: 10, socketGeneration: 2, at: 0.06)
+        _ = witness.recordSendSuccess(sequence: 10, socketGeneration: 2, at: 0.07)
+        _ = witness.recordServerSpeech(.speechStarted, audioTimeMilliseconds: 40,
+                                       socketGeneration: 2, sessionAudioTime: 0.04,
+                                       observedAt: 0.08)
+
+        let snapshot = try #require(witness.poll(at: 1).snapshot)
+        #expect(snapshot.capturedChunks == 1)
+        #expect(snapshot.capturedSamples == 480)
+        #expect(snapshot.deliveredChunks == 1)
+        #expect(snapshot.deliveredSamples == 480)
+        #expect(snapshot.pendingCapturedChunks == 0)
+        #expect(snapshot.localActivityDetected)
+        #expect(snapshot.latestSocketGeneration == 2)
+        let socket = try #require(snapshot.socketGenerations.first)
+        #expect(socket.sendAttempts == 1)
+        #expect(socket.sendSuccesses == 1)
+        #expect(socket.sendFailures == 0)
+        #expect(socket.lastSendSequence == 10)
+        #expect(socket.serverSpeechSignals == 1)
+        #expect(socket.lastServerSignal == .speechStarted)
+        #expect(socket.lastServerAudioTimeMilliseconds == 40)
+    }
+
+    @Test func captureStallEmitsOncePerIncidentAndResetsAfterCapture() {
+        let witness = makeWitness(captureStallThreshold: 2)
+        let first = witness.poll(at: 2.5)
+        #expect(first.anomalies == [.captureStalled(lastCaptureAt: nil, duration: 2.5)])
+        #expect(witness.poll(at: 3).anomalies.isEmpty)
+
+        #expect(witness.recordCapture(sequence: 0, sampleCount: 480, at: 3).anomalies.isEmpty)
+        let second = witness.poll(at: 5.5)
+        #expect(second.anomalies == [.captureStalled(lastCaptureAt: 3, duration: 2.5)])
+        #expect(witness.poll(at: 6).anomalies.isEmpty)
+    }
+
+    @Test func recoveryCaptureReportsAnUnpolledStallExactlyOnce() {
+        let witness = makeWitness(captureStallThreshold: 1)
+        let recovered = witness.recordCapture(sequence: 0, sampleCount: 10, at: 2)
+        #expect(recovered.anomalies == [.captureStalled(lastCaptureAt: nil, duration: 2)])
+        #expect(witness.poll(at: 2.5).anomalies.isEmpty)
+    }
+
+    @Test func pendingCaptureReportsDeliveryLagBeforeDeliveryRecovers() {
+        let witness = makeWitness(deliveryLagThreshold: 0.25)
+        _ = witness.recordCapture(sequence: 12, sampleCount: 480, at: 0)
+
+        let blocked = witness.poll(at: 0.5)
+        #expect(blocked.anomalies == [.captureToDeliveryLag(sequence: 12, lag: 0.5)])
+        #expect(witness.poll(at: 0.75).anomalies.isEmpty)
+        #expect(witness.recordDelivery(sequence: 12, pcm16: pcm(amplitude: 0), at: 1)
+            .anomalies.isEmpty)
+    }
+
+    @Test func deliveryLagIsLatchedUntilAHealthyDeliveryAndSequenceGapsAreTyped() {
+        let witness = makeWitness(deliveryLagThreshold: 0.2)
+        _ = witness.recordCapture(sequence: 1, sampleCount: 480, at: 0)
+        let first = witness.recordDelivery(sequence: 1, pcm16: pcm(amplitude: 0), at: 0.5)
+        #expect(first.anomalies.contains(.captureToDeliveryLag(sequence: 1, lag: 0.5)))
+
+        _ = witness.recordCapture(sequence: 2, sampleCount: 480, at: 0.6)
+        let stillLagging = witness.recordDelivery(sequence: 2, pcm16: pcm(amplitude: 0), at: 1.1)
+        #expect(!stillLagging.anomalies.contains(where: { if case .captureToDeliveryLag = $0 { true } else { false } }))
+
+        let captureGap = witness.recordCapture(sequence: 4, sampleCount: 480, at: 1.25)
+        #expect(captureGap.anomalies.contains(.sequenceGap(stage: .capture,
+                                                           expected: 3, observed: 4)))
+        let healthy = witness.recordDelivery(sequence: 4, pcm16: pcm(amplitude: 0), at: 1.375)
+        #expect(healthy.anomalies.contains(.sequenceGap(stage: .delivery, expected: 3, observed: 4)))
+        _ = witness.recordCapture(sequence: 5, sampleCount: 480, at: 1.5)
+        let lagAgain = witness.recordDelivery(sequence: 5, pcm16: pcm(amplitude: 0), at: 2)
+        #expect(lagAgain.anomalies.contains(.captureToDeliveryLag(sequence: 5, lag: 0.5)))
+
+        let actualCaptureGap = witness.recordCapture(sequence: 7, sampleCount: 480, at: 2.1)
+        #expect(actualCaptureGap.anomalies.contains(.sequenceGap(stage: .capture, expected: 6, observed: 7)))
+    }
+
+    @Test func missingCaptureAndSampleMismatchAreVisibleWithoutAudioContent() {
+        let witness = makeWitness()
+        let noCapture = witness.recordDelivery(sequence: 3, pcm16: pcm(amplitude: 0, count: 4), at: 0)
+        #expect(noCapture.anomalies == [.deliveryWithoutCapture(sequence: 3)])
+
+        _ = witness.recordCapture(sequence: 4, sampleCount: 8, at: 0.1)
+        let mismatch = witness.recordDelivery(sequence: 4, pcm16: pcm(amplitude: 0, count: 4), at: 0.1)
+        #expect(mismatch.anomalies.contains(.deliverySampleCountMismatch(sequence: 4,
+                                                                         captured: 8, delivered: 4)))
+    }
+
+    @Test func sustainedLocalActivityWithoutServerSpeechEmitsOncePerActivityEpisode() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        _ = witness.recordCapture(sequence: 0, sampleCount: 480, at: 0)
+        _ = witness.recordDelivery(sequence: 0, pcm16: pcm(amplitude: 1_000), at: 0.01)
+        _ = witness.recordCapture(sequence: 1, sampleCount: 480, at: 0.4)
+        _ = witness.recordDelivery(sequence: 1, pcm16: pcm(amplitude: 1_000), at: 0.41)
+        _ = witness.recordCapture(sequence: 2, sampleCount: 480, at: 0.6)
+        _ = witness.recordDelivery(sequence: 2, pcm16: pcm(amplitude: 1_000), at: 0.61)
+
+        let unmatched = witness.poll(at: 1.11)
+        #expect(unmatched.anomalies == [.localActivityUnmatched(activeSince: 0, duration: 1.11)])
+        #expect(witness.poll(at: 2).anomalies.isEmpty)
+
+        _ = witness.recordCapture(sequence: 3, sampleCount: 480, at: 2.1)
+        _ = witness.recordDelivery(sequence: 3, pcm16: pcm(amplitude: 0), at: 2.11)
+        _ = witness.recordCapture(sequence: 4, sampleCount: 480, at: 3)
+        _ = witness.recordDelivery(sequence: 4, pcm16: pcm(amplitude: 1_000), at: 3.01)
+        _ = witness.recordCapture(sequence: 5, sampleCount: 480, at: 3.6)
+        _ = witness.recordDelivery(sequence: 5, pcm16: pcm(amplitude: 1_000), at: 3.61)
+        _ = witness.recordServerSpeech(.speechStarted, audioTimeMilliseconds: 3_000,
+                                       socketGeneration: 1, sessionAudioTime: 3,
+                                       observedAt: 3.7)
+        #expect(!witness.poll(at: 5).anomalies.contains(where: {
+            if case .localActivityUnmatched = $0 { true } else { false }
+        }))
+    }
+
+    @Test func oneLoudChunkIsNotSustainedActivity() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        _ = witness.recordCapture(sequence: 0, sampleCount: 480, at: 0)
+        _ = witness.recordDelivery(sequence: 0, pcm16: pcm(amplitude: 2_000), at: 0.01)
+
+        #expect(!witness.poll(at: 2).anomalies.contains(where: {
+            if case .localActivityUnmatched = $0 { true } else { false }
+        }))
+    }
+
+    @Test func lateServerSpeechExplicitlyResolvesAnAlreadyReportedActivityWarning() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        for (sequence, time) in [(0, 0.0), (1, 0.3), (2, 0.6)] {
+            _ = witness.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = witness.recordDelivery(sequence: UInt64(sequence),
+                                       pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        #expect(witness.poll(at: 1.11).anomalies.contains(
+            .localActivityUnmatched(activeSince: 0, duration: 1.11)))
+        _ = witness.recordSendAttempt(sequence: 2, socketGeneration: 2, at: 1.2)
+        #expect(witness.poll(at: 1.4).anomalies.isEmpty)
+
+        let resolved = witness.recordServerSpeech(
+            .speechStarted, audioTimeMilliseconds: 0,
+            socketGeneration: 2, sessionAudioTime: 0.3, observedAt: 1.5)
+        #expect(resolved.anomalies == [.serverSpeechObservedAfterUnmatchedActivity(
+            activeSince: 0, serverObservedAt: 1.5)])
+        #expect(witness.poll(at: 3).anomalies.isEmpty)
+    }
+
+    @Test func delayedTerminalEventCannotMatchANewerLocalActivityEpisode() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        for (sequence, time) in [(0, 0.0), (1, 0.3), (2, 0.6)] {
+            _ = witness.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = witness.recordDelivery(sequence: UInt64(sequence),
+                                       pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        #expect(witness.poll(at: 1.11).anomalies.contains(
+            .localActivityUnmatched(activeSince: 0, duration: 1.11)))
+
+        for (sequence, time) in [(3, 3.0), (4, 3.3), (5, 3.6)] {
+            _ = witness.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = witness.recordDelivery(sequence: UInt64(sequence),
+                                       pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        _ = witness.recordServerSpeech(
+            .transcriptionCompleted, audioTimeMilliseconds: nil,
+            socketGeneration: 1, observedAt: 3.7)
+
+        #expect(witness.poll(at: 4.11).anomalies.contains(where: {
+            guard case .localActivityUnmatched(let activeSince, let duration) = $0 else {
+                return false
+            }
+            return abs(activeSince - 3) < 0.001 && abs(duration - 1.11) < 0.001
+        }))
+    }
+
+    @Test func serverSpeechStartMatchesOnlyTheOverlappingLocalEpisode() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        for (sequence, time) in [(0, 3.0), (1, 3.3), (2, 3.6)] {
+            _ = witness.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = witness.recordDelivery(sequence: UInt64(sequence),
+                                       pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        _ = witness.recordServerSpeech(
+            .speechStarted, audioTimeMilliseconds: 100,
+            socketGeneration: 1, sessionAudioTime: 0.1, observedAt: 3.7)
+        #expect(witness.poll(at: 4.11).anomalies.contains(where: {
+            guard case .localActivityUnmatched(let activeSince, let duration) = $0 else {
+                return false
+            }
+            return abs(activeSince - 3) < 0.001 && abs(duration - 1.11) < 0.001
+        }))
+
+        let matching = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        for (sequence, time) in [(0, 3.0), (1, 3.3), (2, 3.6)] {
+            _ = matching.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = matching.recordDelivery(sequence: UInt64(sequence),
+                                        pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        _ = matching.recordServerSpeech(
+            .speechStarted, audioTimeMilliseconds: 3_200,
+            socketGeneration: 1, sessionAudioTime: 3.2, observedAt: 3.7)
+        #expect(!matching.poll(at: 4.11).anomalies.contains(where: {
+            if case .localActivityUnmatched = $0 { true } else { false }
+        }))
+    }
+
+    @Test func speechEndingBeforeServerGraceStillProducesAnUnmatchedActivityAnomaly() {
+        let witness = makeWitness(sustainedActivityDuration: 0.5, serverSpeechGrace: 0.5)
+        for (sequence, time) in [(0, 0.0), (1, 0.25), (2, 0.55)] {
+            _ = witness.recordCapture(sequence: UInt64(sequence), sampleCount: 480, at: time)
+            _ = witness.recordDelivery(sequence: UInt64(sequence),
+                                       pcm16: pcm(amplitude: 1_000), at: time)
+        }
+        _ = witness.recordCapture(sequence: 3, sampleCount: 480, at: 0.8)
+        _ = witness.recordDelivery(sequence: 3, pcm16: pcm(amplitude: 0), at: 0.8)
+
+        #expect(!witness.poll(at: 1).anomalies.contains(where: {
+            if case .localActivityUnmatched = $0 { true } else { false }
+        }))
+        #expect(witness.poll(at: 1.06).anomalies.contains(
+            .localActivityUnmatched(activeSince: 0, duration: 1.06)))
+    }
+
+    @Test func sendMetadataIsSeparatedAndSortedBySocketGeneration() throws {
+        let witness = makeWitness()
+        _ = witness.recordSendAttempt(sequence: 8, socketGeneration: 3, at: 1)
+        _ = witness.recordSendFailure(sequence: 8, socketGeneration: 3, at: 1.1)
+        _ = witness.recordSendAttempt(sequence: 9, socketGeneration: 4, at: 2)
+        _ = witness.recordSendSuccess(sequence: 9, socketGeneration: 4, at: 2.1)
+
+        let snapshot = try #require(witness.poll(at: 2.2, forceSnapshot: true).snapshot)
+        #expect(snapshot.socketGenerations.map(\.generation) == [3, 4])
+        #expect(snapshot.socketGenerations[0].sendFailures == 1)
+        #expect(snapshot.socketGenerations[1].sendSuccesses == 1)
+        #expect(snapshot.latestSocketGeneration == 4)
+    }
+
+    @Test func reconnectBufferOverflowRecordsOnlyContentFreeSequenceEvidence() {
+        let witness = makeWitness()
+
+        let output = witness.recordReconnectBufferOverflow(
+            evictedSequences: [101, 102, 103], at: 4)
+
+        #expect(output.anomalies == [.reconnectBufferOverflow(
+            evictedChunks: 3, firstSequence: 101, lastSequence: 103)])
+    }
+
+    private func makeWitness(snapshotInterval: TimeInterval = 100,
+                             captureStallThreshold: TimeInterval = 100,
+                             deliveryLagThreshold: TimeInterval = 100,
+                             sustainedActivityDuration: TimeInterval = 100,
+                             serverSpeechGrace: TimeInterval = 100) -> AudioContinuityWitness {
+        AudioContinuityWitness(configuration: .init(
+            snapshotInterval: snapshotInterval,
+            captureStallThreshold: captureStallThreshold,
+            deliveryLagThreshold: deliveryLagThreshold,
+            sustainedActivityDuration: sustainedActivityDuration,
+            serverSpeechGrace: serverSpeechGrace,
+            activity: .init(initialNoiseFloorRMS: 80, minimumNoiseFloorRMS: 20,
+                            minimumActiveRMS: 200, minimumActivePeak: 500,
+                            activationMultiplier: 3, releaseMultiplier: 1.5,
+                            noiseAdaptationRate: 0.05)
+        ), startedAt: 0)
+    }
+
+    private func pcm(amplitude: Int16, count: Int = 480) -> Data {
+        let samples = (0..<count).map { $0.isMultiple(of: 2) ? amplitude : -amplitude }
+        return samples.withUnsafeBytes { Data($0) }
+    }
+}

--- a/Tests/JarvisCoreTests/Screen/ScreenActivityDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenActivityDetectorTests.swift
@@ -1,0 +1,124 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ScreenActivityDetectorTests {
+    @Test func idleAfterQuiescenceReportsOnceUntilAcknowledged() throws {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1,
+            minimumChangedAreaRatio: 0.02)
+
+        #expect(detector.observe(.idle, at: 0) == .idle)
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 0.4), at: 1)
+                == .waitingForQuiescence)
+        #expect(detector.observe(.idle, at: 1.99) == .waitingForQuiescence)
+
+        let result = detector.observe(.idle, at: 2)
+        let id = try #require(stableCandidateID(from: result))
+        #expect(detector.observe(.idle, at: 3) == .awaitingAcknowledgement(id))
+        let acknowledged = detector.acknowledge(id)
+        #expect(acknowledged)
+        #expect(detector.observe(.idle, at: 4) == .idle)
+    }
+
+    @Test func continuousSignificantChangesKeepRestartingQuiescence() {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 2,
+            minimumChangedAreaRatio: 0.01)
+
+        for timestamp in [0.0, 1.0, 2.0, 3.0] {
+            #expect(detector.observe(.contentChanged(changedAreaRatio: 0.2), at: timestamp)
+                    == .waitingForQuiescence)
+        }
+        #expect(detector.observe(.idle, at: 4.99) == .waitingForQuiescence)
+        #expect(stableCandidateID(from: detector.observe(.idle, at: 5)) != nil)
+    }
+
+    @Test func subThresholdChangesAreIgnoredWithoutRestartingCandidate() {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1,
+            minimumChangedAreaRatio: 0.05)
+
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 0.01), at: 0) == .ignored)
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 0.4), at: 1)
+                == .waitingForQuiescence)
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 0.049), at: 1.9) == .ignored)
+        #expect(stableCandidateID(from: detector.observe(.idle, at: 2)) != nil)
+    }
+
+    @Test func rejectedCandidateCanReportAgainButDoesNotSpamBeforeRejection() throws {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 0.5,
+            minimumChangedAreaRatio: 0.01)
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0.3), at: 0)
+
+        let id = try #require(stableCandidateID(from: detector.observe(.idle, at: 0.5)))
+        #expect(detector.observe(.idle, at: 1) == .awaitingAcknowledgement(id))
+        let rejected = detector.reject(id)
+        #expect(rejected)
+        #expect(detector.observe(.idle, at: 1) == .stableChange(id))
+        #expect(detector.observe(.idle, at: 2) == .awaitingAcknowledgement(id))
+    }
+
+    @Test func staleAcknowledgementCannotClearNewerCandidate() throws {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1,
+            minimumChangedAreaRatio: 0.01)
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0.2), at: 0)
+        let firstID = try #require(stableCandidateID(from: detector.observe(.idle, at: 1)))
+
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 0.3), at: 2)
+                == .waitingForQuiescence)
+        let acknowledgedStaleCandidate = detector.acknowledge(firstID)
+        #expect(!acknowledgedStaleCandidate)
+        let secondID = try #require(stableCandidateID(from: detector.observe(.idle, at: 3)))
+        #expect(secondID != firstID)
+        let acknowledgedCurrentCandidate = detector.acknowledge(secondID)
+        #expect(acknowledgedCurrentCandidate)
+    }
+
+    @Test func newerAwaitingCandidateCanBeRediscoveredAfterConsumerWasBusy() throws {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1,
+            minimumChangedAreaRatio: 0.01)
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0.2), at: 0)
+        let firstID = try #require(stableCandidateID(from: detector.observe(.idle, at: 1)))
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0.3), at: 2)
+        let secondID = try #require(stableCandidateID(from: detector.observe(.idle, at: 3)))
+
+        let acknowledgedStaleCandidate = detector.acknowledge(firstID)
+        #expect(!acknowledgedStaleCandidate)
+        #expect(detector.observe(.idle, at: 4) == .awaitingAcknowledgement(secondID))
+    }
+
+    @Test func restartReconciliationChangeProducesCaptureAfterFirstQuietWindow() {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1,
+            minimumChangedAreaRatio: 0.01)
+
+        #expect(detector.observe(.contentChanged(changedAreaRatio: 1), at: 10)
+                == .waitingForQuiescence)
+        #expect(detector.observe(.idle, at: 10.5) == .waitingForQuiescence)
+        #expect(stableCandidateID(from: detector.observe(.idle, at: 11)) != nil)
+    }
+
+    @Test func resetClearsCandidateButDoesNotReuseCandidateIdentity() throws {
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 0,
+            minimumChangedAreaRatio: 0)
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0), at: 0)
+        let firstID = try #require(stableCandidateID(from: detector.observe(.idle, at: 0)))
+
+        detector.reset()
+        #expect(detector.observe(.idle, at: 0) == .idle)
+        _ = detector.observe(.contentChanged(changedAreaRatio: 0), at: 0)
+        let secondID = try #require(stableCandidateID(from: detector.observe(.idle, at: 0)))
+        #expect(secondID != firstID)
+    }
+
+    private func stableCandidateID(
+        from result: ScreenActivityDetector.ObservationResult
+    ) -> ScreenActivityDetector.CandidateID? {
+        guard case .stableChange(let id) = result else { return nil }
+        return id
+    }
+}

--- a/Tests/JarvisCoreTests/Screen/ScreenCaptureOrderingTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenCaptureOrderingTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ScreenCaptureOrderingTests {
+    @Test func olderOrdinaryCaptureCannotAcknowledgeNewerScreenActivity() {
+        #expect(!ScreenCaptureOrdering.canAcknowledge(
+            capturedAt: 100,
+            latestObservedChangeAt: 101,
+            isMonitorSnapshot: false))
+    }
+
+    @Test func currentOrdinaryCaptureCanBecomeTheBaseline() {
+        #expect(ScreenCaptureOrdering.canAcknowledge(
+            capturedAt: 101,
+            latestObservedChangeAt: 101,
+            isMonitorSnapshot: false))
+    }
+
+    @Test func monitorCaptureUsesItsCandidateIDForOrdering() {
+        #expect(ScreenCaptureOrdering.canAcknowledge(
+            capturedAt: 100,
+            latestObservedChangeAt: 101,
+            isMonitorSnapshot: true))
+    }
+}

--- a/Tests/JarvisCoreTests/Screen/ScreenChangeDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenChangeDetectorTests.swift
@@ -1,0 +1,123 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ScreenChangeDetectorTests {
+    private func snapshot(_ text: String? = nil, image: String = "image-a",
+                          visual: UInt64? = nil) -> ScreenSnapshot {
+        ScreenSnapshot(imageBase64: image, recognizedText: text, visualFingerprint: visual)
+    }
+
+    @Test func remainsDormantUntilExplicitlySeeded() {
+        var detector = ScreenChangeDetector()
+
+        #expect(detector.poll(snapshot("question")) == .dormant)
+        #expect(detector.poll(snapshot("question")) == .dormant)
+        #expect(!detector.isSeeded)
+    }
+
+    @Test func firstLocalPollCanSeedWithoutReportingAChange() {
+        var detector = ScreenChangeDetector()
+
+        let didSeed = detector.seedIfNeeded(snapshot("blank editor"))
+        #expect(didSeed)
+        #expect(detector.isSeeded)
+        #expect(detector.poll(snapshot("blank editor")) == .unchanged)
+        let didReseed = detector.seedIfNeeded(snapshot("question appeared"))
+        #expect(!didReseed)
+        #expect(detector.poll(snapshot("question appeared")) == .waitingForStability)
+    }
+
+    @Test func normalizedOCRWhitespaceDoesNotCountAsAChange() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("class  Solution {\n    return answer;\n}"))
+
+        #expect(detector.poll(snapshot(" class Solution { return answer; } ")) == .unchanged)
+    }
+
+    @Test func changingCandidatesCoalesceUntilOneRemainsStable() {
+        var detector = ScreenChangeDetector(requiredStablePollCount: 2)
+        detector.observe(snapshot("// waiting for question"))
+
+        #expect(detector.poll(snapshot("Given an array")) == .waitingForStability)
+        #expect(detector.poll(snapshot("Given an array of integers")) == .waitingForStability)
+        #expect(detector.poll(snapshot("Given an array of integers")) == .stableChange)
+    }
+
+    @Test func stableStateEmitsOnceWhileAwaitingCoachAcknowledgement() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("before"))
+
+        #expect(detector.poll(snapshot("after")) == .waitingForStability)
+        #expect(detector.poll(snapshot("after")) == .stableChange)
+        #expect(detector.poll(snapshot("after")) == .awaitingAcknowledgement)
+
+        detector.observe(snapshot("after"))
+        #expect(detector.poll(snapshot("after")) == .unchanged)
+    }
+
+    @Test func newerStableCandidateCanReplaceOneStillAwaitingAcknowledgement() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("before"))
+
+        #expect(detector.poll(snapshot("partially typed")) == .waitingForStability)
+        #expect(detector.poll(snapshot("partially typed")) == .stableChange)
+        #expect(detector.poll(snapshot("finished solution")) == .waitingForStability)
+        #expect(detector.poll(snapshot("finished solution")) == .stableChange)
+    }
+
+    @Test func failedDeliveryRearmsTheSameStableCandidate() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("before"))
+
+        #expect(detector.poll(snapshot("question")) == .waitingForStability)
+        #expect(detector.poll(snapshot("question")) == .stableChange)
+        #expect(detector.poll(snapshot("question")) == .awaitingAcknowledgement)
+
+        detector.retryUnacknowledgedChange()
+        #expect(detector.poll(snapshot("question")) == .stableChange)
+    }
+
+    @Test func preservesCodeSensitiveCaseAndPunctuation() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("return value"))
+
+        #expect(detector.poll(snapshot("return Value;")) == .waitingForStability)
+        #expect(detector.poll(snapshot("return Value;")) == .stableChange)
+    }
+
+    @Test func sameOCRWithDifferentVisualContentStillCountsAsAChange() {
+        var detector = ScreenChangeDetector(requiredStablePollCount: 1)
+        detector.observe(snapshot("same OCR", visual: 0x0000_0000_0000_0000))
+
+        #expect(detector.poll(snapshot("same OCR", visual: 0xFFFF_FFFF_FFFF_FFFF))
+                == .stableChange)
+    }
+
+    @Test func smallPerceptualHashDriftDoesNotCreateScreenNoise() {
+        var detector = ScreenChangeDetector(requiredStablePollCount: 1)
+        detector.observe(snapshot("same OCR", visual: 0))
+
+        #expect(detector.poll(snapshot("same OCR", visual: 0b1111_1111)) == .unchanged)
+    }
+
+    @Test func fallsBackToTheImageWhenOCRIsUnavailableOrEmpty() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot(nil, image: "jpeg-a"))
+        #expect(detector.poll(snapshot(nil, image: "jpeg-a")) == .unchanged)
+        #expect(detector.poll(snapshot("   \n", image: "jpeg-b")) == .waitingForStability)
+        #expect(detector.poll(snapshot("   \n", image: "jpeg-b")) == .stableChange)
+    }
+
+    @Test func observingARealCaptureReplacesBaselineAndPendingCandidate() {
+        var detector = ScreenChangeDetector()
+        detector.observe(snapshot("old screen"))
+        #expect(detector.poll(snapshot("partially typed")) == .waitingForStability)
+
+        detector.observe(snapshot("coach saw this"))
+        #expect(detector.poll(snapshot("coach saw this")) == .unchanged)
+        #expect(detector.poll(snapshot("partially typed")) == .waitingForStability)
+
+        detector.reset()
+        #expect(detector.poll(snapshot("partially typed")) == .dormant)
+    }
+}

--- a/Tests/JarvisCoreTests/Screen/ScreenFrameActivityClassifierTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenFrameActivityClassifierTests.swift
@@ -1,0 +1,100 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ScreenFrameActivityClassifierTests {
+    @Test func fullSurfaceBrowserRedrawWithUnchangedPixelsIsIdle() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.01)
+        let staticPage = [UInt8](repeating: 180, count: 100)
+
+        #expect(classifier.observe(pixels: staticPage, dirtyAreaRatio: 1) == .idle)
+        #expect(classifier.observe(pixels: staticPage, dirtyAreaRatio: 1) == .idle)
+    }
+
+    @Test func visibleChangeWinsEvenWhenMetadataClaimsAFullRedraw() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.01)
+        let before = [UInt8](repeating: 220, count: 100)
+        var after = before
+        for index in 0..<10 { after[index] = 20 }
+
+        _ = classifier.observe(pixels: before, dirtyAreaRatio: 1)
+        #expect(classifier.observe(pixels: after, dirtyAreaRatio: 1)
+                == .changed(areaRatio: 0.1, evidence: .visualPixels))
+    }
+
+    @Test func boundedDirtyRegionPreservesTinyCodeEditsLostByDownsampling() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.001)
+        let pixels = [UInt8](repeating: 200, count: 100)
+
+        _ = classifier.observe(pixels: pixels, dirtyAreaRatio: nil)
+        #expect(classifier.observe(pixels: pixels, dirtyAreaRatio: 0.005)
+                == .changed(areaRatio: 0.005, evidence: .boundedDirtyRegion))
+    }
+
+    @Test func largeMetadataOnlyRedrawCannotBlockVisualQuiescence() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.001)
+        let pixels = [UInt8](repeating: 200, count: 100)
+
+        _ = classifier.observe(pixels: pixels, dirtyAreaRatio: nil)
+        #expect(classifier.observe(pixels: pixels, dirtyAreaRatio: 0.9) == .idle)
+    }
+
+    @Test func subThresholdPixelNoiseIsIdle() {
+        var classifier = ScreenFrameActivityClassifier(
+            minimumChangedAreaRatio: 0.01, minimumPixelDelta: 16)
+        let before = [UInt8](repeating: 100, count: 100)
+        var after = before
+        after[0] = 115
+
+        _ = classifier.observe(pixels: before, dirtyAreaRatio: nil)
+        #expect(classifier.observe(pixels: after, dirtyAreaRatio: nil) == .idle)
+    }
+
+    @Test func changedDimensionsAreAVisibleChange() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.01)
+        _ = classifier.observe(pixels: [10, 20, 30], dirtyAreaRatio: nil)
+
+        #expect(classifier.observe(pixels: [10, 20, 30, 40], dirtyAreaRatio: nil)
+                == .changed(areaRatio: 1, evidence: .visualPixels))
+    }
+
+    @Test func zeroThresholdDoesNotTurnIdenticalFramesIntoChanges() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0)
+        let pixels = [UInt8](repeating: 120, count: 10)
+
+        _ = classifier.observe(pixels: pixels, dirtyAreaRatio: 0)
+        #expect(classifier.observe(pixels: pixels, dirtyAreaRatio: 0) == .idle)
+    }
+
+    @Test func highConfiguredThresholdStillInitializes() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.5)
+        let pixels = [UInt8](repeating: 120, count: 10)
+
+        #expect(classifier.observe(pixels: pixels, dirtyAreaRatio: 1) == .idle)
+    }
+
+    @Test func visuallyStableCompleteFramesCanFinishQuiescence() {
+        var classifier = ScreenFrameActivityClassifier(minimumChangedAreaRatio: 0.01)
+        var detector = ScreenActivityDetector(
+            quiescenceInterval: 1, minimumChangedAreaRatio: 0.01)
+        let before = [UInt8](repeating: 220, count: 100)
+        var after = before
+        for index in 0..<10 { after[index] = 20 }
+
+        #expect(classifier.observe(pixels: before, dirtyAreaRatio: 1) == .idle)
+        let changed = classifier.observe(pixels: after, dirtyAreaRatio: 1)
+        guard case .changed(let ratio, _) = changed else {
+            Issue.record("Expected a visible change")
+            return
+        }
+        #expect(detector.observe(.contentChanged(changedAreaRatio: ratio), at: 1)
+                == .waitingForQuiescence)
+
+        #expect(classifier.observe(pixels: after, dirtyAreaRatio: 1) == .idle)
+        #expect(detector.observe(.idle, at: 1.5) == .waitingForQuiescence)
+        #expect(classifier.observe(pixels: after, dirtyAreaRatio: 1) == .idle)
+        guard case .stableChange = detector.observe(.idle, at: 2) else {
+            Issue.record("Stable redraws should complete the quiet window")
+            return
+        }
+    }
+}

--- a/Tests/JarvisCoreTests/Screen/ScreenRequestTimingTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenRequestTimingTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ScreenRequestTimingTests {
+    @Test func firstStableChangeWaitsOnlyForPiggyback() {
+        #expect(ScreenRequestTiming.fallbackDeadline(
+            candidateAt: 100,
+            lastVisualRequestAt: nil,
+            piggybackWait: 2,
+            minimumRequestInterval: 60
+        ) == 102)
+    }
+
+    @Test func repeatedChangesCannotCreateMoreThanOneScreenOnlyRequestPerInterval() {
+        #expect(ScreenRequestTiming.fallbackDeadline(
+            candidateAt: 110,
+            lastVisualRequestAt: 100,
+            piggybackWait: 2,
+            minimumRequestInterval: 60
+        ) == 160)
+    }
+
+    @Test func lateChangeStillGetsItsPiggybackWindow() {
+        #expect(ScreenRequestTiming.fallbackDeadline(
+            candidateAt: 170,
+            lastVisualRequestAt: 100,
+            piggybackWait: 2,
+            minimumRequestInterval: 60
+        ) == 172)
+    }
+}

--- a/Tests/JarvisCoreTests/Transcription/RealtimeTranscriptionLedgerTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeTranscriptionLedgerTests.swift
@@ -1,0 +1,189 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct RealtimeTranscriptionLedgerTests {
+    @Test func interleavedItemsKeepTheirOwnDeltasAndAudioStartTimes() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "first", audioStartMilliseconds: 1_250, timelineOrigin: 10)
+        ledger.recordSpeechStarted(itemID: "second", audioStartMilliseconds: 3_000, timelineOrigin: 10)
+        ledger.recordDelta(itemID: "first", delta: "first ")
+        ledger.recordDelta(itemID: "second", delta: "second")
+        ledger.recordDelta(itemID: "first", delta: "answer")
+
+        let second = try #require(ledger.recordCompleted(itemID: "second", transcript: "second final",
+                                                        speaker: .them))
+        let first = try #require(ledger.recordCompleted(itemID: "first", transcript: "first final",
+                                                       speaker: .them))
+        #expect(second.text == "second final")
+        #expect(second.spokenAt == 13)
+        #expect(second.spokenEndAt == nil)
+        #expect(first.text == "first final")
+        #expect(first.spokenAt == 11.25)
+    }
+
+    @Test func failedItemSalvagesAccumulatedDeltas() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "item", audioStartMilliseconds: 500, timelineOrigin: 4)
+        ledger.recordDelta(itemID: "item", delta: "What is ")
+        ledger.recordDelta(itemID: "item", delta: "a semaphore?")
+
+        let result = try #require(ledger.recordFailed(itemID: "item", speaker: .them))
+        #expect(result.text == "What is a semaphore?")
+        #expect(result.spokenAt == 4.5)
+        #expect(result.recoveredFromDeltas)
+        #expect(!result.isContextGap)
+    }
+
+    @Test func failedItemWithoutUsableTextEmitsExplicitContextGap() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "item", audioStartMilliseconds: 250, timelineOrigin: 7)
+        ledger.recordDelta(itemID: "item", delta: "...")
+
+        let result = try #require(ledger.recordFailed(itemID: "item", speaker: .them))
+        #expect(result.text == RealtimeTranscriptionLedger.contextGapMarker)
+        #expect(result.spokenAt == 7.25)
+        #expect(!result.recoveredFromDeltas)
+        #expect(result.isContextGap)
+    }
+
+    @Test func stoppedWithoutTerminalEventSalvagesDeltasAtDeadline() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "item", audioStartMilliseconds: 8_000, timelineOrigin: 1)
+        ledger.recordDelta(itemID: "item", delta: "partial question")
+        #expect(ledger.recordSpeechStopped(itemID: "item"))
+
+        let result = try #require(ledger.resolveStoppedItemTimeout(itemID: "item", speaker: .them))
+        #expect(result.text == "partial question")
+        #expect(result.spokenAt == 9)
+        #expect(result.recoveredFromDeltas)
+    }
+
+    @Test func stoppedTimeoutSuppressesShortOrUntimedEmptyVADBlips() throws {
+        let short = RealtimeTranscriptionLedger()
+        short.recordSpeechStarted(itemID: "short", audioStartMilliseconds: 1_000,
+                                  timelineOrigin: 0)
+        short.recordSpeechStopped(itemID: "short", audioEndMilliseconds: 1_200)
+        #expect(short.resolveStoppedItemTimeout(itemID: "short", speaker: .me) == nil)
+        #expect(!short.hasPendingItems)
+        #expect(short.recordCompleted(itemID: "short", transcript: "late", speaker: .me) == nil)
+
+        let untimed = RealtimeTranscriptionLedger()
+        untimed.recordSpeechStopped(itemID: "untimed")
+        #expect(untimed.resolveStoppedItemTimeout(itemID: "untimed", speaker: .them) == nil)
+        #expect(!untimed.hasPendingItems)
+
+        let speech = RealtimeTranscriptionLedger()
+        speech.recordSpeechStarted(itemID: "speech", audioStartMilliseconds: 1_000,
+                                   timelineOrigin: 0)
+        speech.recordSpeechStopped(itemID: "speech", audioEndMilliseconds: 1_750)
+        let gap = try #require(
+            speech.resolveStoppedItemTimeout(itemID: "speech", speaker: .them))
+        #expect(gap.isContextGap)
+    }
+
+    @Test func timeoutOnlyFinalizesStoppedItemsAndLateTerminalIsIgnored() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "item", audioStartMilliseconds: 0, timelineOrigin: 0)
+        ledger.recordDelta(itemID: "item", delta: "still speaking")
+        #expect(ledger.hasPendingItems)
+        #expect(ledger.resolveStoppedItemTimeout(itemID: "item", speaker: .me) == nil)
+
+        ledger.recordSpeechStopped(itemID: "item")
+        #expect(ledger.hasPendingItems)
+        let result = try #require(ledger.resolveStoppedItemTimeout(itemID: "item", speaker: .me))
+        #expect(result.text == "still speaking")
+        #expect(!ledger.hasPendingItems)
+        #expect(ledger.recordCompleted(itemID: "item", transcript: "still speaking, finalized",
+                                      speaker: .me) == nil)
+        #expect(ledger.recordFailed(itemID: "item", speaker: .me) == nil)
+    }
+
+    @Test func emptyCompletedTextUsesDeltasButNoiseCompletionStaysSilent() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordDelta(itemID: "partial", delta: "usable partial")
+        let partial = try #require(ledger.recordCompleted(itemID: "partial", transcript: "",
+                                                         speaker: .me))
+        #expect(partial.text == "usable partial")
+        #expect(partial.recoveredFromDeltas)
+
+        ledger.recordDelta(itemID: "noise", delta: ".")
+        #expect(ledger.recordCompleted(itemID: "noise", transcript: ".", speaker: .me) == nil)
+    }
+
+    @Test func longDetectedSpeechWithEmptyCompletionEmitsContextGap() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "question", audioStartMilliseconds: 2_000,
+                                   timelineOrigin: 10)
+        ledger.recordSpeechStopped(itemID: "question", audioEndMilliseconds: 4_500)
+
+        let result = try #require(ledger.recordCompleted(itemID: "question", transcript: "",
+                                                        speaker: .them))
+        #expect(result.text == RealtimeTranscriptionLedger.contextGapMarker)
+        #expect(result.spokenAt == 12)
+        #expect(result.isContextGap)
+
+        let shortNoise = RealtimeTranscriptionLedger()
+        shortNoise.recordSpeechStarted(itemID: "noise", audioStartMilliseconds: 1_000,
+                                       timelineOrigin: 0)
+        shortNoise.recordSpeechStopped(itemID: "noise", audioEndMilliseconds: 1_200)
+        #expect(shortNoise.recordCompleted(itemID: "noise", transcript: ".", speaker: .me) == nil)
+    }
+
+    @Test func activeTimeoutAndSocketFailureCannotLeavePendingSpeechBehind() throws {
+        let activeTimeout = RealtimeTranscriptionLedger()
+        activeTimeout.recordSpeechStarted(itemID: "active", audioStartMilliseconds: 5_000,
+                                          timelineOrigin: 10)
+        activeTimeout.recordDelta(itemID: "active", delta: "partial answer")
+        let timedOut = try #require(activeTimeout.resolveActiveItemTimeout(itemID: "active",
+                                                                          speaker: .me))
+        #expect(timedOut.text == "partial answer")
+        #expect(!activeTimeout.hasPendingItems)
+
+        let disconnected = RealtimeTranscriptionLedger()
+        disconnected.recordSpeechStarted(itemID: "first", audioStartMilliseconds: 2_000,
+                                          timelineOrigin: 0)
+        disconnected.recordDelta(itemID: "first", delta: "first partial")
+        disconnected.recordSpeechStarted(itemID: "second", audioStartMilliseconds: 3_000,
+                                          timelineOrigin: 0)
+        let recovered = disconnected.resolveAllInterruptedItems(speaker: .them)
+        #expect(recovered.map(\.itemID) == ["first", "second"])
+        #expect(recovered[0].text == "first partial")
+        #expect(recovered[1].isContextGap)
+        #expect(!disconnected.hasPendingItems)
+    }
+
+    @Test func replayDiscardBoundaryWaitsForOutOfOrderEarlierItem() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "first", audioStartMilliseconds: 1_000,
+                                   timelineOrigin: 10)
+        ledger.recordSpeechStopped(itemID: "first", audioEndMilliseconds: 3_000)
+        ledger.recordSpeechStarted(itemID: "second", audioStartMilliseconds: 4_000,
+                                   timelineOrigin: 10)
+        ledger.recordSpeechStopped(itemID: "second", audioEndMilliseconds: 6_000)
+
+        #expect(ledger.safeReplayDiscardTime == 11)
+        _ = try #require(ledger.recordCompleted(itemID: "second", transcript: "second",
+                                                speaker: .them))
+        #expect(ledger.safeReplayDiscardTime == 11) // first is still unresolved
+
+        let first = try #require(ledger.recordCompleted(itemID: "first", transcript: "first",
+                                                        speaker: .them))
+        #expect(first.spokenEndAt == 13)
+        #expect(ledger.safeReplayDiscardTime == 16) // advances through both terminal items
+    }
+
+    @Test func unknownPendingItemBlocksReplayDiscardAndClearResetsBoundary() throws {
+        let ledger = RealtimeTranscriptionLedger()
+        ledger.recordSpeechStarted(itemID: "known", audioStartMilliseconds: 1_000,
+                                   timelineOrigin: 5)
+        ledger.recordSpeechStopped(itemID: "known", audioEndMilliseconds: 2_000)
+        _ = try #require(ledger.recordCompleted(itemID: "known", transcript: "done", speaker: .me))
+        #expect(ledger.safeReplayDiscardTime == 7)
+
+        ledger.recordDelta(itemID: "unknown", delta: "partial")
+        #expect(ledger.safeReplayDiscardTime == nil)
+        ledger.clear()
+        #expect(ledger.safeReplayDiscardTime == nil)
+        #expect(ledger.pendingItemCount == 0)
+    }
+}

--- a/Tests/JarvisCoreTests/Transcription/RealtimeTranscriptionLedgerTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeTranscriptionLedgerTests.swift
@@ -37,6 +37,7 @@ import Testing
     @Test func failedItemWithoutUsableTextEmitsExplicitContextGap() throws {
         let ledger = RealtimeTranscriptionLedger()
         ledger.recordSpeechStarted(itemID: "item", audioStartMilliseconds: 250, timelineOrigin: 7)
+        ledger.recordSpeechStopped(itemID: "item", audioEndMilliseconds: 1_000)
         ledger.recordDelta(itemID: "item", delta: "...")
 
         let result = try #require(ledger.recordFailed(itemID: "item", speaker: .them))
@@ -44,6 +45,20 @@ import Testing
         #expect(result.spokenAt == 7.25)
         #expect(!result.recoveredFromDeltas)
         #expect(result.isContextGap)
+    }
+
+    @Test func failedShortOrUntimedEmptyVADBlipsStaySilent() {
+        let short = RealtimeTranscriptionLedger()
+        short.recordSpeechStarted(itemID: "short", audioStartMilliseconds: 1_000,
+                                  timelineOrigin: 0)
+        short.recordSpeechStopped(itemID: "short", audioEndMilliseconds: 1_200)
+        #expect(short.recordFailed(itemID: "short", speaker: .them) == nil)
+        #expect(!short.hasPendingItems)
+
+        let untimed = RealtimeTranscriptionLedger()
+        untimed.recordSpeechStopped(itemID: "untimed")
+        #expect(untimed.recordFailed(itemID: "untimed", speaker: .them) == nil)
+        #expect(!untimed.hasPendingItems)
     }
 
     @Test func stoppedWithoutTerminalEventSalvagesDeltasAtDeadline() throws {

--- a/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TriggerContextTests.swift
@@ -22,6 +22,13 @@ import Testing
         #expect(ctx.promptLine == "[01:00] (no speech for 45s)")
     }
 
+    @Test func screenChangedPromptExplainsAttachedFreshSnapshot() {
+        let ctx = TriggerContext(reason: .screenChanged, sessionElapsedSeconds: 75)
+        #expect(ctx.promptLine?.hasPrefix("[01:15]") == true)
+        #expect(ctx.promptLine?.contains("screen changed") == true)
+        #expect(ctx.promptLine?.contains("fresh point-in-time screenshot") == true)
+    }
+
     @Test func hourLongSilenceSpellsHoursAndMinutes() {
         let ctx = TriggerContext(reason: .silence(secondsQuiet: 12640), sessionElapsedSeconds: 13719)
         #expect(ctx.promptLine == "[228:39] (no speech for 3h 30m)")

--- a/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
@@ -36,6 +36,15 @@ import Testing
         }
     }
 
+    /// A terse interviewer rejection changes the requirements immediately. It must not wait for the
+    /// next long utterance, while the same one-word response from the user remains a back-channel.
+    @Test func interviewerRejectionIsImmediateSubstance() {
+        for text in ["No.", "nope"] {
+            #expect(TurnSubstance.isSubstantive(.init(speaker: .them, text: text, at: 1)))
+            #expect(!TurnSubstance.isSubstantive(.init(speaker: .me, text: text, at: 1)))
+        }
+    }
+
     /// Fail open: anything not provably filler reaches the brain — real sentences, and even unknown
     /// words that merely LOOK like filler ("melon" is not on any list).
     @Test func realSpeechFailsOpenToTheBrain() {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -61,10 +61,11 @@ moments the model judges worthwhile.
    cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's
    Start/Stop and the **substance gate** (`TurnSubstance`): a turn-end whose delta is pure
-   back-channel filler ("Hmm", "嗯" — from *either* speaker) or empty is skipped without a
-   request. The gate is speaker-neutral by design: an interviewer question is substance and may
-   draw a proactive tip for the user. Skipped lines ride along on the next substantive turn;
-   silence checks and the hint hotkey always go through.
+   back-channel filler ("Hmm", "嗯") or empty is skipped without a request. Classification is
+   speaker-aware only where conversational meaning demands it: a short interviewer rejection such
+   as "No" is substantive, even though the same user-side fragment is normally filler. Interviewer
+   questions remain first-class and may draw a proactive tip. Skipped lines ride along on the next
+   substantive turn; silence checks and the hint hotkey always go through.
 3. It calls **`gpt-5.5`** with the coach system prompt, the session memory (`CoachHistory`), the
    new transcript delta, the timing context (seconds silent, session elapsed), and the tool set
    `[capture_screen, speak, stay_silent]`. The timing is what lets the model tell "thinking" from
@@ -117,10 +118,10 @@ plugins ship only with full Xcode, and Jarvis builds **CLT-only** (see
 
 | Component | Responsibility | Built on (borrowed) |
 |---|---|---|
-| **AggregateEchoCapture** | The whole capture path: one **private Core Audio aggregate device** = the built-in mic (`me`, clock master) + a system-output **process tap** (`them`, drift-compensated onto the mic's clock). A single IOProc delivers both sample-synced at the device's **native rate** — the one-clock case AEC3 needs; the capture **reads that rate and resamples mic+tap up to 48 kHz** for AEC3 (a no-op when the device is already 48 kHz). So **any input device works** — built-in, USB, 44.1 kHz gear, or AirPods (Bluetooth HFP at 16/24 kHz) — instead of the old hard 48 kHz pin that silently failed to start on Bluetooth mics. Inside the callback it runs AEC3 (tap = far reference, mic = near), removing the other side's speaker bleed from the mic *before* transcription — no headphones, and double-talk works (measured 30–50 dB cancellation). Then downsamples to 24 kHz: cleaned mic → `me` socket, raw tap → `them` socket. Replaces the old separate `AVAudioEngine` mic + `SCStream`. | Core Audio (`AudioHardwareCreateProcessTap`, private aggregate device, drift compensation) + `AVAudioConverter` resampling + WebRTC **AEC3**. |
+| **AggregateEchoCapture** | The whole capture path: one **private Core Audio aggregate device** = the built-in mic (`me`, clock master) + a system-output **process tap** (`them`, drift-compensated onto the mic's clock). A single IOProc delivers both sample-synced at the device's **native rate** — the one-clock case AEC3 needs; the capture **reads that rate and resamples mic+tap up to 48 kHz** for AEC3 (a no-op when the device is already 48 kHz). So **any input device works** — built-in, USB, 44.1 kHz gear, or AirPods (Bluetooth HFP at 16/24 kHz) — instead of the old hard 48 kHz pin that silently failed to start on Bluetooth mics. Inside the callback it runs AEC3 (tap = far reference, mic = near), removing the other side's speaker bleed from the mic *before* transcription — no headphones, and double-talk works (measured 30–50 dB cancellation). The untouched resampled tap remains the `them` source while a separate padded/truncated copy aligns AEC; wire delivery is serialized off the realtime IOProc. Then both sides downsample to 24 kHz. Replaces the old separate `AVAudioEngine` mic + `SCStream`. | Core Audio (`AudioHardwareCreateProcessTap`, private aggregate device, drift compensation) + `AVAudioConverter` resampling + WebRTC **AEC3**. |
 | **WebRTCEchoCanceller** | AEC3 echo canceller driven at 48 kHz on 10 ms frames inside the capture IOProc; far reference first, then the mic cleaned in place. | WebRTC **AEC3** (`webrtc-audio-processing`), vendored static + zero-dylib via `scripts/build-aec.sh`. |
 | **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` (in Core) decides the response — `fatal` pops an `NSAlert` and tears the session down, `warning` alerts without touching a running session (preflight refusals), `degraded` is logged only — so no startup failure is ever silent. The only place an *error* `NSAlert` is raised (confirmation prompts aside); diagnostics stay in `JarvisLog`. | AppKit (`NSAlert`). |
-| **Transcriber** | Maintain a rolling, speaker-labeled, **timestamped** transcript; emit turn-end events and backing-off silence checks (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. A socket is ready only after the server acknowledges its configuration; active ping/pong probes, send/receive errors, and startup timeouts all drive the same reconnect path. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
+| **Transcriber** | Maintain a rolling, speaker-labeled, **spoken-time timestamped** transcript; emit turn-end events and backing-off silence checks (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. A per-`item_id` ledger reconciles out-of-order delta/completed/failed/VAD events, salvages streamed text, and emits an explicit context-gap marker when a detected utterance cannot be recovered. A privacy-preserving continuity witness records content-free capture/delivery/socket/server checkpoints and locally derived activity, so the session log can locate a future gap without retaining PCM. A socket is ready only after the server acknowledges its configuration; active ping/pong probes, send/receive errors, and startup timeouts all drive the same reconnect path. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
 | **CoachDriver** | The event loop. On every substantive trigger (plus every silence check and hint keypress), call the brain with the session memory + transcript delta + timing context and tools, route tool calls, and compact the memory when it grows long. No cooldown/rate cap — restraint is the model's; the only client-side skip is the filler-only turn-end gate (`TurnSubstance`). | `gpt-5.5` (vision + tool-use) with `gpt-5.4-mini` for memory summaries — or a local Claude Code / Codex CLI on the user's subscription (see [§4 Local CLI brain providers](#local-cli-brain-providers)). |
 | **ScreenTool** | Fulfill `capture_screen`: silently shoot the **active window** (default scope) — the window-server frontmost, on whichever display, clean even when partially covered — and attach an **on-device OCR** of the shot to the tool result so the model reads exact text instead of pixels. Falls back to a full-display capture (no OCR) — the Settings-chosen display in Entire-display scope, the main display when no window is eligible; the overlay window is excluded either way. See [settings-window.md](./settings-window.md#capture-scope). | macOS `screencapture` CLI + Apple Vision (`VNRecognizeTextRequest`). |
 | **Overlay Caption** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. Switchable from Settings — **off by default**; when off, tips are suppressed. | AppKit NSPanel; `OverlayCaptionPanel`. |
@@ -260,6 +261,11 @@ streamed (one buffered request; the overlay just paces the display).
 
 ### Resilience
 
+The capture edge keeps two system-audio representations for different contracts: transcription
+preserves every real tap sample and pads only a short/empty callback's missing silence so Realtime
+VAD keeps advancing; AEC receives a separate exact mic-length padded/truncated reference. Neither
+path disables AEC or changes the configured Realtime noise-reduction profile.
+
 The always-on legs are built to survive transient failure rather than die on it:
 
 - **The realtime transcription socket *will* drop** (network blips, server resets, the ~60-min
@@ -270,9 +276,25 @@ The always-on legs are built to survive transient failure rather than die on it:
   startup-timeout, and liveness failures all enter one idempotent reconnect path. Each replacement
   socket has a generation so stale callbacks cannot damage the new one, and diagnostics label the
   `me`/`them` side, socket generation, server session, and current macOS network-path summary. While
-  reconnecting, audio is **buffered** (`PCMBuffer`, capped at `maxBufferedAudioSeconds`, oldest
-  evicted) and **flushed into the new session** — a mid-sentence drop no longer loses the user's
-  words. Reconnect uses capped exponential backoff.
+  reconnecting, audio remains in one **transactional FIFO plus recovery tail** (`PCMBuffer`, capped at
+  `maxBufferedAudioSeconds`). Exactly one oldest chunk is claimed at a time. A successful URLSession
+  callback moves it into the in-memory tail rather than deleting it, because Realtime intentionally
+  sends no confirmation for `input_audio_buffer.append`; only server VAD/transcription audio-clock
+  progress retires a safe prefix. On failure, the unconfirmed tail is requeued ahead of audio captured
+  during reconnect backoff. This closes the ready-transition, asynchronous-send, and idle half-open
+  loss edges; deliberate cap eviction is logged and carried as an explicit context warning. Within a
+  healthy socket, streamed transcript deltas survive a failed or missing terminal event; an
+  unrecoverable detected utterance becomes an explicit context-gap line instead of disappearing.
+  Sequence, sample, timestamp, and socket-generation checkpoints cover the capture, delivery,
+  WebSocket attempt/completion, and server-event boundaries. Periodic content-free summaries and
+  typed anomalies show which boundary stopped advancing; sustained local activity without a server
+  speech event leaves an explicit warning for the next real coach turn. This evidence diagnoses loss
+  but cannot reconstruct words that never reached transcription. VAD-only start/stop events do not
+  restart silence checks without contributing context. Pending items are finalized by bounded
+  stopped/active deadlines. On a recoverable socket failure, their old server IDs are cleared and
+  their retained PCM is transcribed by the replacement session instead of first emitting a partial
+  or gap that the replay would duplicate. Stale speech state therefore cannot suppress silence
+  coaching after reconnect. Reconnect uses capped exponential backoff.
 - **The brain call** is single-flighted (a turn can't double-speak) and runs under a generous request
   timeout — a hang backstop set well above the reasoning-turn tail, so a slow turn is waited out, not
   abandoned. Because client-owned memory makes every request self-contained and tool effects happen
@@ -297,7 +319,9 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 - **Built and run in the main `forrest` account inside a git worktree** (recoverability). The
   separate-restricted-account requirement is waived for the personal build; see [sandbox.md](./sandbox.md).
 - **Egress is narrow and explicit:** audio to `gpt-4o-transcribe`; a screenshot + transcript window
-  to `gpt-5.5` *only when the model triggers a capture/response*. The only screen-/audio-derived data
+  to `gpt-5.5` *only when the model triggers a capture/response*. The audio witness persists only
+  counters, sequence/sample metadata, timestamps, socket generations, server audio-clock values, and
+  a local activity bit in the owner-only session log — never PCM or recovered words. The only screen-/audio-derived data
   written to **local** disk is the owner-only, bounded per-session **activity log** (spoken tips,
   transcribed lines, the screenshots the model saw); raw mic audio and the live transcript are never
   archived. Requests are sent `store:true`, so what the model saw does remain inspectable (and

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -6,7 +6,7 @@
 
 > **Scope:** This page describes the **native Swift app** — the thing being built. The earlier
 > two-phase plan (a Natively fork PoC first) was **dropped on 2026-06-14**; we build this directly,
-> including the model-triggered `capture_screen` tool-loop. See [decisions.md](./decisions.md).
+> including the hybrid screen-context loop. See [decisions.md](./decisions.md).
 > Exact schemas, the coach prompt, and config are **not duplicated here** — they live in code
 > (`Sources/JarvisCore/`, esp. `ToolDefs.swift`, `Config.swift`, `CoachDriver.swift`); this page is
 > the *why*, the code is the *what*.
@@ -42,36 +42,50 @@ glue that wires them into a proactive coach. We write the least code possible an
 ```
 
 Always-on and cheap: audio streams continuously to the Realtime API, producing a rolling,
-speaker-labeled transcript. The transcript — not the screen — is the constant input signal.
+speaker-labeled transcript. The transcript — not the screen — is the constant remote input signal.
 
-On demand and expensive: the screen is **only** captured when the model asks for it via the
-`capture_screen` tool, and a coaching response is **only** produced when the model calls `speak`.
-This is what keeps Jarvis cheap and fast — the costly vision and generation steps fire only at
-moments the model judges worthwhile.
+Screen context is hybrid and still bounded. On ordinary speech, the model applies a general
+freshness rule and can call `capture_screen` whenever the meaning of the conversation suggests a
+question, prompt, code, or solution may have appeared or changed; there is no phrase list. The
+harness pre-captures on silence/manual-hint checks and after a locally detected stable screen
+change. Low-rate, low-resolution one-shot ScreenCaptureKit screenshots compare visible pixels
+locally without opening a persistent screen-sharing session. After visible content settles, one full
+capture plus on-device OCR verifies that it actually changed. The snapshot first waits to join the
+next speech request at no extra request cost; a tightly rate-limited screen-only request is the
+fallback. Silent monitor turns that produce no tip are not retained in conversation memory. The exact
+accepted snapshot becomes the auditable coaching image; intermediate frames are neither sent nor
+retained. A coaching response is still produced only when the model calls `speak`.
 
 ### The turn
 
 1. The Transcriber emits a **turn-end** event (`gpt-4o-transcribe` server VAD ends the turn after a
-   tuned silence window) or a **silence check** fires (you've gone quiet, maybe stuck). The silence
+   tuned silence window), a **silence check** fires (you've gone quiet, maybe stuck), or the local
+   screen monitor reports a stable visual change. The silence
    check carries *how long* you've been quiet and backs off across a long silence (the interval
    doubles each step up to a cap — see `Config`), resetting on speech; past an idle cutoff it stops
    probing entirely (you've stepped away — a nudge into an empty room still bills a request) until
    speech re-arms it.
-2. The CoachDriver calls the brain on every trigger that carries **substance** — there is no
-   cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
+2. The CoachDriver calls the brain on every trigger that carries **substance** — there is no general
+   audio-turn cooldown, rate cap, or wake-word gate (the screen-only monitor fallback is bounded
+   before it reaches the driver). Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's
    Start/Stop and the **substance gate** (`TurnSubstance`): a turn-end whose delta is pure
    back-channel filler ("Hmm", "嗯") or empty is skipped without a request. Classification is
    speaker-aware only where conversational meaning demands it: a short interviewer rejection such
    as "No" is substantive, even though the same user-side fragment is normally filler. Interviewer
    questions remain first-class and may draw a proactive tip. Skipped lines ride along on the next
-   substantive turn; silence checks and the hint hotkey always go through.
+   substantive turn; silence checks, visual changes, and the hint hotkey always go through.
 3. It calls **`gpt-5.5`** with the coach system prompt, the session memory (`CoachHistory`), the
    new transcript delta, the timing context (seconds silent, session elapsed), and the tool set
    `[capture_screen, speak, stay_silent]`. The timing is what lets the model tell "thinking" from
    "stuck."
-4. The model may call `capture_screen`. The harness fulfills it (a silent screenshot) and
-   returns the image into the request. The model may now reason over what's on screen.
+4. Silence, manual hints, and stable local screen changes arrive with a harness-captured image plus
+   OCR. A stable monitor snapshot piggybacks on the next speech request when possible; only the
+   fallback creates a screen-only request, under the monitor's cost interval. On ordinary speech,
+   the model decides from the meaning of the turn whether it needs to call `capture_screen`; a
+   screenshot from conversation history is explicitly not evidence of current state. Every
+   successful capture resets the local monitor's baseline. If an early capture is still blank, the
+   monitor supplies a new turn after the subsequently updated screen becomes stable.
 5. The model calls `speak(lines)` — a tip of up to ~3 short lines, returned **already split**
    into an array (Structured Outputs / `strict:true`), so the client never splits prose on
    punctuation — or `stay_silent`. A tool call is **required** on every turn: silence is an
@@ -97,11 +111,11 @@ path still works for testing/practice; it is simply not latency-critical there.)
 
 Proactive coaching is the default, but the user can also **pull** a hint on demand. Pressing the
 global hotkey **⌥⌘J** while a session is running fires a `manualHint` trigger that does in **one**
-brain round-trip what the proactive screen path needs two for: the harness captures the screenshot
+brain round-trip what a model-requested screen path needs two for: the harness captures the screenshot
 *itself* and injects it — plus a synthetic "give me a hint now" user message — into the *first*
-request, and forces the `speak` tool, so a screen-aware hint always comes straight back. (The
-proactive path, by contrast, must first let the model decide to call `capture_screen`, then reason
-over the returned image on a second trip — the latency this hotkey exists to skip.) It reuses the
+request, and forces the `speak` tool, so a screen-aware hint always comes straight back. Other
+deterministic visual triggers also pre-capture, but do not force speech; ordinary audio turns may
+still let the model call `capture_screen` and reason over the result on a second trip. It reuses the
 live session's brain, conversation, and transcript, so the hint has full context, and it routes
 through the same single-in-flight turn box as audio triggers (a press coalesces, never stacks). It is
 inert — a beep — when no session is running, since there is no live conversation to hint from. The
@@ -122,8 +136,9 @@ plugins ship only with full Xcode, and Jarvis builds **CLT-only** (see
 | **WebRTCEchoCanceller** | AEC3 echo canceller driven at 48 kHz on 10 ms frames inside the capture IOProc; far reference first, then the mic cleaned in place. | WebRTC **AEC3** (`webrtc-audio-processing`), vendored static + zero-dylib via `scripts/build-aec.sh`. |
 | **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` (in Core) decides the response — `fatal` pops an `NSAlert` and tears the session down, `warning` alerts without touching a running session (preflight refusals), `degraded` is logged only — so no startup failure is ever silent. The only place an *error* `NSAlert` is raised (confirmation prompts aside); diagnostics stay in `JarvisLog`. | AppKit (`NSAlert`). |
 | **Transcriber** | Maintain a rolling, speaker-labeled, **spoken-time timestamped** transcript; emit turn-end events and backing-off silence checks (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. A per-`item_id` ledger reconciles out-of-order delta/completed/failed/VAD events, salvages streamed text, and emits an explicit context-gap marker when a detected utterance cannot be recovered. A privacy-preserving continuity witness records content-free capture/delivery/socket/server checkpoints and locally derived activity, so the session log can locate a future gap without retaining PCM. A socket is ready only after the server acknowledges its configuration; active ping/pong probes, send/receive errors, and startup timeouts all drive the same reconnect path. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
-| **CoachDriver** | The event loop. On every substantive trigger (plus every silence check and hint keypress), call the brain with the session memory + transcript delta + timing context and tools, route tool calls, and compact the memory when it grows long. No cooldown/rate cap — restraint is the model's; the only client-side skip is the filler-only turn-end gate (`TurnSubstance`). | `gpt-5.5` (vision + tool-use) with `gpt-5.4-mini` for memory summaries — or a local Claude Code / Codex CLI on the user's subscription (see [§4 Local CLI brain providers](#local-cli-brain-providers)). |
+| **CoachDriver** | The event loop. On every substantive trigger (plus every silence check, stable visual change, and hint keypress), call the brain with the session memory + transcript delta + timing context and tools, route tool calls, and compact the memory when it grows long. It attaches harness-provided snapshots for silence/manual/change triggers and otherwise leaves capture judgment to the model. No cooldown/rate cap — restraint is the model's; the only client-side skip is the filler-only turn-end gate (`TurnSubstance`). | `gpt-5.5` (vision + tool-use) with `gpt-5.4-mini` for memory summaries — or a local Claude Code / Codex CLI on the user's subscription (see [§4 Local CLI brain providers](#local-cli-brain-providers)). |
 | **ScreenTool** | Fulfill `capture_screen`: silently shoot the **active window** (default scope) — the window-server frontmost, on whichever display, clean even when partially covered — and attach an **on-device OCR** of the shot to the tool result so the model reads exact text instead of pixels. Falls back to a full-display capture (no OCR) — the Settings-chosen display in Entire-display scope, the main display when no window is eligible; the overlay window is excluded either way. See [settings-window.md](./settings-window.md#capture-scope). | macOS `screencapture` CLI + Apple Vision (`VNRecognizeTextRequest`). |
+| **ScreenChangeMonitor** | From session start, take low-rate one-shot ScreenCaptureKit screenshots at a bounded resolution, avoiding a persistent macOS sharing session. `ScreenFrameActivityClassifier` compares one grayscale byte per pixel with the prior poll; visible changes feed `ScreenActivityDetector`, and unchanged polls advance quiescence. Only then does `InMemoryScreenCapture` take one full capture and use a content-free OCR/image fingerprint to suppress duplicates. The stable snapshot waits briefly to piggyback on speech, then falls back to a screen-only request under a strict minimum interval. Intermediate pixels remain memory-only; the accepted snapshot enters `CoachDriver`, and failed delivery re-arms it. | `SCScreenshotManager` + Foundation-only frame/activity/content state machines. |
 | **Overlay Caption** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. Switchable from Settings — **off by default**; when off, tips are suppressed. | AppKit NSPanel; `OverlayCaptionPanel`. |
 | **Overlay Box** | A persistent window logging every `speak` tip in full, timestamped — the scrollable history of what the caption flashed one line at a time. Movable, resizable, opaque, also excluded from capture; switched on/off from Settings (**on by default**), cleared on each Start. Fed by the same `speak` call as the caption via **`BroadcastOverlay`**, which fans one `OverlayRendering.render` out to both sinks (so `CoachDriver` is unchanged). | AppKit NSPanel; `OverlayBoxPanel`. |
 | **MenuBar** | Manual **Start/Stop** of the pipeline (no auto-start), an explicit connection state (starting, listening, reconnecting, system-audio connecting, microphone-only, or stopped), and one-time API-key entry. It turns green only when the microphone transcription socket is configured and ready. The two overlay surfaces are switched from Settings, not the menu. | AppKit menu-bar item; owner-only file for the key. |
@@ -173,13 +188,19 @@ lifecycle consequence.
 - **Continuous (cheap):** audio → Realtime → transcript. This runs the whole session.
 - **Per-turn (cheap):** a `gpt-5.5` call on each substantive turn-end and each silence event, with a
   bounded, mostly-cached working set. Filler-only turn-ends (from either speaker) are skipped
-  client-side — free. No image unless the model asks.
-- **On-demand (expensive):** a screenshot + vision tokens, only when the model calls
-  `capture_screen`. A coaching response, only when the model calls `speak`.
+  client-side — free. No per-turn screenshot default.
+- **Local visual watch (bounded):** low-resolution one-shot ScreenCaptureKit captures compare visible
+  pixels locally without an ongoing sharing session. A full capture and OCR happen only after
+  quiescence; unchanged content is suppressed, and intermediate poll pixels are never sent, encoded,
+  OCR'd, or persisted (only the immediately previous grayscale frame is held).
+- **On-demand (expensive):** a screenshot + vision tokens when the model calls `capture_screen`, or
+  when a silence/manual hint or stable local screen change requires current visual context. Stable
+  changes first piggyback on a speech call; a screen-only fallback is rate-limited. A coaching
+  response is still produced only when the model calls `speak`.
 
-The model is the cost governor: it spends vision tokens and screen real estate only when it
-judges them worthwhile. That is the whole point of making screen capture a model-invoked tool
-rather than a per-turn screenshot.
+The model remains the response governor, while the harness guarantees freshness at the few points
+where stale or missing visual context would make that judgment unreliable. This avoids both a
+per-turn screenshot tax and the failure mode where a screen-blind model elects not to look.
 
 ### Models and APIs
 
@@ -202,8 +223,11 @@ rather than a per-turn screenshot.
   debugging — the retention tradeoff is documented in [sandbox.md](./sandbox.md).
 - **Transcription — `gpt-4o-transcribe` over the GA Realtime API** with **tuned `server_vad`** (not
   `semantic_vad`, which is reported flaky in transcription-only mode — it can stop emitting
-  `…transcription.completed` entirely). Turn-end fires on `…transcription.completed`, plus a
-  client-side debounce so a brief mid-thought pause doesn't fragment one sentence into several turns.
+  `…transcription.completed` entirely). Realtime events are reconciled by `item_id`: deltas are
+  retained until completed/failed, audio-start timestamps preserve spoken order, and a stopped item
+  without a terminal event is salvaged or marked as a context gap after a bounded deadline. Turn-end
+  fires only after usable text or that explicit gap lands, plus a client-side debounce so a brief
+  mid-thought pause doesn't fragment one sentence into several turns.
 
 ### Local CLI brain providers
 
@@ -266,6 +290,18 @@ preserves every real tap sample and pads only a short/empty callback's missing s
 VAD keeps advancing; AEC receives a separate exact mic-length padded/truncated reference. Neither
 path disables AEC or changes the configured Realtime noise-reduction profile.
 
+Stable-screen duplicate suppression likewise combines two local, content-free signals: normalized
+OCR and a tolerant 64-bit perceptual image hash. This keeps diagrams, highlighting, and OCR-missed
+edits visible without reacting to small JPEG/pixel drift. The one full snapshot bound to a request is
+persisted before network send for audit, but its monitor baseline advances only after success; a
+newer candidate that settled behind an older in-flight request is resumed rather than discarded.
+Monotonic capture ordering prevents an ordinary screenshot from clearing activity observed after
+that screenshot began, and switching the watched window/display forces a full-stage reconciliation.
+At the cheaper first stage, the downscaled pixels must visibly differ; identical one-shot polls
+advance quiescence regardless of how often an app redraws internally. Content-free witness counters
+separate changed polls, idle polls, failed polls, full captures, duplicates, piggybacks, and
+screen-only requests.
+
 The always-on legs are built to survive transient failure rather than die on it:
 
 - **The realtime transcription socket *will* drop** (network blips, server resets, the ~60-min
@@ -283,18 +319,20 @@ The always-on legs are built to survive transient failure rather than die on it:
   progress retires a safe prefix. On failure, the unconfirmed tail is requeued ahead of audio captured
   during reconnect backoff. This closes the ready-transition, asynchronous-send, and idle half-open
   loss edges; deliberate cap eviction is logged and carried as an explicit context warning. Within a
-  healthy socket, streamed transcript deltas survive a failed or missing terminal event; an
-  unrecoverable detected utterance becomes an explicit context-gap line instead of disappearing.
-  Sequence, sample, timestamp, and socket-generation checkpoints cover the capture, delivery,
-  WebSocket attempt/completion, and server-event boundaries. Periodic content-free summaries and
-  typed anomalies show which boundary stopped advancing; sustained local activity without a server
-  speech event leaves an explicit warning for the next real coach turn. This evidence diagnoses loss
-  but cannot reconstruct words that never reached transcription. VAD-only start/stop events do not
-  restart silence checks without contributing context. Pending items are finalized by bounded
-  stopped/active deadlines. On a recoverable socket failure, their old server IDs are cleared and
-  their retained PCM is transcribed by the replacement session instead of first emitting a partial
-  or gap that the replay would duplicate. Stale speech state therefore cannot suppress silence
-  coaching after reconnect. Reconnect uses capped exponential backoff.
+  healthy socket, streamed transcript deltas survive
+  a failed/missing terminal event;
+  an unrecoverable detected utterance becomes an explicit context-gap line instead of disappearing.
+  Sequence/sample/timestamp checkpoints cover the capture, delivery, WebSocket attempt/completion,
+  and server-event boundaries. Periodic content-free summaries and typed anomalies show which
+  boundary stopped advancing; sustained local activity without a server speech event leaves an
+  explicit warning for the next real coach turn. This evidence diagnoses loss but cannot reconstruct
+  words that never reached transcription.
+  VAD-only start/stop events do not restart silence checks without contributing context. Pending
+  items are finalized by bounded stopped/active deadlines. On a recoverable socket failure, their old
+  server IDs are cleared and their retained PCM is transcribed by the replacement session instead of
+  first emitting a partial/gap that the replay would duplicate; terminal reconnect failure still
+  finalizes what text is available. Stale speech state therefore cannot suppress silence coaching
+  after reconnect. Reconnect uses capped exponential backoff.
 - **The brain call** is single-flighted (a turn can't double-speak) and runs under a generous request
   timeout — a hang backstop set well above the reasoning-turn tail, so a slow turn is waited out, not
   abandoned. Because client-owned memory makes every request self-contained and tool effects happen
@@ -319,14 +357,18 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 - **Built and run in the main `forrest` account inside a git worktree** (recoverability). The
   separate-restricted-account requirement is waived for the personal build; see [sandbox.md](./sandbox.md).
 - **Egress is narrow and explicit:** audio to `gpt-4o-transcribe`; a screenshot + transcript window
-  to `gpt-5.5` *only when the model triggers a capture/response*. The audio witness persists only
-  counters, sequence/sample metadata, timestamps, socket generations, server audio-clock values, and
-  a local activity bit in the owner-only session log — never PCM or recovered words. The only screen-/audio-derived data
+  to `gpt-5.5` only on a model-requested or harness-provided fresh-screen coaching turn. Local change
+  frames are neither sent nor persisted. The audio witness persists only counters, sequence/sample
+  metadata, timestamps, socket generations, server audio-clock values, and a local activity bit in
+  the owner-only session log — never PCM or recovered words. The only screen-/audio-derived data
   written to **local** disk is the owner-only, bounded per-session **activity log** (spoken tips,
   transcribed lines, the screenshots the model saw); raw mic audio and the live transcript are never
   archived. Requests are sent `store:true`, so what the model saw does remain inspectable (and
   retained) server-side at OpenAI for debugging (see [sandbox.md](./sandbox.md)).
-- **Behavioral restraint (model-governed):** there is **no cooldown or rate cap** in code. Every
+- **Behavioral restraint (model-governed):** there is no general audio-turn cooldown or rate cap in
+  code; the stable-screen fallback alone has a strict cost interval because it can create a request
+  without speech. Pending screen context still joins the next speech request for free, and a silent
+  monitor turn that produces no tip does not enlarge later prompts. Every
   substantive utterance — from either speaker; only back-channel filler is skipped as pure cost —
   reaches the brain, and the brain decides whether it has anything worth
   saying — that restraint lives in the system prompt (see [`coachSystemPrompt`](../Sources/JarvisCore/Coach/ToolDefs.swift)).
@@ -339,19 +381,22 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 ## 6. Non-Goals (v1)
 
 - Multiple modes / a tiered sensitivity dial. (One mode: LeetCode Coach.)
-- Continuous OCR or recording the screen/audio to disk ("recall").
+- Recording the screen/audio to disk for recall. Stable-change monitoring is in-memory during an active
+  coaching session and persists only the stable screenshots the brain actually sees.
 - A dedicated wake-word engine. Direct address is just the word "Jarvis" (or a question) appearing
   in the transcript, which the brain reads and answers — there is no wake-word detector. (A global
   **⌥⌘J** hotkey for an on-demand screen hint *does* exist — see [§2](#on-demand-hint-j) — but it
   complements the proactive default; it is not a trigger-to-listen wake key.)
-- Productization: auth, billing, onboarding, multi-provider.
+- Productization: auth, billing, onboarding.
 - Windows / cross-platform.
 
 ## 7. Design Principles
 
 1. **Build the harness, not the intelligence.** If a model or an OS framework can do it, we don't write it.
 2. **Least code wins.** Prefer a borrowed tool (`screencapture`, an Apple framework, an OpenAI API) over custom code, every time.
-3. **The model is the cost governor.** Expensive actions (vision, speaking) happen only when the model opts in.
+3. **The model is the response governor.** Speaking always requires a model tool call; vision is
+   model-requested on ordinary speech and harness-provided for silence/manual hints and stable local
+   changes, never a screenshot on every turn.
 4. **Proactive, but disciplined.** Speaking up unprompted is the whole point; the model's own restraint (a tuned system prompt) keeps it from being annoying.
 5. **Sees the screen, not the disk.** Security is enforced by the sandbox, not by good intentions.
 6. **Self-verifying.** Every build ships with tests and a smoke checklist the agent can run to prove it works.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -314,3 +314,77 @@
 - **Why:** For a subscription holder, per-turn API billing is the product's dominant marginal cost; the CLIs expose the same frontier models under flat-rate plans the user already pays for. The `BrainClient` seam meant the driver, client-managed memory, retry, and traffic audit all carry over unchanged; detection-by-file-probe keeps the Settings tab instant and side-effect-free.
 - **Rejected:** (a) Wiring the CLIs' MCP interfaces for native tool calling — a protocol server + handshake per turn for three tools; the JSON-line protocol does the same job with a parser that tolerates prose/fences and degrades a forced `speak` to speaking the raw reply. (b) Auth verification by running the CLI at detection time — slow, may bill a request, and a Keychain prompt from `security` would be worse; the marker heuristic is a UI hint, with failures surfacing loudly at Start. (c) Replacing transcription too — the CLIs have no realtime audio surface; the OpenAI key remains the ears.
 - **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers), [settings-window.md → Brain](./settings-window.md#brain); egress note in [sandbox.md](./sandbox.md#data-egress).
+
+### 2026-07-16 — Realtime transcript integrity is tracked per audio item
+
+- **Chose:** Reconcile Realtime transcription by `item_id` instead of treating only
+  `…transcription.completed` as meaningful. `RealtimeTranscriptionLedger` records VAD start time and
+  streamed deltas, accepts out-of-order completion/failure, salvages delta text on failure or a
+  missing-terminal deadline, and emits an explicit context-gap line when failed, timed-out, or
+  long VAD-confirmed speech cannot be recovered from an empty completion. Transcript timestamps use
+  `audio_start_ms`, so inference completion order cannot reorder speakers. Bare `speech_stopped` no
+  longer resets the silence clock. Every real system-output sample is preserved for transcription;
+  a short/empty callback is padded only with its missing silence so the Realtime audio clock and
+  trailing-silence VAD keep advancing, while a separate exact-length padded/truncated copy feeds AEC.
+  Noise-reduction policy stays at its configured setting for both streams; source-specific tuning
+  requires representative live evaluation rather than assuming digital loopback is noise-free.
+  VAD-only starts/stops cannot restart the silence interval: a due check waits locally for the pending
+  item, while socket failure or a long active-item deadline resolves it so stale speech state cannot
+  suppress coaching forever.
+- **Why:** In the 2026-07-16 interview session, the user's long answer about an AI project reached the
+  mic transcript but the interviewer's question never appeared in either the activity log or the
+  exact brain traffic. The gap was upstream of `CoachDriver`; the old client ignored documented delta
+  and failed events, silently discarded unusable completion text, and mutated the system tap to the
+  mic buffer length before sending it. A sentence must either arrive or leave a visible integrity
+  failure — never disappear invisibly.
+- **Rejected:** (a) Logging only the failure event — observable but still deprives the coach of
+  streamed text. (b) Treating every VAD stop as a turn — it supplies no language context and, in the
+  old timer path, allowed noise/typing to postpone a silence check indefinitely. (c) Switching
+  transcription models as a first response — it changes the commit/VAD contract without fixing the
+  client's dropped event paths.
+- **Detail:** `Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift`,
+  `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`, `AggregateEchoCapture.swift`.
+
+### 2026-07-16 — Short interviewer rejection is substantive
+
+- **Chose:** Keep the closed-class filler gate, but classify exact interviewer-side “No”/“Nope” as
+  substantive. The same user-side fragments remain filler unless other substance rules apply.
+- **Why:** The interview log showed an interviewer “No.” correction skipped as filler and delivered
+  only with a later turn. Speaker identity changes the meaning here: an interviewer rejection is
+  actionable feedback, not a back-channel.
+- **Rejected:** Removing the filler gate — would restore the large steady-state cost from acknowledgments.
+- **Detail:** `Sources/JarvisCore/Triggers/TurnSubstance.swift`.
+
+### 2026-07-17 — Audio continuity evidence is content-free, not a recording
+
+- **Chose:** Add a per-side continuity witness across capture, delivery, WebSocket
+  attempt/completion, and Realtime server-speech boundaries. It retains sequence/sample counters,
+  timestamps, socket generations, server audio-clock values, and a locally derived activity bit;
+  periodic summaries and typed anomalies go only to the owner-only session log. Realtime item deltas
+  remain the only recoverable words. Sustained local activity without a server speech event adds an
+  explicit warning to the rolling transcript for the next real coach turn, without inventing text or
+  creating its own coach request. Capture timestamps are assigned in the IOProc, while witness locking
+  and PCM activity inspection run on the existing delivery queue so AEC timing is not disturbed.
+  Every delivered PCM chunk enters one byte-capped transactional FIFO plus an in-memory recovery
+  tail. One typed claim is sent at a time. URLSession completion moves it to that tail but cannot
+  retire it: the Realtime contract explicitly provides no confirmation event for
+  `input_audio_buffer.append`. Server VAD/transcription audio-clock progress advances only the prefix
+  behind the earliest unresolved item, including out-of-order completions. Socket failure requeues
+  the remaining tail before never-sent audio, then the replacement session transcribes interrupted
+  items from PCM instead of duplicating a partial old-session finalization. Thus the ready transition,
+  an asynchronous send error, and a half-open socket cannot silently strand a chunk. An overflow of
+  the deliberate cap is itself a typed anomaly and an explicit context warning.
+- **Why:** The prior session cannot retrospectively reveal whether the missing question disappeared
+  before capture, between capture and delivery, at the socket, or inside transcription. Boundary
+  evidence makes the next failure locatable while preserving the rule that raw audio is never
+  archived. Live reconnect validation then exposed the remaining boundary: macOS accepted offline
+  append messages locally for twelve seconds before ping detected the dead socket, so the old FIFO
+  deleted the exact missing phrases and replayed only later silence. The witness isolated that stage;
+  the bounded recovery tail now retains and retranscribes those words after reconnect.
+- **Rejected:** (a) Persist raw PCM — it would reveal the words but reverses the project's privacy
+  posture. (b) Send every stream to a second transcription provider — doubles audio egress and cost.
+  (c) Hash audio chunks as proof — a content hash does not reveal what was said or which downstream
+  stage failed, while increasing fingerprinting risk.
+- **Detail:** `Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift`,
+  `Sources/JarvisCore/Audio/AdaptiveAudioActivityDetector.swift`,
+  `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -40,6 +40,8 @@
 - **Why:** Cheaper and smarter than capturing on every turn.
 - **Rejected:** Always-on screen capture.
 - **Detail:** [architecture.md §2](./architecture.md#2-core-loop).
+- **Superseded by:** The hybrid freshness policy of 2026-07-16. Model-requested capture remains,
+  while stable local changes no longer depend on a screen-blind model choosing to look.
 
 ### 2026-06-13 — Coach is time-aware
 
@@ -308,6 +310,7 @@
 - **Why:** OpenAI's function-calling and reasoning guides require reasoning items to accompany a client-fulfilled tool call's output; dropping them (our old behavior, and a known ecosystem anti-pattern — the Agents SDK, Vercel AI SDK, and LangChain all round-trip them) discards the chain of thought mid-turn, so the model re-reasons over the screenshot from scratch: worse answers, more reasoning tokens, and OpenAI's own cookbook measured a 40%→80% cache-utilization gain from replaying them.
 - **Rejected:** (a) `previous_response_id` server threading — reintroduces the server-side conversation the 2026-07-07 decision removed. (b) `store:false` + `include: reasoning.encrypted_content` — the fully stateless variant; deferred with the existing `store:true` debuggability choice, and it's the same replay path when flipped. (c) Keeping reasoning items across turns — OpenAI ignores stale ones, they'd bloat every later request, and a mid-session brain-model switch invalidates them. (d) A generic SDK/agent-framework dependency to manage the loop — none exists for Swift, and owning the message list is where the harness's cost machinery lives.
 - **Detail:** `Sources/JarvisCore/Brain/OpenAIBrainClient.swift` (verbatim extract/re-emit), `CoachDriver.swift` (whole-output threading), `CoachHistory.swift` (commit-time conversion), `Brain.swift` (`ChatMessage.rawItems`).
+
 ### 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers
 
 - **Chose:** A `BrainProvider` selection (Settings → Brain): the OpenAI Responses API (default), or a locally installed **Claude Code** / **Codex** CLI spawned per turn (`CLIBrainClient` behind the same `BrainClient` protocol), so the brain — coach, summarizer, evaluator — bills to the user's existing Claude / ChatGPT **subscription** instead of the metered key. CLIs are auto-detected by pure file probes (`AgentCLIDetector`: $PATH + known install dirs + on-disk auth markers; no subprocess, no Keychain prompt) so selection is one radio click. Tool use rides a prompt-embedded JSON protocol generated from the same `ToolDef`s; every turn is a single model call — screenshots reach Claude inline as base64 image blocks (stream-json input, all built-in tools disabled) and Codex as 0600 session-dir files via `-i` (`--sandbox read-only`); both CLIs run with session persistence off so no transcript copy lands in their own stores. The API-key section merged into the Brain tab — the key stays required for Realtime transcription regardless of provider.
@@ -322,15 +325,15 @@
   streamed deltas, accepts out-of-order completion/failure, salvages delta text on failure or a
   missing-terminal deadline, and emits an explicit context-gap line when failed, timed-out, or
   long VAD-confirmed speech cannot be recovered from an empty completion. Transcript timestamps use
-  `audio_start_ms`, so inference completion order cannot reorder speakers. Bare `speech_stopped` no
-  longer resets the silence clock. Every real system-output sample is preserved for transcription;
-  a short/empty callback is padded only with its missing silence so the Realtime audio clock and
-  trailing-silence VAD keep advancing, while a separate exact-length padded/truncated copy feeds AEC.
-  Noise-reduction policy stays at its configured setting for both streams; source-specific tuning
-  requires representative live evaluation rather than assuming digital loopback is noise-free.
-  VAD-only starts/stops cannot restart the silence interval: a due check waits locally for the pending
-  item, while socket failure or a long active-item deadline resolves it so stale speech state cannot
-  suppress coaching forever.
+  `audio_start_ms`, so inference completion order cannot reorder
+  speakers. Bare `speech_stopped` no longer resets the silence clock. Every real system-output sample
+  is preserved for transcription; a short/empty callback is padded only with its missing silence so
+  the Realtime audio clock and trailing-silence VAD keep advancing, while a separate exact-length
+  padded/truncated copy feeds AEC. Noise-reduction policy stays
+  at its configured setting for both streams; source-specific tuning requires representative live
+  evaluation rather than assuming digital loopback is noise-free. VAD-only starts/stops cannot restart
+  the silence interval: a due check waits locally for the pending item, while socket failure or a long
+  active-item deadline resolves it so stale speech state cannot suppress coaching forever.
 - **Why:** In the 2026-07-16 interview session, the user's long answer about an AI project reached the
   mic transcript but the interviewer's question never appeared in either the activity log or the
   exact brain traffic. The gap was upstream of `CoachDriver`; the old client ignored documented delta
@@ -344,6 +347,33 @@
   client's dropped event paths.
 - **Detail:** `Sources/JarvisCore/Transcription/RealtimeTranscriptionLedger.swift`,
   `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`, `AggregateEchoCapture.swift`.
+
+### 2026-07-16 — Screen context uses model freshness judgment plus a stable local monitor
+
+- **Chose:** Keep model-requested `capture_screen` for ordinary speech and tell the model that older
+  screenshots never prove current state; when the meaning of a turn suggests a question, prompt,
+  code, or solution may have appeared or changed, it must look before screen-specific advice. This is
+  semantic prompt/context policy, not a phrase list. Pre-capture into the first brain request for
+  manual hints, silence checks, and stable screen changes. `ScreenChangeMonitor` starts with the
+  active coaching session and uses its first local poll as a baseline; `ScreenChangeDetector`
+  combines normalized-OCR and tolerant perceptual-image fingerprints and requires the changed state
+  to repeat before
+  emitting it. ScreenCaptureKit keeps these polls off disk. That exact stable snapshot becomes the
+  logged image sent by `CoachDriver`, and only a successful first brain request advances the baseline;
+  a failed request re-arms the candidate. Screenshots and OCR are described as point-in-time
+  observations that become stale after typing or navigation.
+- **Why:** In the same interview, the last captured editor was blank. The interviewer then posted a
+  question and the user typed code, but the model repeatedly chose `stay_silent` from transcript-only
+  turns and never viewed the new state. Asking a model that cannot see the screen whether it needs to
+  see the screen is not a sufficient freshness guarantee. Stable local detection catches question and
+  solution changes without uploading or persisting every intermediate typing frame.
+- **Rejected:** (a) Send a screenshot on every speech turn — deterministic but costly, distracting,
+  and usually unchanged. (b) A finite transcript cue list — unscalable language matching that still
+  cannot catch silent typing/navigation. (c) Retaining or uploading intermediate monitor polls —
+  unnecessary exposure; only the stable screenshot consumed by a coaching turn belongs in the log.
+- **Detail:** `Sources/JarvisCore/Coach/ToolDefs.swift`, `ScreenChangeDetector.swift`,
+  `Sources/JarvisApp/Capture/InMemoryScreenCapture.swift`, `ScreenChangeMonitor.swift`,
+  `CoachDriver.swift`.
 
 ### 2026-07-16 — Short interviewer rejection is substantive
 
@@ -388,3 +418,77 @@
 - **Detail:** `Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift`,
   `Sources/JarvisCore/Audio/AdaptiveAudioActivityDetector.swift`,
   `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`.
+
+### 2026-07-17 — Native frame metadata gates full screen capture and coach cost
+
+- **Chose:** Use a low-rate, low-resolution `SCStream` only as a local activity signal. Native
+  complete/idle status and dirty rectangles feed a Foundation-only quiescence state machine. One
+  full screenshot plus on-device OCR runs after the surface settles; a normalized-OCR hash plus a
+  tolerant 64-bit perceptual image hash suppress duplicates without hiding diagrams or OCR-missed
+  edits. A stable snapshot waits briefly to piggyback on the next speech request, then falls
+  back to a screen-only request under a minimum interval. Failed/cancelled delivery re-arms the exact
+  candidate, including a newer candidate that settled while an older request was in flight. A
+  watchdog ignores unusable blank/suspended frames and restarts interrupted streams; generation and
+  identity checks stop a stream whose asynchronous startup completed after Stop/restart.
+- **Why:** A full-resolution screenshot/OCR poll is unnecessary work, while a transcript cue list
+  cannot catch silent typing or navigation. ScreenCaptureKit already exposes change/idle metadata,
+  so the OS can cheaply gate the expensive stage. Piggybacking gives speech the newest visual context
+  without another request; the fallback still catches a silently posted question, and the interval
+  bounds cost during repeated typing pauses.
+- **Rejected:** (a) A fixed phrase list — incomplete and language-specific. (b) One model request per
+  frame or per full capture — unbounded cost and noise. (c) Adding Peekaboo, OBS, Pensieve, or an OCR
+  recorder as a dependency — useful behavioral references, but substantially larger, differently
+  licensed or privacy-oriented, and unnecessary beside the native framework already in the app.
+- **Detail:** `Sources/JarvisApp/Capture/ScreenChangeMonitor.swift`,
+  `Sources/JarvisCore/Screen/ScreenActivityDetector.swift`,
+  `ScreenChangeDetector.swift`.
+- **Superseded by:** 2026-07-17 — Visible pixel stability outranks full-surface redraw metadata.
+
+### 2026-07-17 — Visible pixel stability outranks full-surface redraw metadata
+
+- **Chose:** Keep the low-rate, low-resolution `SCStream`, but compare its actual downscaled pixels
+  locally. A visible pixel delta is a change; a bounded dirty region remains supporting evidence for
+  tiny edits; broad/full-surface dirty metadata alone is not. Complete frames whose visible pixels are
+  unchanged count as idle for quiescence. Content-free counters distinguish native idle, stable
+  redraws, pixel versus dirty-region changes, missing/broad metadata, and unclassifiable frames; the
+  latter cannot keep the watchdog alive. Full screenshot/OCR, persistence, piggybacking, request-rate
+  bounds, and acknowledgement/retry behavior stay unchanged.
+- **Why:** A live active-window run against the interview browser produced 121 complete frames and no
+  native idle for a full minute, so the metadata-only monitor took zero full captures and made zero
+  coach requests. Browsers may continuously repaint a visually static page, and invalid/missing dirty
+  metadata was conservatively treated as a full change. Neither case is evidence that the question or
+  code is still moving. Comparing the already-bounded frame restores liveness without recurring OCR,
+  disk writes, or model cost.
+- **Rejected:** (a) Wait indefinitely for native idle — disproved by the live browser. (b) Treat every
+  complete/full-dirty frame as meaningful — recreates the failure. (c) Poll full-resolution screenshots
+  and Vision OCR continuously — more CPU and screen-derived data lifetime than the low-resolution
+  signal needs. (d) Ignore dirty metadata entirely — risks missing a tiny code edit lost in
+  downsampling.
+- **Supersedes:** the metadata-only activity classification in the preceding entry; its two-stage
+  capture, deduplication, piggyback, retry, and cost bounds stand.
+- **Detail:** `Sources/JarvisCore/Screen/ScreenFrameActivityClassifier.swift`,
+  `Sources/JarvisApp/Capture/ScreenChangeMonitor.swift`.
+- **Superseded by:** 2026-07-17 — One-shot polling preserves capture invisibility and bounds silent cost.
+
+### 2026-07-17 — One-shot polling preserves capture invisibility and bounds silent cost
+
+- **Chose:** Replace the monitor's long-lived `SCStream` with low-rate, low-resolution one-shot
+  `SCScreenshotManager` captures. Keep the first stable silent change responsive, then enforce a
+  minute-scale minimum between visual-only brain requests; the latest pending snapshot can still
+  piggyback on speech without another request. Record every visual-only brain trigger explicitly in
+  the activity log, and discard monitor-only turns from conversation memory when the model stays
+  silent.
+- **Why:** Live validation showed macOS's persistent purple screen-sharing control for the lifetime of
+  the stream, violating the interview posture, and three short typing pauses produced three billed
+  brain requests in 51 seconds. Two of those requests returned `stay_silent` yet their OCR context
+  enlarged later prompts. One-shot local polls preserve freshness without an ongoing sharing session;
+  the hard fallback interval bounds silent cost, while speech piggybacking preserves timely context.
+- **Rejected:** (a) Hide or work around macOS's sharing indicator — it is an OS privacy surface, not
+  app UI Jarvis should suppress. (b) Disable silent screen monitoring — restores the original stale
+  blank-screen failure. (c) Let every settled edit call the model — model restraint governs whether to
+  speak, but cannot make the request itself free. (d) Continuous full-resolution OCR polling — more
+  CPU and screen-derived data lifetime than downscaled pixel comparison needs.
+- **Supersedes:** the persistent-stream portion of the two preceding screen-monitor decisions; their
+  quiescence, full-capture deduplication, piggyback, audit, and retry behavior stand.
+- **Detail:** `Sources/JarvisApp/Capture/ScreenActivityPoller.swift`, `ScreenChangeMonitor.swift`,
+  `Sources/JarvisCore/Screen/ScreenRequestTiming.swift`, `CoachDriver.swift`.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -8,72 +8,42 @@
 
 ## Current phase
 
-**Realtime reliability hardened headlessly — awaiting live validation.** Earlier live runs verified
-the end-to-end pipeline and exposed intermittent startup/mid-session socket losses plus a brain
-request timeout. The app now verifies the two real transcription sockets, actively monitors them,
-shows connection health in the menu, preserves audio across reconnects, and retries one transient
-primary brain failure. The brain can now also run through a locally installed Claude Code / Codex
-CLI on the user's subscription (auto-detected in Settings → Brain, which absorbed the API-key tab) —
-the CLI integration itself is live-validated end-to-end against real `claude` 2.1.211 / `codex` 0.144
-binaries (coach turns, screenshot vision via the file handoff, summarizer calls, cleanup); the
-in-app flow awaits the same macOS smoke run. The implementation builds and
-the full tested harness is green; the new OS/network behavior still needs a human smoke run.
+**Interview audio reliability and local CLI brain providers are implemented.** Realtime
+transcription reconciles each `item_id` across VAD, delta, completion, and failure events; salvages
+partial text or emits an explicit context gap; preserves every real system-audio sample while
+padding only missing tap silence for VAD; and keeps AEC on a separate exact-length reference.
+Content-free continuity checkpoints cover capture through server speech without archiving PCM.
+Locally accepted WebSocket sends remain in a bounded memory-only recovery tail because Realtime does
+not acknowledge audio appends; server audio-clock progress retires only a safe prefix, and a
+replacement socket replays the rest after a half-open failure. A live Wi-Fi reconnect run confirms
+that speech captured during the outage returns after recovery. The brain can also run through a
+locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
+those providers and keeps the OpenAI API-key path available.
 
 ## Next action
 
-Run the **reliability smoke run** from the reliability branch — build, run, and validate live:
-
-1. `./scripts/build-app.sh release` → `open ./Jarvis.app`; grant Microphone + Screen Recording
-   (one-time; they persist afterward — see [build-and-run.md](./build-and-run.md)).
-2. Paste your OpenAI key in Settings → Brain — it saves to an owner-only file. Jarvis
-   does **not** auto-start; press **Start Jarvis** in the menu to begin. Confirm the status progresses
-   from Starting to final, unqualified Listening only after both transcription sessions report ready,
-   then use **Stop Jarvis** to halt. Model IDs are doc-verified; no edit expected.
-3. Run the **live smoke checklist** ([README](../README.md#live-smoke-checklist)): speak →
-   transcript; "I'm stuck on two-sum" → coaching overlay + observed `capture_screen`; overlay
-   excluded from the screenshot; while you talk steadily Jarvis stays mostly quiet (model restraint,
-   not a rate cap) and **Stop Jarvis** halts the pipeline. (Run via `./scripts/build-app.sh --run`,
-   then open Settings → Activity to watch each step.)
-4. Leave Jarvis silent beyond one health-probe interval, then speak; transcription should still work
-   without waiting for speech to discover a dead socket. Toggle Wi-Fi off/on once: the menu should
-   show Reconnecting, buffered speech should replay after recovery, and the log should identify the
-   `me`/`them` socket plus the macOS network-path state. Confirm two persistent failures degrade to
-   microphone-only or stop loudly rather than leaving a false green state.
-5. For the brain path, watch Settings → Activity during a transient timeout/network loss: the first
-   failure should log one retry and either complete on that retry or fail normally so the next trigger
-   carries the unsent transcript. Permanent HTTP failures must not retry.
-6. **Brain-input PoC** (window-scoped capture + OCR sidecar — see the 2026-07-07
-   [decision](./decisions.md)): with a LeetCode window frontmost, a planted bug, and effort **Low**,
-   compare bug-found rate / input tokens / latency across capture scopes (full display vs. active
-   window vs. active window + OCR, 5 runs each) to confirm Low+clean-input replaces High.
-7. **One-click session evaluation** (see the 2026-07-15 [decision](./decisions.md)): while coaching
-   runs, Settings → Activity → **Evaluate** stays disabled for the live session; after Stop it
-   enables — click it and expect `brain-traffic.jsonl` in the session dir, the audit report window,
-   and `eval-report.md` saved beside the traffic it audits.
-8. **CLI brain provider** (see the 2026-07-16 [decision](./decisions.md)): with Claude Code (or
-   Codex) installed and signed in, Settings → Brain should show it "detected"; select it, Start, and
-   confirm a coaching turn speaks, a "check my screen" request produces a `capture_screen` (the
-   screenshot handed to the CLI as a session-dir file, deleted after the turn), turns land in
-   `brain-traffic.jsonl` with the CLI argv, and a session with the CLI uninstalled fails Start
-   loudly with the missing-CLI alert.
+Review and merge the audio reliability change. Then run the remaining in-app CLI provider smoke:
+select a detected Claude Code or Codex provider, confirm a coaching turn and screen request, and
+confirm a missing CLI fails Start loudly. The standard release checklist remains in
+[build-and-run.md](./build-and-run.md).
 
 ## Built
 
 Tested `JarvisCore` + `JarvisOverlay` harness is green (`./scripts/run-tests.sh`); `JarvisApp` is the
 thin OS shell, verified by the smoke run.
 
-- `Sources/JarvisCore/Audio/` — PCM + utterance buffering (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`).
-- `Sources/JarvisCore/Transcription/` — realtime session wire contract + rolling transcript (`RealtimeSession`, `Transcript`, `NoiseReduction`).
+- `Sources/JarvisCore/Audio/` — transactional PCM + utterance buffering, adaptive content-free activity detection, non-destructive AEC reference alignment, and system-audio timeline preservation (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`, `AdaptiveAudioActivityDetector`, `EchoReferenceAlignment`, `SystemAudioTimeline`).
+- `Sources/JarvisCore/Transcription/` — realtime session wire contract, per-item event ledger, and rolling transcript (`RealtimeSession`, `RealtimeTranscriptionLedger`, `Transcript`, `NoiseReduction`).
 - `Sources/JarvisCore/Brain/` — the LLM integration: the `BrainClient` contract (`Brain`), `OpenAIBrainClient`, `CLIBrainClient` + `AgentCLIProcessRunner` + `AgentCLIDetector` (the local Claude Code / Codex brain providers), `RetryingBrainClient`, `BrainProvider`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
 - `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver`, `CoachHistory` (client-managed session memory), `ToolDefs` (coach tools + system prompt).
-- `Sources/JarvisCore/Triggers/` — turn/silence trigger detection + silence backoff (`Trigger`, `SilenceBackoff`).
+- `Sources/JarvisCore/Triggers/` — turn/silence trigger detection, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
 - `Sources/JarvisCore/Screen/` — the model-triggered screen-capture tool contract + window-scoped capture logic (`ScreenCapture`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`).
 - `Sources/JarvisCore/Overlay/` — overlay text model + length-proportional timing + fan-out (`OverlayRendering`, `OverlayTiming`, `OverlayAppearance`, `BroadcastOverlay`).
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + brain/screen preferences (`Config`, `Secrets`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
-- `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, session-history store, wire-level brain traffic capture + one-click session evaluation, user-facing errors (`ActivityLog`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `UserFacingError`).
+- `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation, user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
 - `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`).
-- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), readiness/liveness/reconnect monitoring (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
+- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain (provider + model + API key) / Overlay / Screen / Activity sections).
 - `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the one-click **Evaluate** session audit.
@@ -81,7 +51,6 @@ thin OS shell, verified by the smoke run.
 
 ## Not yet built
 
-- **Live validation of the new Realtime reliability behavior** — the remaining gate for this hardening pass; see Next action.
 - **Universal binary** — `Sources/CJarvisAEC/lib/libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 slice if Intel is ever needed.
 - **Neural double-talk canceller** (DTLN / Muesli-style on the same aligned streams) — the escalation if AEC3 over-attenuates the user under loud far audio in practice.
 - **Minimum macOS version confirmed** — currently targeting macOS 14+; confirm against the APIs actually used (ScreenCaptureKit needs 13+).

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -8,42 +8,49 @@
 
 ## Current phase
 
-**Interview audio reliability and local CLI brain providers are implemented.** Realtime
-transcription reconciles each `item_id` across VAD, delta, completion, and failure events; salvages
-partial text or emits an explicit context gap; preserves every real system-audio sample while
-padding only missing tap silence for VAD; and keeps AEC on a separate exact-length reference.
-Content-free continuity checkpoints cover capture through server speech without archiving PCM.
-Locally accepted WebSocket sends remain in a bounded memory-only recovery tail because Realtime does
-not acknowledge audio appends; server audio-clock progress retires only a safe prefix, and a
-replacement socket replays the rest after a half-open failure. A live Wi-Fi reconnect run confirms
-that speech captured during the outage returns after recovery. The brain can also run through a
-locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
-those providers and keeps the OpenAI API-key path available.
+**Interview context reliability hardening and local CLI brain providers are implemented.**
+Realtime transcription now reconciles each
+`item_id` across VAD/delta/completed/failed events, salvages partial text or emits an explicit gap,
+preserves every real system-audio sample while padding short tap silence for VAD, keeps AEC on its
+separate exact-length reference, and records privacy-preserving continuity checkpoints from
+capture through server speech. Locally accepted WebSocket sends remain in a bounded memory-only
+recovery tail because Realtime does not acknowledge audio appends; server audio-clock progress retires
+only a safe prefix, and a replacement socket replays the rest after a half-open failure. Visual context
+uses general model freshness judgment for speech plus
+a two-stage native screen monitor: low-rate one-shot downscaled captures gate one stable full capture,
+which piggybacks on speech when possible and otherwise uses a tightly bounded screen-only fallback.
+The monitor never opens a persistent macOS screen-sharing session, unchanged polls advance
+quiescence, and silent monitor turns do not inflate later prompts. There is no phrase list,
+raw-audio archive, or recurring full-resolution poll.
+The brain can also run through a locally installed Claude Code or Codex CLI on the user's subscription;
+Settings → Brain auto-detects those providers and keeps the OpenAI API-key path available.
 
 ## Next action
 
-Review and merge the audio reliability change. Then run the remaining in-app CLI provider smoke:
-select a detected Claude Code or Codex provider, confirm a coaching turn and screen request, and
-confirm a missing CLI fails Start loudly. The standard release checklist remains in
-[build-and-run.md](./build-and-run.md).
+Repeat the focused posted-question screen check in the active interview browser. Confirm that no
+persistent purple screen-sharing control appears, Settings → Activity shows the explicit stable-screen
+trigger row, and repeated silent edits remain under the screen-only request bound reported by the
+screen witness. Then run the remaining in-app CLI provider smoke: select a detected
+Claude Code or Codex provider, confirm a coaching turn and screen request, and confirm a missing CLI
+fails Start loudly. The standard release checklist remains in [build-and-run.md](./build-and-run.md).
 
 ## Built
 
-Tested `JarvisCore` + `JarvisOverlay` harness is green (`./scripts/run-tests.sh`); `JarvisApp` is the
-thin OS shell, verified by the smoke run.
+The reliability paths have focused automated coverage; `JarvisApp` remains the thin OS shell verified
+by the smoke run.
 
 - `Sources/JarvisCore/Audio/` — transactional PCM + utterance buffering, adaptive content-free activity detection, non-destructive AEC reference alignment, and system-audio timeline preservation (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`, `AdaptiveAudioActivityDetector`, `EchoReferenceAlignment`, `SystemAudioTimeline`).
 - `Sources/JarvisCore/Transcription/` — realtime session wire contract, per-item event ledger, and rolling transcript (`RealtimeSession`, `RealtimeTranscriptionLedger`, `Transcript`, `NoiseReduction`).
 - `Sources/JarvisCore/Brain/` — the LLM integration: the `BrainClient` contract (`Brain`), `OpenAIBrainClient`, `CLIBrainClient` + `AgentCLIProcessRunner` + `AgentCLIDetector` (the local Claude Code / Codex brain providers), `RetryingBrainClient`, `BrainProvider`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
 - `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver`, `CoachHistory` (client-managed session memory), `ToolDefs` (coach tools + system prompt).
-- `Sources/JarvisCore/Triggers/` — turn/silence trigger detection, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
-- `Sources/JarvisCore/Screen/` — the model-triggered screen-capture tool contract + window-scoped capture logic (`ScreenCapture`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`).
+- `Sources/JarvisCore/Triggers/` — turn/silence/visual trigger context, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
+- `Sources/JarvisCore/Screen/` — screen-capture contract, window-scoped selection, OCR layout, and local frame/activity/content state machines (`ScreenCapture`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`, `ScreenFrameActivityClassifier`, `ScreenActivityDetector`, `ScreenChangeDetector`).
 - `Sources/JarvisCore/Overlay/` — overlay text model + length-proportional timing + fan-out (`OverlayRendering`, `OverlayTiming`, `OverlayAppearance`, `BroadcastOverlay`).
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + brain/screen preferences (`Config`, `Secrets`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
 - `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation, user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
 - `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`).
-- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
+- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot/OCR and two-stage native change-monitor edge (`WindowScopedScreenCapture`, `ScreenActivityPoller`, `InMemoryScreenCapture`, `ScreenPerceptualHash`, `ScreenTextRecognizer`, `ScreenChangeMonitor`).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain (provider + model + API key) / Overlay / Screen / Activity sections).
 - `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the one-click **Evaluate** session audit.


### PR DESCRIPTION
> **Parked / draft.** This change is intentionally separated from #74 so the audio/transcription reliability fix can merge independently. Its base is `fix/interview-context-reliability`. Because this repository squash-merges, rebase the single screen commit onto updated `main` and retarget the PR after #74 merges.

## Problem

In the interview session that motivated #74, the last screenshot Jarvis sent to the coach showed a blank editor. The interviewer then posted the real question and the user began typing a solution, but those silent visual changes produced no transcript event. A screen-blind model repeatedly chose `stay_silent`, so it never saw the question or corrected the developing solution.

Prompt guidance alone improves capture decisions on speech turns, but it cannot discover a screen change when neither person says anything. Capturing every turn or every frame would create avoidable vision cost, CPU work, and privacy exposure.

## Solution

- Keep model-triggered `capture_screen` for ordinary speech, with explicit freshness guidance that a historical screenshot never proves the current screen state.
- Poll the active capture scope locally at low rate and bounded resolution using one-shot `SCScreenshotManager` captures. There is no persistent `SCStream`, so the monitor does not leave macOS's purple screen-sharing control visible.
- Compare downscaled visible pixels locally, use dirty-region metadata only as supporting evidence for tiny edits, and wait for quiescence before taking one full screenshot.
- Deduplicate full captures with normalized OCR plus a tolerant perceptual image hash, preserving meaningful non-text changes without reacting to small encoding drift.
- Hold the latest stable snapshot briefly so it can piggyback on the next speech request. If the interview remains silent, allow a screen-only fallback no more than once per minute.
- Record an explicit “stable screen change detected” activity row, persist the exact image before network send for audit, retry failed delivery safely, and prevent stale captures from acknowledging newer activity.
- Drop silent monitor-only turns from conversation history so repeated `stay_silent` checks do not inflate later prompts.

## Why this shape

This is a two-stage local gate: cheap one-shot pixels decide whether anything visibly changed; full capture, OCR, persistence, and model cost happen only after the new state settles. The model remains responsible for whether to speak, while the harness supplies fresh context when speech cannot reveal that a question or solution appeared.

The one-minute screen-only bound caps silent cost. Speech piggybacking remains immediate and does not add another brain request. Intermediate poll images stay memory-only and are never OCR'd, uploaded, or written to disk.

## Validation

- `swift build && ./scripts/run-tests.sh`
- 416 tests in 53 suites passed.
- Automated coverage includes visible-pixel stability under browser redraws, tiny dirty-region edits, OCR/perceptual deduplication, quiescence, candidate replacement, retry/re-arm behavior, capture ordering, piggyback timing, the screen-only request bound, audit-before-send, and silent-history removal.
- Manual session `2026-07-17_16-35-50_D4BF` exposed the browser-redraw quiescence issue and led to visible-pixel classification.
- Manual session `2026-07-17_19-39-22_38DE` exposed the persistent purple control and three short-interval brain calls; that led to one-shot polling plus the hard fallback interval.
- Final manual session `2026-07-17_20-18-16_621B` showed no persistent purple button, one accepted full screenshot, one corresponding brain request, and the explicit stable-screen activity marker.

## Known review findings before ready

The final combined-PR review produced three screen-specific findings after the last implementation commit. They are deliberately preserved here and must be addressed before this draft is marked ready:

- Prevent the asynchronous startup seed from baselining a screen update that appears after Start but before the first low-rate change report.
- Reject a full monitor capture if a newer screen change was observed while that capture was in flight, so stale pixels are never sent as the latest state.
- If startup seeding fails, keep the first dirty snapshot unbaselined until a brain request successfully consumes it, including displacement and settle-back cases.

## Review state

This PR is deliberately left as a draft for later consideration. #74 does not depend on it.