### PR TITLE
fix(activity): separate human and debug logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,11 @@ The squash-merge subject carries the PR number (`type: summary (#N)`).
 - **No secrets in code, ever** — not in source, tests, or examples. The API key lives in an owner-only
   `0600` file (`OPENAI_API_KEY` env var is a headless fallback only); see
   [`wiki/sandbox.md`](./wiki/sandbox.md) for why not the Keychain.
+- **Keep human activity separate from agent diagnostics.** `ActivityLog` is the human-facing coaching
+  record: only finalized interviewer/user speech, manual hint requests, screens Jarvis actually viewed,
+  and tips Jarvis displayed belong there. Lifecycle, transport, retry, error, timing, and diagnosis
+  details go through `jlog` to `jarvis-debug.log`. Never mirror `jlog` into `ActivityLog`; when a real
+  coaching event is also useful diagnostically, record the typed activity event explicitly.
 - **The only screen-/audio-derived data persisted to disk is the per-session log directory** (the
   activity log — spoken tips, transcribed "heard:" lines, the screenshots the model looked at — plus
   the wire-level brain traffic record and its on-demand evaluation report). It is written every run to an

--- a/Sources/JarvisApp/App/ErrorReporter.swift
+++ b/Sources/JarvisApp/App/ErrorReporter.swift
@@ -7,8 +7,8 @@ import JarvisCore
 /// `.degraded` is logged only. The only place an *error* `NSAlert` is raised (confirmation prompts,
 /// e.g. ActivityViewer's clear-history, are a separate concern and don't route here).
 ///
-/// Diagnostics stay in `JarvisLog`/`jlog` (it still owns the debug + activity logs); this type owns
-/// *user-facing surfacing + session-lifecycle consequence*. `report(_:)` is `nonisolated` so any
+/// Diagnostics stay in the agent-facing `JarvisLog`/`jlog` debug log; this type owns *user-facing
+/// surfacing + session-lifecycle consequence*. `report(_:)` is `nonisolated` so any
 /// thread (the capture IOProc, a URLSession delegate) can call it directly; it hops to the main actor.
 @MainActor
 final class ErrorReporter {

--- a/Sources/JarvisApp/Capture/RealtimeTranscriptionLifecycle.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriptionLifecycle.swift
@@ -381,6 +381,7 @@ final class RealtimeTranscriptionLifecycle: @unchecked Sendable {
         transcript.append(.init(speaker: speaker, text: text, at: at))
         let detail = reason.map { ", recovered after \($0)" } ?? ""
         jlog("🗣 heard (\(speaker.rawValue)): \"\(text)\" (item \(item.itemID)\(detail))")
+        ActivityLog.shared.record(.heard(speaker: speaker, text: text))
         pending.append(text)
         resetSilenceTimer()
         scheduleTurnDebounce()

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -123,7 +123,10 @@ public final class CoachDriver: @unchecked Sendable {
         // A hotkey trigger leaves no "🗣 heard:" line (the user pressed a key, didn't speak), so record
         // it — with the synthetic request we pre-fill as the user's message — so the activity viewer
         // shows what the shortcut sent to the brain.
-        if reason == .manualHint, let line = ctx.promptLine { jlog("⌨️ hint shortcut — \(line)") }
+        if reason == .manualHint, let line = ctx.promptLine {
+            jlog("⌨️ hint shortcut — \(line)")
+            ActivityLog.shared.record(.manualHint(prompt: line))
+        }
 
         // The delta: only the lines the brain hasn't seen yet (the rest live in `history`).
         let delta = transcript.renderFrom(index: currentSentCount())
@@ -135,7 +138,7 @@ public final class CoachDriver: @unchecked Sendable {
         // manual-hint triggers always go through. Logged so gate misfires are auditable.
         if reason == .turnEnd && !delta.lines.contains(where: TurnSubstance.isSubstantive) {
             // Log WHAT was skipped (not just that a skip happened) so a gate misfire — a real remark
-            // wrongly classified as filler — is visible in the activity viewer, not silent.
+            // wrongly classified as filler — is visible in the debug log, not silent.
             let preview = delta.lines.isEmpty
                 ? "nothing new"
                 : String(delta.lines.map(\.text).joined(separator: " · ").prefix(80))
@@ -163,7 +166,8 @@ public final class CoachDriver: @unchecked Sendable {
             let shot = await Task.detached(priority: .userInitiated, operation: { screen.capture() }).value
             if Task.isCancelled { jlog("… turn cancelled (stopped) after capture"); return .cancelled }
             if let shot {
-                jlog("👁 looking at your screen", image: shot.imageBase64)
+                jlog("👁 looking at your screen")
+                ActivityLog.shared.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
                 turnMessages.append(.userImage(shot.imageBase64))
                 // OCR sidecar: the same window as exact text, so the model reads code instead of
                 // deciphering pixels. Rides as its own user message — there's no tool result to
@@ -238,7 +242,8 @@ public final class CoachDriver: @unchecked Sendable {
                     return .cancelled
                 }
                 if let shot {
-                    jlog("👁 looking at your screen", image: shot.imageBase64)   // thumbnail in the activity viewer
+                    jlog("👁 looking at your screen")
+                    ActivityLog.shared.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
                     if let text = shot.recognizedText {
                         jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
                     }
@@ -275,6 +280,7 @@ public final class CoachDriver: @unchecked Sendable {
                 // This is the "speak after Stop" guard the TurnTaskBox relies on.
                 if Task.isCancelled { jlog("… turn cancelled (stopped) before speaking"); return .cancelled }
                 jlog("💬 \(lines.joined(separator: " "))")
+                ActivityLog.shared.record(.tip(lines: lines))
                 let perLine = lines.map { OverlayTiming.displaySeconds(for: $0, config: config) }
                 overlay.render(lines, perLineSeconds: perLine)
                 // Close the call locally — we own the history, so no follow-up round trip is needed.

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -1,14 +1,28 @@
 import Foundation
 
-/// The model behind the activity viewer. Mirrors `jlog` lines into an in-app `WKWebView` window
-/// (see `ActivityViewer` in JarvisApp) by **pushing** each line to a registered observer, and
-/// persists the session to disk so past sessions can be browsed later. Until `enable(directory:)`
-/// is called (on each Start), `record(_:)` is a no-op and nothing is written.
+/// The model behind the human-facing activity viewer. It records only the coaching exchange — heard
+/// speech, manual hint requests, screens Jarvis viewed, and tips Jarvis gave — then pushes those
+/// entries into an in-app `WKWebView` window (see `ActivityViewer` in JarvisApp) and persists them so
+/// past sessions can be browsed later. Diagnostics belong exclusively in `JarvisLog`.
 ///
 /// This type is UI-free (Foundation only): it generates the page HTML and the per-row JS as plain
 /// strings; the WebView lives in JarvisApp. See wiki/build-and-run.md.
 public final class ActivityLog: @unchecked Sendable {
     public static let shared = ActivityLog()
+
+    /// A human-visible event in the coaching exchange. Keeping this closed set typed prevents
+    /// lifecycle, transport, retry, error, and other diagnostic strings from leaking into the
+    /// activity viewer through a generic logging call.
+    public enum Event: Sendable {
+        /// A finalized utterance from the user (`me`) or interviewer (`them`).
+        case heard(speaker: Speaker, text: String)
+        /// The user explicitly requested help through the manual-hint shortcut.
+        case manualHint(prompt: String)
+        /// Jarvis captured and viewed the screen while preparing a coaching response.
+        case screenViewed(imageBase64JPEG: String)
+        /// Jarvis displayed these coaching lines to the user.
+        case tip(lines: [String])
+    }
 
     /// One recorded line. `imageFile` is the relative `shot-N.jpg` name on disk (the bytes the DOM
     /// renders are passed separately as base64), or nil for a plain text line.
@@ -63,7 +77,7 @@ public final class ActivityLog: @unchecked Sendable {
 
     /// Turn on the viewer for a session. `directory` is this session's dir; an empty
     /// `jarvis-activity.jsonl` is created at 0600 immediately so the session is discoverable by
-    /// `SessionStore.listSessions()` even before its first `record()`.
+    /// `SessionStore.listSessions()` even before its first event.
     public func enable(directory: URL) {
         queue.sync {
             dir = directory
@@ -79,12 +93,29 @@ public final class ActivityLog: @unchecked Sendable {
         queue.sync { dir = nil; entries.removeAll(); totalCount = 0; shotSeq = 0; onAppend = nil }
     }
 
-    /// Append a line: persist it, then push it to the observer. No-op when disabled.
+    /// Append one human-facing coaching event: persist it, then push it to the observer. No-op when
+    /// disabled. Call `jlog` instead for diagnostics.
     ///
-    /// When `imageBase64` is a base64 JPEG (a screenshot the model just looked at), the `.jpg` is
-    /// written **first** (owner-only) and then the `.jsonl` line referencing it — so a persisted
-    /// reference always points at a file that exists.
-    public func record(_ message: String, imageBase64: String? = nil, at date: Date = Date()) {
+    /// When a screen-view event carries a base64 JPEG, the `.jpg` is written **first** (owner-only)
+    /// and then the `.jsonl` line referencing it — so a persisted reference always points at a file
+    /// that exists.
+    public func record(_ event: Event, at date: Date = Date()) {
+        let message: String
+        let imageBase64: String?
+        switch event {
+        case .heard(let speaker, let text):
+            message = "🗣 heard (\(speaker.rawValue)): \"\(text)\""
+            imageBase64 = nil
+        case .manualHint(let prompt):
+            message = "⌨️ hint shortcut — \(prompt)"
+            imageBase64 = nil
+        case .screenViewed(let imageBase64JPEG):
+            message = "👁 looking at your screen"
+            imageBase64 = imageBase64JPEG
+        case .tip(let lines):
+            message = "💬 \(lines.joined(separator: " "))"
+            imageBase64 = nil
+        }
         queue.async { [self] in
             guard let dir else { return }
             let shotName = imageBase64.flatMap { saveShot($0, in: dir) }
@@ -178,6 +209,15 @@ public final class ActivityLog: @unchecked Sendable {
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
         return ""
+    }
+
+    /// Whether a persisted row belongs in the human-facing viewer. New rows are guaranteed by the
+    /// typed `Event` API; this also hides diagnostic rows from sessions written by older builds.
+    static func isHumanFacing(message: String, imageFile: String?) -> Bool {
+        if imageFile != nil { return true }
+        let m = message.trimmingCharacters(in: .whitespaces)
+        return m.hasPrefix("🗣 heard") || m.hasPrefix("⌨️ hint shortcut")
+            || m.hasPrefix("👁 looking at your screen") || m.hasPrefix("💬")
     }
 
     /// The empty page shell: dark theme, a header with a live count, the row container, the lightbox

--- a/Sources/JarvisCore/Diagnostics/Log.swift
+++ b/Sources/JarvisCore/Diagnostics/Log.swift
@@ -4,7 +4,7 @@ import Foundation
 /// no flat file is created. On each Start the app calls `JarvisLog.enableFileLogging(directory:)`,
 /// after which `jlog` also appends to `<directory>/jarvis-debug.log` (created `0600`, truncated
 /// fresh for the session). The file is always owner-only and never lands in a world-readable path —
-/// see wiki/sandbox.md ("activity log persistence").
+/// see wiki/sandbox.md ("per-session log directory").
 public enum JarvisLog {
     private static let lock = NSLock()
     nonisolated(unsafe) private static var directory: URL?   // guarded by `lock`
@@ -27,13 +27,11 @@ public enum JarvisLog {
     }
 }
 
-/// Lightweight logger: always writes to the unified log (Console) and mirrors into the activity
-/// viewer; additionally appends to the session debug file when file logging is enabled.
-/// `image`, when set, is a base64-encoded JPEG screenshot to show as a thumbnail in the activity
-/// viewer (the file log and unified log stay text-only).
-public func jlog(_ message: String, image base64JPEG: String? = nil) {
+/// Agent-facing diagnostic logger: always writes to the unified log (Console) and additionally
+/// appends to the session debug file when file logging is enabled. It deliberately never writes to
+/// `ActivityLog`, whose entries are a separate, human-facing coaching record.
+public func jlog(_ message: String) {
     NSLog("%@", message)
-    ActivityLog.shared.record(message, imageBase64: base64JPEG)  // HTML activity viewer (no-op until enabled)
 
     guard let url = JarvisLog.debugLogURL else { return }
     let line = "\(logTimestamp()) \(message)\n"

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -54,16 +54,19 @@ public struct SessionStore: Sendable {
             .sorted { $0.id > $1.id }   // id is a lexically-sortable timestamp ⇒ newest first
     }
 
-    /// Whether a session's log holds anything worth browsing: at least one coaching-class line
-    /// (`💬`/`👁`/`🗣`/`🤫`/`💭`/error — see `ActivityLog.cssClass`) or a captured screenshot. Pure
-    /// lifecycle noise ("coaching started"/"stopped") classifies as empty, so an aborted run is hidden.
+    /// Whether a session's log holds at least one human-facing coaching event. The classifier also
+    /// keeps lifecycle and diagnostic rows written by older builds from making aborted runs visible.
     private static func hasCoachingContent(_ sessionURL: URL) -> Bool {
         let url = sessionURL.appendingPathComponent("jarvis-activity.jsonl")
         guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
         for raw in text.split(separator: "\n", omittingEmptySubsequences: true) {
             guard let line = try? JSONDecoder().decode(Line.self, from: Data(raw.utf8)) else { continue }
-            if line.s != nil { return true }
-            if !ActivityLog.cssClass(for: line.m).isEmpty { return true }
+            let shot = line.s.flatMap { name -> String? in
+                guard Self.isShotName(name), FileManager.default.fileExists(atPath:
+                    sessionURL.appendingPathComponent(name).path) else { return nil }
+                return name
+            }
+            if ActivityLog.isHumanFacing(message: line.m, imageFile: shot) { return true }
         }
         return false
     }
@@ -83,8 +86,10 @@ public struct SessionStore: Sendable {
                 shotName = s
                 bytes = try? Data(contentsOf: session.url.appendingPathComponent(s))
             }
+            if bytes == nil { shotName = nil }
+            guard ActivityLog.isHumanFacing(message: line.m, imageFile: shotName) else { continue }
             out.append((ActivityLog.Entry(time: line.t, message: line.m,
-                                          imageFile: bytes == nil ? nil : shotName), bytes))
+                                          imageFile: shotName), bytes))
         }
         return out
     }

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -36,7 +36,7 @@ public extension UserFacingError {
     /// The selected CLI is installed but its sign-in couldn't be confirmed (Claude Code may keep
     /// credentials only in the macOS Keychain, which Jarvis deliberately doesn't probe). A false
     /// negative is possible, so this is a degraded notice, not a Start blocker — but it makes a
-    /// never-working brain visible in the activity log instead of silent.
+    /// never-working brain visible in the debug log instead of silent.
     static func brainCLISignInUnconfirmed(provider: String) -> UserFacingError {
         .init(title: "\(provider) sign-in unconfirmed",
               message: "Couldn't confirm \(provider) is signed in \u{2014} coaching turns may fail. If they do, run the CLI once in Terminal to sign in, then Stop and Start.",

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -146,16 +146,11 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 
     /// End-to-end: a real capture→speak turn through the production `CoachDriver` with the activity
-    /// log enabled (as dev mode does). Proves the screenshot the model looked at lands in the
-    /// activity log as a genuine, owner-only JPEG rendered as a clickable thumbnail linked to the
-    /// full image — the behaviour verified by hand, now automated against regressions.
+    /// log enabled (as it is for every session). Proves the screenshot the model looked at lands in
+    /// the activity log as a genuine, owner-only JPEG rendered as a clickable thumbnail linked to
+    /// the full image — the behaviour verified by hand, now automated against regressions.
     ///
-    /// This drives the shared `ActivityLog` singleton (the real production path: CoachDriver → jlog →
-    /// ActivityLog.shared). Peer tests in this suite also call jlog() and can write into this dir
-    /// while it's the active sink — `.serialized` does NOT prevent that (swift-testing's serialization
-    /// doesn't isolate a test from its peers). Robustness instead comes from: (1) selecting the shot
-    /// by exact byte-match to our fixture, so another test's screenshot can't be mistaken for ours,
-    /// and (2) the append-only `jarvis-activity.jsonl`, so our line survives interleaved writes.
+    /// This drives the shared `ActivityLog` singleton through the real typed activity-event path.
     /// `disable()` in defer resets the singleton afterwards.
     @Test func screenshotLandsInActivityLogAsValidJpeg() async throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -201,10 +196,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 
     /// A hotkey trigger leaves no "🗣 heard:" transcript line (the user pressed a key, didn't speak),
     /// so the manual hint must record its OWN activity line — including the synthetic message we
-    /// pre-fill as the user's request — so the dev viewer shows what the shortcut sent to the brain.
-    /// Drives the shared `ActivityLog` like the screenshot e2e above; the suite is `.serialized` so the
-    /// two shared-log tests don't race. (Other suites' `jlog` calls may also land in this dir while it's
-    /// enabled; that only adds lines, so the `contains` check stays robust.)
+    /// pre-fill as the user's request — so the viewer shows what the shortcut sent to the brain.
+    /// Drives the shared `ActivityLog` like the screenshot e2e above; the suite is `.serialized` so
+    /// the shared-log tests don't race.
     @Test func manualHintTriggerAndPrefilledMessageLandInActivityLog() async throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-hintlog-\(ProcessInfo.processInfo.globallyUniqueString)")
@@ -232,6 +226,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             .appendingPathComponent("jarvis-activity-boundary-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
+        JarvisLog.enableFileLogging(directory: dir)
         ActivityLog.shared.enable(directory: dir)
 
         let brain = ScriptedBrain(script: [
@@ -246,6 +241,11 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(jsonl.contains("activity-boundary-tip-417"))
         #expect(!jsonl.contains("quiet for 417s"))
         #expect(!jsonl.contains("thinking"))
+
+        let debug = try String(contentsOf: dir.appendingPathComponent("jarvis-debug.log"), encoding: .utf8)
+        #expect(debug.contains("quiet for 417s"))
+        #expect(debug.contains("thinking"))
+        #expect(debug.contains("activity-boundary-tip-417"))
     }
 
     /// Stop cancelling a turn *while the screenshot is being captured* must abort before emitting:

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -71,9 +71,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 }
 
-// `.serialized`: two tests here drive the shared `ActivityLog` singleton (the screenshot e2e and the
-// manual-hint trigger-log e2e). Serializing the suite keeps their enable()/disable() from racing each
-// other — they are the only code that enables the shared log, so no other suite can collide.
+// `.serialized`: the activity-log end-to-end tests drive the shared `ActivityLog` singleton.
+// Serializing the suite keeps their enable()/disable() calls from racing each other — they are the
+// only code that enables the shared log, so no other suite can collide.
 @Suite(.serialized) struct CoachDriverPipelineTests {
     private func makeDriver(brain: BrainClient, summarizer: BrainClient? = nil,
                             screen: ScreenCapturing = FakeScreen(),
@@ -223,6 +223,29 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
         // The trigger marker carries the pre-filled synthetic request ("…pressed the hint shortcut…").
         #expect(jsonl.contains("hint shortcut"))
+    }
+
+    /// The activity viewer is the human coaching record, not a second debug console. Internal turn
+    /// state still belongs in `jarvis-debug.log`, while the tip produced by that turn remains visible.
+    @Test func activityLogExcludesCoachingDiagnostics() async throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jarvis-activity-boundary-\(ProcessInfo.processInfo.globallyUniqueString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
+        ActivityLog.shared.enable(directory: dir)
+
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "s", lines: ["activity-boundary-tip-417"])])
+        ])
+        let (driver, _) = makeDriver(brain: brain, clock: ManualClock(now: 417))
+
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 417)) == .spoke)
+
+        _ = ActivityLog.shared.attach { _ in }   // sync barrier: all async records have landed
+        let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
+        #expect(jsonl.contains("activity-boundary-tip-417"))
+        #expect(!jsonl.contains("quiet for 417s"))
+        #expect(!jsonl.contains("thinking"))
     }
 
     /// Stop cancelling a turn *while the screenshot is being captured* must abort before emitting:

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -44,8 +44,8 @@ import Foundation
         #expect(snap.rows.isEmpty)                       // empty session
         #expect(snap.total == 0)
         let pixel = Data([0xFF, 0xD8, 0xFF, 0xD9]).base64EncodedString()
-        log.record("👁 looking", imageBase64: pixel)
-        log.record("💬 tip")
+        log.record(.screenViewed(imageBase64JPEG: pixel))
+        log.record(.tip(lines: ["tip"]))
         _ = log.attach { _ in }                          // sync barrier: drains the serial queue
 
         let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
@@ -63,8 +63,8 @@ import Foundation
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
         let pixel = Data([0xFF, 0xD8, 0xFF, 0xD9]).base64EncodedString()
-        log.record("👁 looking", imageBase64: pixel)
-        log.record("💬 tip")
+        log.record(.screenViewed(imageBase64JPEG: pixel))
+        log.record(.tip(lines: ["tip"]))
         let snap = log.attach { _ in }                   // late attach: snapshot must contain prior rows
         #expect(snap.rows.count == 2)
         #expect(snap.shown == 2)
@@ -85,10 +85,22 @@ import Foundation
 
     @Test func recordIsNoOpWhenDisabled() {
         let log = ActivityLog()                          // never enabled
-        log.record("💬 should not crash or write anything")
+        log.record(.tip(lines: ["should not crash or write anything"]))
         let snap = log.attach { _ in }
         #expect(snap.total == 0)
         #expect(snap.rows.isEmpty)
+    }
+
+    @Test func eventFormattingKeepsDiagnosticDetailsOut() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        log.record(.heard(speaker: .them, text: "How would you optimize it?"))
+        _ = log.attach { _ in }
+
+        let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
+        #expect(jsonl.contains(#"heard (them): \"How would you optimize it?\""#))
+        #expect(!jsonl.contains("item"))
+        #expect(!jsonl.contains("recovered"))
     }
 
     /// Shared temp-dir helper (also used by SessionStoreTests). Owner-only dir, like the real app.

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -31,16 +31,18 @@ import Foundation
 
     @Test func hidesContentlessPastSessionsButKeepsCurrentAndContentful() throws {
         let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
-        // A past session with only lifecycle breadcrumbs (no coaching class, no shot) — an aborted run.
+        // A past session with only lifecycle/diagnostic breadcrumbs — an aborted run.
         try makeSession(base, "2026-06-16_09-00-00_aaaa", lines: [
             "{\"t\":\"09:00:00\",\"m\":\"Jarvis: session …\"}",
-            "{\"t\":\"09:00:01\",\"m\":\"Jarvis: coaching started (mic + system audio).\"}",
-            "{\"t\":\"09:00:02\",\"m\":\"Jarvis: stopped.\"}",
+            "{\"t\":\"09:00:01\",\"m\":\"💭 thinking…\"}",
+            "{\"t\":\"09:00:02\",\"m\":\"Jarvis realtime error event: oops\"}",
         ])
         // A past session that actually coached (has a 💬 line) — keep it.
         try makeSession(base, "2026-06-16_10-00-00_bbbb", lines: ["{\"t\":\"10:00:00\",\"m\":\"💬 try this\"}"])
         // A past session whose only content is a screenshot reference — keep it.
-        try makeSession(base, "2026-06-16_10-30-00_cccc", lines: ["{\"t\":\"10:30:00\",\"m\":\"saw\",\"s\":\"shot-1.jpg\"}"])
+        try makeSession(base, "2026-06-16_10-30-00_cccc", lines: [
+            "{\"t\":\"10:30:00\",\"m\":\"👁 looking at your screen\",\"s\":\"shot-1.jpg\"}"
+        ], shot: ("shot-1.jpg", Data([0xFF, 0xD8, 0xFF, 0xD9])))
         // The current session, breadcrumbs only — always shown so the live run appears in the picker.
         try makeSession(base, "2026-06-16_11-00-00_dddd", lines: ["{\"t\":\"11:00:00\",\"m\":\"Jarvis: coaching started.\"}"])
 
@@ -56,26 +58,28 @@ import Foundation
         let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
         let id = "2026-06-16_10-00-00_aaaa"
         try makeSession(base, id, lines: [
-            "{\"t\":\"10:00:00\",\"m\":\"hi\",\"s\":\"shot-1.jpg\"}",
+            "{\"t\":\"10:00:00\",\"m\":\"👁 looking at your screen\",\"s\":\"shot-1.jpg\"}",
             "not valid json",
             "{\"t\":\"10:00:01\",\"m\":\"evil\",\"s\":\"../escape.jpg\"}",
-            "{\"t\":\"10:00:02\",\"m\":\"text only\"}",
+            "{\"t\":\"10:00:02\",\"m\":\"🗣 heard (me): text only\"}",
+            "{\"t\":\"10:00:03\",\"m\":\"💭 thinking…\"}",
         ], shot: ("shot-1.jpg", Data([0xFF, 0xD8, 0xFF, 0xD9])))
         let store = SessionStore(base: base, current: nil)
         let session = try #require(store.listSessions().first)
         let rows = store.entries(for: session)
-        #expect(rows.count == 3)                     // malformed line skipped
-        #expect(rows[0].0.message == "hi")
+        #expect(rows.count == 2)                     // malformed + diagnostic rows skipped
+        #expect(rows[0].0.message == "👁 looking at your screen")
         #expect(rows[0].1 != nil)                    // valid shot bytes loaded
-        #expect(rows[1].0.message == "evil")
-        #expect(rows[1].1 == nil)                    // traversal filename → no bytes
-        #expect(rows[2].1 == nil)                    // text-only line
+        #expect(rows[1].0.message == "🗣 heard (me): text only")
+        #expect(rows[1].1 == nil)                    // text-only coaching line
     }
 
     @Test func entriesDropImageWhenShotFileMissing() throws {
         let base = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: base) }
         let id = "2026-06-16_10-00-00_aaaa"
-        try makeSession(base, id, lines: ["{\"t\":\"1\",\"m\":\"m\",\"s\":\"shot-9.jpg\"}"])  // file absent
+        try makeSession(base, id, lines: [
+            "{\"t\":\"1\",\"m\":\"👁 looking at your screen\",\"s\":\"shot-9.jpg\"}"
+        ])  // file absent
         let store = SessionStore(base: base, current: nil)
         let rows = store.entries(for: try #require(store.listSessions().first))
         #expect(rows.count == 1)

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -59,23 +59,26 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
 
 ## The live activity viewer
 
-Settings → **Activity** opens an **in-app `WKWebView`** window into which Swift *pushes* each `jlog`
-line (and `capture_screen` thumbnails as in-memory `data:` URIs). Chosen over a local HTTP server +
-SSE: for an app that already holds the entries in memory, pushing into an embedded WebView is less
-code, has zero network surface, and is the most testable (the production runtime *is* the test
-runtime). It also sidesteps the `file://` `fetch()` restriction that forced the original viewer's
-`<meta refresh>` reload.
+Settings → **Activity** opens an **in-app `WKWebView`** into which `ActivityLog` pushes the typed,
+human-facing coaching exchange: finalized interviewer/user speech, manual hint requests, screens
+Jarvis viewed, and tips Jarvis displayed. Screen-view events carry their thumbnails as in-memory
+`data:` URIs. Chosen over a local HTTP server + SSE: for an app that already holds the entries in
+memory, pushing into an embedded WebView is less code, has zero network surface, and is the most
+testable (the production runtime *is* the test runtime). It also sidesteps the `file://` `fetch()`
+restriction that forced the original viewer's `<meta refresh>` reload.
 
 - New events stream in live (no reload, no flicker); thumbnails open in an in-page lightbox.
 - Each Start opens a fresh session (a Stop→Start gets a new log, never resuming the previous run),
   persisted as owner-only `jarvis-activity.jsonl` + `shot-N.jpg`, so past runs can be browsed and the
   history cleared from the viewer. Old sessions are pruned to the most recent few at each Start.
 - **The viewer and its file logging are always on** (they used to be `--dev`-gated; that flag is gone).
-  On every launch `jlog` writes to the unified log (Console.app) *and* the per-session files in the
-  gitignored, workspace-local `.jarvis/<session>/` (`0600` files in a `0700` dir). `build-app.sh --run`
-  passes that path via `--log-dir`, since the `open`-launched app can't find the repo itself; opening
-  the bundle directly with no `--log-dir` falls back to `~/Library/Application Support/Jarvis/sessions/`.
-  The full privacy posture is in [sandbox.md](./sandbox.md).
+  On every Start, `ActivityLog` writes the coaching exchange to `jarvis-activity.jsonl` while `jlog`
+  writes agent-facing diagnostics to the unified log (Console.app) and `jarvis-debug.log`. Both files
+  live in the gitignored, workspace-local `.jarvis/<session>/` (`0600` files in a `0700` dir).
+  `build-app.sh --run` passes that path via `--log-dir`, since the `open`-launched app can't find the
+  repo itself; opening the bundle directly with no `--log-dir` falls back to
+  `~/Library/Application Support/Jarvis/sessions/`. The full privacy posture is in
+  [sandbox.md](./sandbox.md).
 - The viewer's rendering logic (`htmlShell`/`rowScript`) and history reader (`SessionStore`) live in
   `JarvisCore` so they're unit/WebKit-tested; `ActivityViewer` in `JarvisApp` is the thin window.
 
@@ -83,4 +86,5 @@ runtime). It also sidesteps the `file://` `fetch()` restriction that forced the 
 
 Some behavior can only be verified by a human with a real key, a mic, and granted permissions — see
 the checklist in the [README](../README.md#live-smoke-checklist). Run via `./scripts/build-app.sh
---run` and watch each step in the activity viewer (Settings → Activity).
+--run`; review the coaching exchange in the activity viewer (Settings → Activity) and use the
+session's `jarvis-debug.log` for readiness and diagnostic detail.


### PR DESCRIPTION
## Summary

- make `jlog` agent-facing only: Console plus the per-session `jarvis-debug.log`
- restrict `ActivityLog` to typed, human-facing coaching events: heard speech, manual hints, viewed screenshots, and displayed tips
- filter diagnostic rows when browsing sessions written by older builds
- document the activity/debug boundary in the repository agent rules

## Root cause

`jlog` unconditionally mirrored every lifecycle, transport, retry, error, and diagnosis line into `ActivityLog`. The Activity tab therefore behaved like a second debug console instead of a reviewable record of the coaching exchange.

## Impact

The Activity tab now shows the interaction among the interviewer, user, and Jarvis, while coding-agent diagnostics remain available in `jarvis-debug.log`. Existing activity files are not rewritten, but their diagnostic rows are hidden when browsed.

## Validation

- `swift build && ./scripts/run-tests.sh`
- 392 tests across 51 suites passed
- the opt-in live ScreenCaptureKit test remained skipped as expected
- regression coverage verifies the same turn keeps `quiet` and `thinking` details in `jarvis-debug.log` while only its coaching tip reaches `jarvis-activity.jsonl`
