### PR TITLE
fix: harden CLI auth, ghost mode, and session diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,11 +161,20 @@ The squash-merge subject carries the PR number (`type: summary (#N)`).
 - **No secrets in code, ever** — not in source, tests, or examples. The API key lives in an owner-only
   `0600` file (`OPENAI_API_KEY` env var is a headless fallback only); see
   [`wiki/sandbox.md`](./wiki/sandbox.md) for why not the Keychain.
+- **Preserve ghost mode for the whole coaching lifecycle.** From a live pipeline through terminal
+  teardown, no autonomous path may activate Jarvis, change its activation policy, present an alert,
+  sheet, or window, open another app or URL, request attention, post a notification, or play a sound.
+  Only `OverlayCaptionPanel` and `OverlayBoxPanel` may present automatically; both must remain
+  nonactivating and capture-excluded. Runtime failures stop or degrade silently, append fixed typed
+  copy to Activity, and put raw detail only in `jarvis-debug.log`. The persistent menu-bar item,
+  explicit user actions that open Settings/Activity, and unavoidable macOS privacy UI are the named
+  exceptions. Every presentation API call needs an inline `ghost-mode-allowed` reason so
+  `scripts/check-ghost-mode.sh` can enforce the boundary in the normal test gate.
 - **Keep human activity separate from agent diagnostics.** `ActivityLog` is the human-facing coaching
   record: only finalized interviewer/user speech, manual hint requests, screens Jarvis actually viewed,
-  and tips Jarvis displayed belong there. Lifecycle, transport, retry, error, timing, and diagnosis
-  details go through `jlog` to `jarvis-debug.log`. Never mirror `jlog` into `ActivityLog`; when a real
-  coaching event is also useful diagnostically, record the typed activity event explicitly.
+  tips Jarvis displayed, and fixed typed runtime-failure notices belong there. Lifecycle, transport,
+  retry, raw error, timing, and diagnosis details go through `jlog` to `jarvis-debug.log`. Never
+  mirror `jlog` into `ActivityLog`; record the corresponding typed activity event explicitly.
 - **The only screen-/audio-derived data persisted to disk is the per-session log directory** (the
   activity log — spoken tips, transcribed "heard:" lines, the screenshots the model looked at — plus
   the wire-level brain traffic record and its on-demand evaluation report). It is written every run to an

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -180,7 +180,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // in-place reapply must remain ghost-safe even if the queued report executes after stop().
         let wasRunning = transcriber != nil || themTranscriber != nil
         let reportContext: UserFacingError.PresentationContext =
-            !wasRunning && drainingStops == 0 ? .startup : .runtime
+            wasRunning ? .runtime : .startup
         guard let key = secrets.apiKey(), !key.isEmpty else {
             jlog("Jarvis: can't start — no API key.")
             if wasRunning {

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -65,7 +65,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private static let retainedSessions = 10
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        NSApp.setActivationPolicy(.accessory) // menu-bar app, no Dock icon
+        NSApp.setActivationPolicy(.accessory) // ghost-mode-allowed: launch configuration
         MainMenu.install() // an Edit menu so ⌘X/⌘C/⌘V/⌘A work in the Settings text fields
         networkDiagnostics.start()
 
@@ -153,7 +153,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // trip; otherwise beep — there's no live driver/conversation to hint from when stopped.
         hotkeys = HotkeyController()
         hotkeys?.onRequestHint = { [weak self] in
-            guard let self, let fire = self.requestManualHint else { NSSound.beep(); return }
+            guard let self, let fire = self.requestManualHint else {
+                NSSound.beep() // ghost-mode-allowed: explicit user hotkey while stopped
+                return
+            }
             fire()
         }
 
@@ -173,9 +176,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// running — which must NOT be misattributed as a new coaching run.
     @discardableResult
     private func start(freshSession: Bool = true) -> Bool {
+        // Capture whether this Start is replacing a live pipeline before any guard or teardown. An
+        // in-place reapply must remain ghost-safe even if the queued report executes after stop().
+        let wasRunning = transcriber != nil || themTranscriber != nil
+        let reportContext: UserFacingError.PresentationContext =
+            !wasRunning && drainingStops == 0 ? .startup : .runtime
         guard let key = secrets.apiKey(), !key.isEmpty else {
             jlog("Jarvis: can't start — no API key.")
-            errorReporter.report(.noAPIKey)
+            if wasRunning {
+                ActivityLog.shared.record(.settingsChangeNotApplied)
+            }
+            errorReporter.report(.noAPIKey, context: reportContext)
             return false
         }
         // A CLI brain provider's binary must exist before anything is torn down — a failed Start
@@ -185,7 +196,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if brainProvider.usesLocalCLI {
             guard let cli = AgentCLIDetector().detect(brainProvider) else {
                 jlog("Jarvis: can't start — \(brainProvider.displayName) CLI not found.")
-                errorReporter.report(.brainCLIMissing(provider: brainProvider.displayName))
+                if wasRunning {
+                    ActivityLog.shared.record(.settingsChangeNotApplied)
+                }
+                errorReporter.report(.brainCLIMissing(provider: brainProvider.displayName),
+                                     context: reportContext)
                 return false
             }
             switch cli.authenticationStatus {
@@ -193,10 +208,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 break
             case .signedOut:
                 jlog("Jarvis: can't start — \(brainProvider.displayName) isn't signed in.")
-                errorReporter.report(.brainCLINotSignedIn(provider: brainProvider.displayName))
+                if wasRunning {
+                    ActivityLog.shared.record(.settingsChangeNotApplied)
+                }
+                errorReporter.report(.brainCLINotSignedIn(provider: brainProvider.displayName),
+                                     context: reportContext)
                 return false
             case .unknown:
-                errorReporter.report(.brainCLISignInUnconfirmed(provider: brainProvider.displayName))
+                errorReporter.report(.brainCLISignInUnconfirmed(provider: brainProvider.displayName),
+                                     context: reportContext)
             }
             brainCLI = cli
         }
@@ -255,7 +275,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 ActivityLog.shared.record(.coachingStopped(provider: brainProvider))
                 errorReporter.report(.brainCLIStopped(provider: brainProvider.displayName,
                                                        signInCommand: signInCommand,
-                                                       reason: reason))
+                                                       reason: reason),
+                                     context: .runtime)
             }
         } else {
             onBrainFailure = nil
@@ -272,10 +293,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Route turns through TurnTaskBox so Stop can cancel an in-flight one. Concurrent triggers are
         // coalesced inside CoachDriver (the running turn batches them in), so we don't cancel here.
         let turns = TurnTaskBox()
-        // Mic socket gave up (bad key / quota / network): coaching can't continue. Report fatal — the
-        // reporter's onFatal stops the session and corrects the menu (no more lying 🟢).
+        // Mic socket gave up (bad key / quota / network): coaching can't continue. Record only fixed
+        // human-facing copy, then stop through the ghost-safe runtime reporter.
         let onMicTerminalFailure: @Sendable () -> Void = { [errorReporter] in
-            errorReporter.report(.transcriptionStopped)
+            ActivityLog.shared.record(.transcriptionStopped)
+            errorReporter.report(.transcriptionStopped, context: .runtime)
         }
         // "Them" socket gave up: degrade gracefully — stop the system-audio transcriber, keep the mic
         // running. The shared aggregate capture keeps feeding the mic side; its now-nil "them"
@@ -291,7 +313,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.systemConnectionState = .failed
                 self.refreshConnectionUI()
             }
-            errorReporter.report(.systemAudioStopped)
+            ActivityLog.shared.record(.systemAudioStopped)
+            errorReporter.report(.systemAudioStopped, context: .runtime)
         }
 
         // "Me" side: the mic. Drives turn-end and the backing-off silence check ("are you stuck?").
@@ -356,7 +379,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     data, sequenceNumber: sequence, capturedAt: capturedAt)
             })
         capture.onUnavailable = { [errorReporter] reason in
-            errorReporter.report(.captureFailed(reason: reason))
+            ActivityLog.shared.record(.audioCaptureStopped)
+            errorReporter.report(.captureStopped(reason: reason), context: .runtime)
         }
         self.transcriber = transcriber
         self.themTranscriber = themTranscriber
@@ -389,7 +413,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         themTranscriber.connect()
         if let reason = capture.start() {
             stop()                      // tear down the sockets we just opened
-            errorReporter.report(.captureFailed(reason: reason))
+            if reportContext == .runtime {
+                ActivityLog.shared.record(.audioCaptureStopped)
+            }
+            errorReporter.report(.captureFailed(reason: reason), context: reportContext)
             return false
         }
         jlog("Jarvis: coaching starting — verifying realtime transcription connections.")

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -250,6 +250,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if brainProvider.usesLocalCLI {
             let signInCommand = brainProvider == .claudeCode ? "claude auth login" : "codex login"
             onBrainFailure = { [errorReporter] reason in
+                // Preserve ghost mode: the fixed Activity notice is enough for the human-facing
+                // record; the provider's detailed failure stays in jarvis-debug.log below.
+                ActivityLog.shared.record(.coachingStopped(provider: brainProvider))
                 errorReporter.report(.brainCLIStopped(provider: brainProvider.displayName,
                                                        signInCommand: signInCommand,
                                                        reason: reason))

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -188,16 +188,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 errorReporter.report(.brainCLIMissing(provider: brainProvider.displayName))
                 return false
             }
-            if !cli.authenticated {
-                // Codex's auth.json is its only credential store — an absent marker means signed
-                // out for real, and every brain turn would fail: don't open a pipeline that can
-                // never coach. Claude may keep credentials only in the macOS Keychain (a false
-                // negative), so it proceeds with a visible degraded notice instead of a lockout.
-                if brainProvider == .codexCLI {
-                    jlog("Jarvis: can't start — \(brainProvider.displayName) isn't signed in.")
-                    errorReporter.report(.brainCLINotSignedIn(provider: brainProvider.displayName))
-                    return false
-                }
+            switch cli.authenticationStatus {
+            case .signedIn:
+                break
+            case .signedOut:
+                jlog("Jarvis: can't start — \(brainProvider.displayName) isn't signed in.")
+                errorReporter.report(.brainCLINotSignedIn(provider: brainProvider.displayName))
+                return false
+            case .unknown:
                 errorReporter.report(.brainCLISignInUnconfirmed(provider: brainProvider.displayName))
             }
             brainCLI = cli
@@ -245,12 +243,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                            traffic: sessionTraffic, trafficTag: "summarizer")
         }
         let brain = RetryingBrainClient(base: coachBase)
+        // A token can expire after the bounded Start preflight, and other runtime failures remain
+        // possible. If the actual CLI request fails, surface the reason and stop the green-but-
+        // unusable session instead of silently ignoring every later utterance.
+        let onBrainFailure: (@Sendable (String) -> Void)?
+        if brainProvider.usesLocalCLI {
+            let signInCommand = brainProvider == .claudeCode ? "claude auth login" : "codex login"
+            onBrainFailure = { [errorReporter] reason in
+                errorReporter.report(.brainCLIStopped(provider: brainProvider.displayName,
+                                                       signInCommand: signInCommand,
+                                                       reason: reason))
+            }
+        } else {
+            onBrainFailure = nil
+        }
         // Fan each spoken tip out to both the Overlay Caption and the persistent Overlay Box.
         let overlaySink = BroadcastOverlay([overlayCaption, overlayBox])
         let driver = CoachDriver(config: config, transcript: transcript,
                                  brain: brain, summarizer: summarizer,
                                  screen: WindowScopedScreenCapture(preferences: screenPreferences),
-                                 overlay: overlaySink, clock: clock)
+                                 overlay: overlaySink, clock: clock,
+                                 onBrainFailure: onBrainFailure)
 
         // CoachDriver is @unchecked Sendable; capture it (not @MainActor self) in the callbacks.
         // Route turns through TurnTaskBox so Stop can cancel an in-flight one. Concurrent triggers are

--- a/Sources/JarvisApp/App/ErrorReporter.swift
+++ b/Sources/JarvisApp/App/ErrorReporter.swift
@@ -3,17 +3,18 @@ import JarvisCore
 
 /// The single funnel for user-facing failures. Every error in the app is reported here; severity
 /// decides the response — `.fatal` pops a modal alert AND tears the session down (`onFatal`),
-/// `.warning` pops the alert but leaves any running session untouched (preflight failures),
-/// `.degraded` is logged only. The only place an *error* `NSAlert` is raised (confirmation prompts,
-/// e.g. ActivityViewer's clear-history, are a separate concern and don't route here).
+/// `.terminal` tears the session down without activating the app, `.warning` pops the alert but
+/// leaves any running session untouched (preflight failures), and `.degraded` is logged only. The
+/// only place an *error* `NSAlert` is raised (confirmation prompts, e.g. ActivityViewer's
+/// clear-history, are a separate concern and don't route here).
 ///
 /// Diagnostics stay in the agent-facing `JarvisLog`/`jlog` debug log; this type owns *user-facing
 /// surfacing + session-lifecycle consequence*. `report(_:)` is `nonisolated` so any
 /// thread (the capture IOProc, a URLSession delegate) can call it directly; it hops to the main actor.
 @MainActor
 final class ErrorReporter {
-    /// Invoked for a `.fatal` error (on the main actor) to stop the running session and correct the
-    /// menu. Wired by `AppDelegate` once the menu bar exists.
+    /// Invoked for an error whose severity stops the session (on the main actor), correcting the
+    /// menu without requiring a modal alert. Wired by `AppDelegate` once the menu bar exists.
     var onFatal: (() -> Void)?
 
     nonisolated func report(_ error: UserFacingError) {

--- a/Sources/JarvisApp/App/ErrorReporter.swift
+++ b/Sources/JarvisApp/App/ErrorReporter.swift
@@ -1,12 +1,11 @@
 import AppKit
 import JarvisCore
 
-/// The single funnel for user-facing failures. Every error in the app is reported here; severity
-/// decides the response — `.fatal` pops a modal alert AND tears the session down (`onFatal`),
-/// `.terminal` tears the session down without activating the app, `.warning` pops the alert but
-/// leaves any running session untouched (preflight failures), and `.degraded` is logged only. The
-/// only place an *error* `NSAlert` is raised (confirmation prompts, e.g. ActivityViewer's
-/// clear-history, are a separate concern and don't route here).
+/// The single funnel for user-facing failures. Severity decides the lifecycle consequence; the
+/// call-site context decides whether a startup alert is permitted. Runtime failures never activate
+/// the app or present UI, even when they stop the session. The only place an *error* `NSAlert` is
+/// raised (confirmation prompts, e.g. ActivityViewer's clear-history, are a separate concern and
+/// don't route here).
 ///
 /// Diagnostics stay in the agent-facing `JarvisLog`/`jlog` debug log; this type owns *user-facing
 /// surfacing + session-lifecycle consequence*. `report(_:)` is `nonisolated` so any
@@ -17,19 +16,21 @@ final class ErrorReporter {
     /// menu without requiring a modal alert. Wired by `AppDelegate` once the menu bar exists.
     var onFatal: (() -> Void)?
 
-    nonisolated func report(_ error: UserFacingError) {
-        Task { @MainActor in self.present(error) }
+    nonisolated func report(_ error: UserFacingError,
+                            context: UserFacingError.PresentationContext) {
+        Task { @MainActor in self.present(error, context: context) }
     }
 
-    private func present(_ error: UserFacingError) {
+    private func present(_ error: UserFacingError,
+                         context: UserFacingError.PresentationContext) {
         jlog("Jarvis: \(error.severity) — \(error.title): \(error.message)")  // diagnostics still go to JarvisLog
         if error.severity.stopsSession { onFatal?() }
-        guard error.severity.showsAlert else { return }
-        NSApp.activate(ignoringOtherApps: true)
-        let alert = NSAlert()
+        guard error.severity.showsAlert(in: context) else { return }
+        NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit startup failure
+        let alert = NSAlert() // ghost-mode-allowed: explicit startup failure
         alert.messageText = error.title
         alert.informativeText = error.message
         alert.alertStyle = .warning
-        alert.runModal()
+        alert.runModal() // ghost-mode-allowed: explicit startup failure
     }
 }

--- a/Sources/JarvisApp/Settings/BrainSection.swift
+++ b/Sources/JarvisApp/Settings/BrainSection.swift
@@ -98,11 +98,12 @@ final class BrainSection: NSObject, SettingsSection {
 
         apiKey.addControls(to: view, top: 112)
 
-        refreshDetection()
         return view
     }
 
-    /// Re-probe on every show so an install or sign-in completed while the app was open appears.
+    /// Populate on initial activation and re-probe on every later show so an install or sign-in
+    /// completed while the app was open appears. `makeView()` deliberately does not probe: the
+    /// Settings host activates the initial tab immediately after building all section views.
     func didBecomeActive() {
         refreshDetection()
     }

--- a/Sources/JarvisApp/Settings/BrainSection.swift
+++ b/Sources/JarvisApp/Settings/BrainSection.swift
@@ -6,11 +6,11 @@ import JarvisCore
 /// active, and the OpenAI API key — one tab, because the four choices are one decision. The model
 /// list is per provider (each remembers its own); the effort is one global setting applied to all
 /// three, mapped onto each CLI's scale by `CLIBrainClient`. Installed CLIs are auto-detected
-/// (re-probed every time the tab is shown, it's pure file checks), so switching to one is a single
-/// radio click. Selections persist immediately through `BrainPreferences`; changes take effect on
-/// the next Start, since the brain client is built once per coaching run. The transcription model
-/// is deliberately NOT here; it's a separate concern — which is also why the key stays required:
-/// transcription always runs on it.
+/// whenever the tab is shown; Claude's bounded status command distinguishes signed in, signed out,
+/// and an unavailable probe. Selections persist immediately through `BrainPreferences`; changes
+/// take effect on the next Start, since the brain client is built once per coaching run. The
+/// transcription model is deliberately NOT here; it's a separate concern — which is also why the
+/// key stays required: transcription always runs on it.
 @MainActor
 final class BrainSection: NSObject, SettingsSection {
     let title = "Brain"
@@ -102,8 +102,7 @@ final class BrainSection: NSObject, SettingsSection {
         return view
     }
 
-    /// Re-probe on every show: instant (file checks only), and it catches a CLI installed or signed
-    /// in while the app was already running.
+    /// Re-probe on every show so an install or sign-in completed while the app was open appears.
     func didBecomeActive() {
         refreshDetection()
     }
@@ -112,12 +111,17 @@ final class BrainSection: NSObject, SettingsSection {
     /// selected provider.
     private func refreshDetection() {
         let selected = preferences.provider
+        let detected = Dictionary(uniqueKeysWithValues: detector.detectAll().map { ($0.provider, $0) })
         for (provider, radio) in radios {
             var title = provider.displayName
             var enabled = true
             if provider.usesLocalCLI {
-                if let cli = detector.detect(provider) {
-                    title += cli.authenticated ? " — detected, signed in" : " — detected"
+                if let cli = detected[provider] {
+                    switch cli.authenticationStatus {
+                    case .signedIn: title += " — detected, signed in"
+                    case .signedOut: title += " — detected, signed out"
+                    case .unknown: title += " — detected, sign-in unknown"
+                    }
                 } else {
                     title += " — not installed"
                     enabled = false
@@ -130,8 +134,15 @@ final class BrainSection: NSObject, SettingsSection {
             radio.state = provider == selected ? .on : .off
         }
         var note = Self.note(for: selected)
-        if selected.usesLocalCLI, let cli = detector.detect(selected), !cli.authenticated {
-            note += " Couldn't confirm it's signed in — run the CLI once if turns fail."
+        if selected.usesLocalCLI, let cli = detected[selected] {
+            switch cli.authenticationStatus {
+            case .signedIn:
+                break
+            case .signedOut:
+                note += " Sign in through the CLI before starting Jarvis."
+            case .unknown:
+                note += " Couldn't check its sign-in status — run the CLI once if turns fail."
+            }
         }
         providerNote?.stringValue = note
         reloadModels(for: selected)

--- a/Sources/JarvisApp/Settings/SettingsWindow.swift
+++ b/Sources/JarvisApp/Settings/SettingsWindow.swift
@@ -32,14 +32,14 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
 
     func show() {
         if let window {
-            NSApp.activate(ignoringOtherApps: true)
-            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit Settings action
+            window.makeKeyAndOrderFront(nil) // ghost-mode-allowed: explicit Settings action
             return
         }
         build()
-        NSApp.setActivationPolicy(.regular)
-        NSApp.activate(ignoringOtherApps: true)
-        window?.makeKeyAndOrderFront(nil)
+        NSApp.setActivationPolicy(.regular) // ghost-mode-allowed: explicit Settings action
+        NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit Settings action
+        window?.makeKeyAndOrderFront(nil) // ghost-mode-allowed: explicit Settings action
     }
 
     private func build() {
@@ -99,7 +99,7 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
         activeSection?.didResignActive()        // e.g. turn the overlay preview off if Overlay was open
         activeSection = nil
         for section in sections { section.windowWillClose() }
-        NSApp.setActivationPolicy(.accessory)   // back to menu-bar-only
+        NSApp.setActivationPolicy(.accessory) // ghost-mode-allowed: close explicit Settings action
         window = nil
         tabView = nil
     }

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -26,6 +26,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
     private var sessionIDField: NSTextField?
     private var copySessionIDButton: NSButton?
     private var evaluateButton: NSButton?
+    private var clearHistoryButton: NSButton?
     private var isEvaluating = false      // an audit is in flight; keep the button disabled meanwhile
     private var sessions: [SessionStore.Session] = []
 
@@ -92,6 +93,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         clear.frame = NSRect(x: content.bounds.width - 134, y: 36, width: 120, height: 28)
         clear.autoresizingMask = [.minXMargin]
         header.addSubview(clear)
+        self.clearHistoryButton = clear
 
         let idLabel = NSTextField(labelWithString: "Session ID")
         idLabel.frame = NSRect(x: 14, y: 11, width: 60, height: 18)
@@ -138,6 +140,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         sessionIDField = nil
         copySessionIDButton = nil
         evaluateButton = nil
+        clearHistoryButton = nil
         loaded = false
         pending = []
         snapshotRows = []
@@ -200,14 +203,14 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         refreshEvaluateButtonState()
     }
 
-    /// Evaluate is enabled only for a *finished* conversation: any past session, or the current one
-    /// once coaching is stopped. A live session's traffic file is still being appended to, so an
-    /// audit of it would judge half a story. A session that already has a persisted report flips the
-    /// button to "Open report" instead — reopening the saved audit is free and always safe, so it
-    /// stays enabled regardless of coaching state. Owns the title too: `isEvaluating` survives a
-    /// Settings close/reopen (the viewer outlives its content view), so a rebuilt button mid-audit
-    /// correctly shows "Evaluating…" disabled instead of inviting a duplicate audit.
+    /// Evaluate and Clear stay disabled for the entire coaching lifecycle. Past-session evaluation
+    /// is data-safe while another session runs, but its asynchronous completion can otherwise open
+    /// a browser or alert mid-session. Owns the title too: `isEvaluating` survives a Settings
+    /// close/reopen (the viewer outlives its content view), so a rebuilt button mid-audit correctly
+    /// shows "Evaluating…" disabled instead of inviting a duplicate audit.
     private func refreshEvaluateButtonState() {
+        let coachingRunning = isCoachingRunning?() == true
+        clearHistoryButton?.isEnabled = !coachingRunning
         guard let button = evaluateButton else { return }
         if isEvaluating {
             button.title = "Evaluating…"
@@ -220,6 +223,12 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
             return
         }
         let session = sessions[idx]
+        if coachingRunning {
+            button.title = SessionEvaluator.savedReport(in: session.url) == nil ? "Evaluate" : "Open report"
+            button.toolTip = "Stop Jarvis before evaluating or opening a report"
+            button.isEnabled = false
+            return
+        }
         if SessionEvaluator.savedReport(in: session.url) != nil {
             button.title = "Open report"
             button.toolTip = "Open this session's evaluation report in your browser"
@@ -227,7 +236,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         } else {
             button.title = "Evaluate"
             button.toolTip = "Send this session's recorded LLM traffic to the brain model for a context-engineering audit (stopped sessions only)"
-            button.isEnabled = !(session.isCurrent && (isCoachingRunning?() ?? false))
+            button.isEnabled = true
         }
     }
 
@@ -297,18 +306,17 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
     /// show (and persist) the resulting audit report. A session that was already evaluated just
     /// reopens its saved report — no re-billing. Only *stopped* conversations qualify for a fresh
     /// audit: any past session, or the current one once coaching is stopped. The button is already
-    /// disabled for the live session (`refreshEvaluateButtonState`); the guard here is the
+    /// disabled while any session runs (`refreshEvaluateButtonState`); the guard here is the
     /// race-proof backstop for a click that lands exactly as a Start flips the state.
     @objc private func evaluateTapped() {
+        guard isCoachingRunning?() != true else {
+            jlog("Jarvis: suppressed Activity evaluation presentation while coaching is running.")
+            return
+        }
         guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else { return }
         let session = sessions[idx]
         if let report = SessionEvaluator.savedReport(in: session.url) {
             openReport(report, for: session)
-            return
-        }
-        if session.isCurrent, isCoachingRunning?() == true {
-            info("Session still running",
-                 "Evaluation works on a finished conversation. Stop Jarvis first, then evaluate this session.")
             return
         }
         guard SessionEvaluator.hasTraffic(in: session.url) else {
@@ -341,32 +349,44 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
     /// the `.md`) and hand the page to the default browser. The page carries a "Copy as Markdown"
     /// button so the raw report can be pasted into an agent chat to work on the findings.
     private func openReport(_ report: String, for session: SessionStore.Session) {
+        guard isCoachingRunning?() != true else {
+            jlog("Jarvis: evaluation completed while coaching is running; report saved without opening a browser.")
+            return
+        }
         do {
             let url = try EvalReportPage.write(markdown: report, in: session.url,
                                                title: "Session evaluation — \(session.label)")
-            NSWorkspace.shared.open(url)
+            NSWorkspace.shared.open(url) // ghost-mode-allowed: guarded explicit Activity action
         } catch {
             info("Couldn't write the report page", error.localizedDescription)
         }
     }
 
     private func info(_ title: String, _ message: String) {
-        let alert = NSAlert()
+        guard isCoachingRunning?() != true else {
+            jlog("Jarvis: suppressed Activity alert while coaching is running — \(title): \(message)")
+            return
+        }
+        let alert = NSAlert() // ghost-mode-allowed: guarded explicit Activity action
         alert.messageText = title
         alert.informativeText = message
-        alert.runModal()
+        alert.runModal() // ghost-mode-allowed: guarded explicit Activity action
     }
 
     // MARK: - Clear history
 
     @objc private func clearHistoryTapped() {
-        let alert = NSAlert()
+        guard isCoachingRunning?() != true else {
+            jlog("Jarvis: suppressed Clear history confirmation while coaching is running.")
+            return
+        }
+        let alert = NSAlert() // ghost-mode-allowed: guarded explicit Activity action
         alert.messageText = "Clear session history?"
         alert.informativeText = "This permanently deletes all previous sessions (logs and screenshots). The current session is kept."
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Clear")
         alert.addButton(withTitle: "Cancel")
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        guard alert.runModal() == .alertFirstButtonReturn else { return } // ghost-mode-allowed: guarded explicit Activity action
         store.clearHistory()
         populatePicker()
         loadCurrent()   // the viewed session may be gone; fall back to the live one

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -23,6 +23,8 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
 
     private var webView: WKWebView?
     private var picker: NSPopUpButton?
+    private var sessionIDField: NSTextField?
+    private var copySessionIDButton: NSButton?
     private var evaluateButton: NSButton?
     private var isEvaluating = false      // an audit is in flight; keep the button disabled meanwhile
     private var sessions: [SessionStore.Session] = []
@@ -54,18 +56,22 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         let content = NSView(frame: NSRect(x: 0, y: 0, width: 560, height: 420))
         content.autoresizingMask = [.width, .height]
 
-        let header = NSVisualEffectView(frame: NSRect(x: 0, y: content.bounds.height - 44, width: content.bounds.width, height: 44))
+        let headerHeight: CGFloat = 72
+        let header = NSVisualEffectView(frame: NSRect(x: 0,
+                                                      y: content.bounds.height - headerHeight,
+                                                      width: content.bounds.width,
+                                                      height: headerHeight))
         header.autoresizingMask = [.width, .minYMargin]
         header.material = .headerView
         header.blendingMode = .withinWindow
         header.state = .active
 
         let sessionLabel = NSTextField(labelWithString: "Session")
-        sessionLabel.frame = NSRect(x: 14, y: 13, width: 60, height: 18)
+        sessionLabel.frame = NSRect(x: 14, y: 41, width: 60, height: 18)
         sessionLabel.textColor = .secondaryLabelColor
         header.addSubview(sessionLabel)
 
-        let pop = NSPopUpButton(frame: NSRect(x: 76, y: 8, width: 240, height: 26))
+        let pop = NSPopUpButton(frame: NSRect(x: 76, y: 36, width: 230, height: 26))
         pop.target = self
         pop.action = #selector(sessionChanged)
         pop.toolTip = "Switch between this and previous sessions"
@@ -75,7 +81,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
 
         let evaluate = NSButton(title: "Evaluate", target: self, action: #selector(evaluateTapped))
         evaluate.bezelStyle = .rounded
-        evaluate.frame = NSRect(x: content.bounds.width - 246, y: 8, width: 104, height: 28)
+        evaluate.frame = NSRect(x: content.bounds.width - 246, y: 36, width: 104, height: 28)
         evaluate.autoresizingMask = [.minXMargin]
         header.addSubview(evaluate)
         self.evaluateButton = evaluate
@@ -83,11 +89,35 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         let clear = NSButton(title: "Clear history", target: self, action: #selector(clearHistoryTapped))
         clear.bezelStyle = .rounded
         clear.toolTip = "Delete all previous sessions (keeps the current one)"
-        clear.frame = NSRect(x: content.bounds.width - 134, y: 8, width: 120, height: 28)
+        clear.frame = NSRect(x: content.bounds.width - 134, y: 36, width: 120, height: 28)
         clear.autoresizingMask = [.minXMargin]
         header.addSubview(clear)
 
-        let wv = WKWebView(frame: NSRect(x: 0, y: 0, width: content.bounds.width, height: content.bounds.height - 44))
+        let idLabel = NSTextField(labelWithString: "Session ID")
+        idLabel.frame = NSRect(x: 14, y: 11, width: 60, height: 18)
+        idLabel.textColor = .secondaryLabelColor
+        header.addSubview(idLabel)
+
+        let idField = NSTextField(labelWithString: "")
+        idField.frame = NSRect(x: 76, y: 9, width: 240, height: 20)
+        idField.font = .monospacedSystemFont(ofSize: NSFont.smallSystemFontSize, weight: .regular)
+        idField.isSelectable = true
+        idField.lineBreakMode = .byTruncatingTail
+        idField.toolTip = "Exact session directory ID; select it to copy"
+        header.addSubview(idField)
+        self.sessionIDField = idField
+
+        let copyID = NSButton(title: "Copy ID", target: self, action: #selector(copySessionIDTapped))
+        copyID.bezelStyle = .rounded
+        copyID.frame = NSRect(x: 324, y: 5, width: 78, height: 28)
+        copyID.toolTip = "Copy the exact session ID"
+        copyID.autoresizingMask = [.maxXMargin]
+        header.addSubview(copyID)
+        self.copySessionIDButton = copyID
+
+        let wv = WKWebView(frame: NSRect(x: 0, y: 0,
+                                        width: content.bounds.width,
+                                        height: content.bounds.height - headerHeight))
         wv.autoresizingMask = [.width, .height]
         wv.navigationDelegate = self
 
@@ -105,6 +135,8 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         log.detach()
         webView = nil
         picker = nil
+        sessionIDField = nil
+        copySessionIDButton = nil
         evaluateButton = nil
         loaded = false
         pending = []
@@ -134,6 +166,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         if let idx = sessions.firstIndex(where: { $0.isCurrent }) {
             picker?.selectItem(at: idx)
         }
+        refreshSessionID()
         refreshEvaluateButtonState()
     }
 
@@ -141,7 +174,24 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else { return }
         let s = sessions[idx]
         if s.isCurrent { loadCurrent() } else { loadPast(s) }
+        refreshSessionID()
         refreshEvaluateButtonState()
+    }
+
+    private func refreshSessionID() {
+        guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else {
+            sessionIDField?.stringValue = ""
+            copySessionIDButton?.isEnabled = false
+            return
+        }
+        sessionIDField?.stringValue = sessions[idx].id
+        copySessionIDButton?.isEnabled = true
+    }
+
+    @objc private func copySessionIDTapped() {
+        guard let idx = picker?.indexOfSelectedItem, sessions.indices.contains(idx) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(sessions[idx].id, forType: .string)
     }
 
     /// Coaching started or stopped (AppDelegate calls this from Start/Stop): the live session just

--- a/Sources/JarvisCore/Brain/AgentCLIAuthenticationStatus.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIAuthenticationStatus.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// What Jarvis can establish about a detected local brain CLI's current sign-in state.
+/// `unknown` is distinct from signed out so a failed or timed-out status probe never becomes a
+/// false logout claim.
+public enum AgentCLIAuthenticationStatus: Sendable, Equatable {
+    case signedIn
+    case signedOut
+    case unknown
+}

--- a/Sources/JarvisCore/Brain/AgentCLIDetector.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIDetector.swift
@@ -84,6 +84,10 @@ public struct AgentCLIDetector: Sendable {
         let loggedIn: Bool
     }
 
+    /// The status document is tiny. This is only a runaway-output backstop for a broken wrapper,
+    /// and keeps the post-timeout pipe drain bounded in both time and memory.
+    private static let maxClaudeAuthStatusBytes = 64 * 1_024
+
     /// Claude's own status command reads whichever credential store that installation uses and does
     /// not make a model request. A malformed result or timeout is `unknown`, never "signed out".
     private func claudeAuthenticationStatus(executable: URL) -> AgentCLIAuthenticationStatus {
@@ -122,10 +126,39 @@ public struct AgentCLIDetector: Sendable {
         process.waitUntilExit()
         terminator.cancel()
         killer.cancel()
-        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        let data = Self.readAvailableOutput(stdout.fileHandleForReading)
         guard let status = try? JSONDecoder().decode(ClaudeAuthStatus.self, from: data) else {
             return .unknown
         }
         return status.loggedIn ? .signedIn : .signedOut
+    }
+
+    /// Drain only bytes already available after the wrapper exits. A wrapper may leave a child
+    /// holding the inherited stdout pipe open; a blocking `readDataToEndOfFile()` would then defeat
+    /// the process watchdog while waiting for that unrelated child to close its writer.
+    private static func readAvailableOutput(_ handle: FileHandle) -> Data {
+        let descriptor = handle.fileDescriptor
+        let flags = fcntl(descriptor, F_GETFL)
+        guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) >= 0 else {
+            try? handle.close()
+            return Data()
+        }
+        defer { try? handle.close() }
+
+        var output = Data()
+        var buffer = [UInt8](repeating: 0, count: 4_096)
+        while output.count < maxClaudeAuthStatusBytes {
+            let capacity = min(buffer.count, maxClaudeAuthStatusBytes - output.count)
+            let count = read(descriptor, &buffer, capacity)
+            if count > 0 {
+                output.append(contentsOf: buffer.prefix(Int(count)))
+                continue
+            }
+            if count == 0 { break }
+            if errno == EINTR { continue }
+            if errno == EAGAIN || errno == EWOULDBLOCK { break }
+            return Data()
+        }
+        return output
     }
 }

--- a/Sources/JarvisCore/Brain/AgentCLIDetector.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIDetector.swift
@@ -1,17 +1,25 @@
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 
-/// Finds installed `claude` / `codex` CLIs by probing the filesystem — no subprocess is spawned, so
-/// detection is instant and safe to run every time the Settings tab opens. The home directory and
-/// PATH are injectable (tests point them at a fixture directory, mirroring how `BrainPreferences`
-/// takes a `UserDefaults(suiteName:)`); the file checks themselves are the real FileManager.
+/// Finds installed `claude` / `codex` CLIs and checks their sign-in state. Binary discovery stays a
+/// pure filesystem probe. Claude authentication comes from its non-billing `auth status --json`
+/// command because its on-disk account marker can survive an expired OAuth session; the command is
+/// bounded so Settings cannot hang on a broken CLI. Codex's auth file remains authoritative.
 public struct AgentCLIDetector: Sendable {
     private let home: URL
     private let pathVariable: String?
+    private let authStatusTimeout: TimeInterval
 
     public init(home: URL = URL(fileURLWithPath: NSHomeDirectory()),
-                pathVariable: String? = ProcessInfo.processInfo.environment["PATH"]) {
+                pathVariable: String? = ProcessInfo.processInfo.environment["PATH"],
+                authStatusTimeout: TimeInterval = 2) {
         self.home = home
         self.pathVariable = pathVariable
+        self.authStatusTimeout = authStatusTimeout
     }
 
     /// All CLI providers found on this machine, in `BrainProvider` declaration order.
@@ -25,7 +33,7 @@ public struct AgentCLIDetector: Sendable {
         guard let name = provider.cliExecutableName else { return nil }
         guard let url = firstExecutable(named: name) else { return nil }
         return DetectedAgentCLI(provider: provider, executableURL: url,
-                                authenticated: isAuthenticated(provider))
+                                authenticationStatus: authenticationStatus(provider, executable: url))
     }
 
     /// The common install locations consulted after $PATH — the single source of truth, also used
@@ -58,24 +66,66 @@ public struct AgentCLIDetector: Sendable {
         return nil
     }
 
-    /// On-disk auth markers per CLI. Claude Code writes `~/.claude/.credentials.json` where no
-    /// Keychain is available and records the OAuth account in `~/.claude.json`; Codex keeps its
-    /// ChatGPT-login token in `~/.codex/auth.json`. Deliberately NOT probed via the Keychain
-    /// (`security` can trigger a password prompt) or by running the CLI (slow, may bill a request).
-    private func isAuthenticated(_ provider: BrainProvider) -> Bool {
-        let fm = FileManager.default
+    private func authenticationStatus(_ provider: BrainProvider, executable: URL)
+        -> AgentCLIAuthenticationStatus {
         switch provider {
         case .openAI:
-            return false
+            return .unknown
         case .claudeCode:
-            if fm.fileExists(atPath: home.appendingPathComponent(".claude/.credentials.json").path) {
-                return true
-            }
-            let settings = try? String(contentsOf: home.appendingPathComponent(".claude.json"),
-                                       encoding: .utf8)
-            return settings?.contains("\"oauthAccount\"") == true
+            return claudeAuthenticationStatus(executable: executable)
         case .codexCLI:
-            return fm.fileExists(atPath: home.appendingPathComponent(".codex/auth.json").path)
+            return FileManager.default.fileExists(
+                atPath: home.appendingPathComponent(".codex/auth.json").path
+            ) ? .signedIn : .signedOut
         }
+    }
+
+    private struct ClaudeAuthStatus: Decodable {
+        let loggedIn: Bool
+    }
+
+    /// Claude's own status command reads whichever credential store that installation uses and does
+    /// not make a model request. A malformed result or timeout is `unknown`, never "signed out".
+    private func claudeAuthenticationStatus(executable: URL) -> AgentCLIAuthenticationStatus {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = ["auth", "status", "--json"]
+        process.standardInput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let stdout = Pipe()
+        process.standardOutput = stdout
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = home.path
+        let extraDirectories = [executable.deletingLastPathComponent().path]
+            + Self.fallbackDirectories(home: home)
+        environment["PATH"] = ([pathVariable].compactMap { $0 } + extraDirectories)
+            .joined(separator: ":")
+        environment.removeValue(forKey: "OPENAI_API_KEY")
+        process.environment = environment
+
+        do {
+            try process.run()
+        } catch {
+            return .unknown
+        }
+
+        // `Process` termination callbacks can be delayed while the test runner or app is busy.
+        // Wait for the child directly and bound that wait with pid-only watchdogs, matching the
+        // production CLI runner without capturing the non-Sendable Process in GCD closures.
+        let pid = process.processIdentifier
+        let timeout = max(0.01, authStatusTimeout)
+        let terminator = DispatchWorkItem { kill(pid, SIGTERM) }
+        let killer = DispatchWorkItem { kill(pid, SIGKILL) }
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout, execute: terminator)
+        DispatchQueue.global().asyncAfter(deadline: .now() + timeout + 1, execute: killer)
+        process.waitUntilExit()
+        terminator.cancel()
+        killer.cancel()
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        guard let status = try? JSONDecoder().decode(ClaudeAuthStatus.self, from: data) else {
+            return .unknown
+        }
+        return status.loggedIn ? .signedIn : .signedOut
     }
 }

--- a/Sources/JarvisCore/Brain/DetectedAgentCLI.swift
+++ b/Sources/JarvisCore/Brain/DetectedAgentCLI.swift
@@ -4,14 +4,12 @@ import Foundation
 public struct DetectedAgentCLI: Sendable, Equatable {
     public let provider: BrainProvider
     public let executableURL: URL
-    /// Best-effort "signed in" check from the CLI's on-disk auth markers. A false negative is
-    /// possible (e.g. Claude Code storing credentials only in the Keychain), so callers should treat
-    /// this as a hint for the UI, never as a hard gate.
-    public let authenticated: Bool
+    public let authenticationStatus: AgentCLIAuthenticationStatus
 
-    public init(provider: BrainProvider, executableURL: URL, authenticated: Bool) {
+    public init(provider: BrainProvider, executableURL: URL,
+                authenticationStatus: AgentCLIAuthenticationStatus) {
         self.provider = provider
         self.executableURL = executableURL
-        self.authenticated = authenticated
+        self.authenticationStatus = authenticationStatus
     }
 }

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -46,6 +46,10 @@ public final class CoachDriver: @unchecked Sendable {
     /// nothing is dropped and turns don't pile up. The first such trigger is kept and the batched
     /// speech rides along via the sent-index, so a later trigger needn't displace it.
     private var pendingTrigger: TriggerReason?
+    /// Latched only when the app supplied `onBrainFailure`, which means this provider failure is
+    /// terminal for the session. It prevents pending or newly arriving triggers from issuing another
+    /// request while the app's main-actor stop is still being scheduled.
+    private var terminalBrainFailure = false
 
     public init(config: Config, transcript: RollingTranscript,
                 brain: BrainClient, summarizer: BrainClient? = nil,
@@ -74,16 +78,31 @@ public final class CoachDriver: @unchecked Sendable {
 
     /// Atomically claim the single in-flight slot, OR (if busy) record the trigger as pending. One
     /// critical section so a trigger can never slip between "am I busy?" and "set pending" and be lost.
-    /// Returns true if this call now owns the turn loop. The first pending trigger is kept; the
-    /// coalesced speech rides along regardless, so a later trigger needn't displace it.
-    private func claimOrPend(_ reason: TriggerReason) -> Bool {
+    /// Returns whether this call owns the loop, was queued behind it, or arrived after a terminal
+    /// provider failure. The first pending trigger is kept; the coalesced speech rides along
+    /// regardless, so a later trigger needn't displace it.
+    private enum TriggerClaim {
+        case claimed
+        case pending
+        case terminalFailure
+    }
+
+    private func claimOrPend(_ reason: TriggerReason) -> TriggerClaim {
         stateLock.lock(); defer { stateLock.unlock() }
+        if terminalBrainFailure { return .terminalFailure }
         if isHandling {
             if pendingTrigger == nil { pendingTrigger = reason }
-            return false
+            return .pending
         }
         isHandling = true
-        return true
+        return .claimed
+    }
+
+    private func latchTerminalBrainFailure() {
+        stateLock.lock()
+        terminalBrainFailure = true
+        pendingTrigger = nil
+        stateLock.unlock()
     }
 
     /// Atomically take the next pending trigger (keeping the slot) OR release the slot. One critical
@@ -100,9 +119,15 @@ public final class CoachDriver: @unchecked Sendable {
         // Single-in-flight, but we COALESCE rather than drop: a trigger arriving while a turn runs is
         // recorded as pending and picked up by the running turn when it finishes — so nothing is lost
         // and turns can't pile up. The batched speech rides along automatically via the sent-index.
-        guard claimOrPend(reason) else {
+        switch claimOrPend(reason) {
+        case .claimed:
+            break
+        case .pending:
             jlog("… busy; batching this \(reason) into the running turn")
             return .busy
+        case .terminalFailure:
+            jlog("… terminal brain failure already ended this coaching session")
+            return .brainError
         }
         var current = reason
         var outcome: TurnOutcome = .silentByModel
@@ -204,6 +229,7 @@ public final class CoachDriver: @unchecked Sendable {
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
                 let detail = error.localizedDescription
                 jlog("Jarvis coach: brain request failed on \(reason): \(detail)")
+                if onBrainFailure != nil { latchTerminalBrainFailure() }
                 onBrainFailure?(detail)
                 // Speech already marked sent (a later-iteration failure) must not vanish from memory —
                 // commit what this turn accumulated. A first-request failure commits nothing; the

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -28,6 +28,9 @@ public final class CoachDriver: @unchecked Sendable {
     private let screen: ScreenCapturing
     private let overlay: OverlayRendering
     private let clock: Clock
+    /// The app edge uses this to surface a provider failure and end a session that can no longer
+    /// coach. Nil keeps Core-only callers/tests free of UI policy.
+    private let onBrainFailure: (@Sendable (String) -> Void)?
     private let sessionStart: TimeInterval
     private let history = CoachHistory()
 
@@ -46,7 +49,8 @@ public final class CoachDriver: @unchecked Sendable {
 
     public init(config: Config, transcript: RollingTranscript,
                 brain: BrainClient, summarizer: BrainClient? = nil,
-                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock) {
+                screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock,
+                onBrainFailure: (@Sendable (String) -> Void)? = nil) {
         self.config = config
         self.transcript = transcript
         self.brain = brain
@@ -54,6 +58,7 @@ public final class CoachDriver: @unchecked Sendable {
         self.screen = screen
         self.overlay = overlay
         self.clock = clock
+        self.onBrainFailure = onBrainFailure
         self.sessionStart = clock.now()
     }
 
@@ -197,7 +202,9 @@ public final class CoachDriver: @unchecked Sendable {
             } catch {
                 // A cancellation (barge-in / Stop) is expected — report it quietly, not as a failure.
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
-                jlog("Jarvis coach: brain request failed on \(reason): \(error.localizedDescription)")
+                let detail = error.localizedDescription
+                jlog("Jarvis coach: brain request failed on \(reason): \(detail)")
+                onBrainFailure?(detail)
                 // Speech already marked sent (a later-iteration failure) must not vanish from memory —
                 // commit what this turn accumulated. A first-request failure commits nothing; the
                 // un-advanced sentCount re-sends the delta next turn instead.

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-/// The model behind the human-facing activity viewer. It records only the coaching exchange — heard
-/// speech, manual hint requests, screens Jarvis viewed, and tips Jarvis gave — then pushes those
+/// The model behind the human-facing activity viewer. It records the coaching exchange — heard
+/// speech, manual hint requests, screens Jarvis viewed, and tips Jarvis gave — plus a fixed,
+/// non-sensitive notice when coaching must stop without interrupting the user. It pushes those
 /// entries into an in-app `WKWebView` window (see `ActivityViewer` in JarvisApp) and persists them so
-/// past sessions can be browsed later. Diagnostics belong exclusively in `JarvisLog`.
+/// past sessions can be browsed later. Detailed diagnostics belong exclusively in `JarvisLog`.
 ///
 /// This type is UI-free (Foundation only): it generates the page HTML and the per-row JS as plain
 /// strings; the WebView lives in JarvisApp. See wiki/build-and-run.md.
@@ -11,8 +12,8 @@ public final class ActivityLog: @unchecked Sendable {
     public static let shared = ActivityLog()
 
     /// A human-visible event in the coaching exchange. Keeping this closed set typed prevents
-    /// lifecycle, transport, retry, error, and other diagnostic strings from leaking into the
-    /// activity viewer through a generic logging call.
+    /// transport, retry, error details, and other diagnostic strings from leaking into the activity
+    /// viewer through a generic logging call.
     public enum Event: Sendable {
         /// A finalized utterance from the user (`me`) or interviewer (`them`).
         case heard(speaker: Speaker, text: String)
@@ -22,6 +23,10 @@ public final class ActivityLog: @unchecked Sendable {
         case screenViewed(imageBase64JPEG: String)
         /// Jarvis displayed these coaching lines to the user.
         case tip(lines: [String])
+        /// Coaching ended because the selected brain could not respond. Carries only the provider,
+        /// never the raw error, so the notice cannot expose provider diagnostics during screen
+        /// sharing.
+        case coachingStopped(provider: BrainProvider)
     }
 
     /// One recorded line. `imageFile` is the relative `shot-N.jpg` name on disk (the bytes the DOM
@@ -115,6 +120,9 @@ public final class ActivityLog: @unchecked Sendable {
         case .tip(let lines):
             message = "💬 \(lines.joined(separator: " "))"
             imageBase64 = nil
+        case .coachingStopped(let provider):
+            message = "⏹ coaching stopped — \(provider.displayName) couldn't respond; check Settings → Brain"
+            imageBase64 = nil
         }
         queue.async { [self] in
             guard let dir else { return }
@@ -206,6 +214,7 @@ public final class ActivityLog: @unchecked Sendable {
         if m.hasPrefix("👁") { return "see" }
         if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
         if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
+        if m.hasPrefix("⏹ coaching stopped") { return "think" }
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
         return ""
@@ -218,6 +227,7 @@ public final class ActivityLog: @unchecked Sendable {
         let m = message.trimmingCharacters(in: .whitespaces)
         return m.hasPrefix("🗣 heard") || m.hasPrefix("⌨️ hint shortcut")
             || m.hasPrefix("👁 looking at your screen") || m.hasPrefix("💬")
+            || m.hasPrefix("⏹ coaching stopped")
     }
 
     /// The empty page shell: dark theme, a header with a live count, the row container, the lightbox

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -27,6 +27,16 @@ public final class ActivityLog: @unchecked Sendable {
         /// never the raw error, so the notice cannot expose provider diagnostics during screen
         /// sharing.
         case coachingStopped(provider: BrainProvider)
+        /// Coaching ended because the microphone transcription connection was lost. No transport
+        /// detail is carried; the fixed copy points to diagnostics.
+        case transcriptionStopped
+        /// Coaching ended because the running audio capture became unavailable. No device or route
+        /// detail is carried; the fixed copy points to diagnostics.
+        case audioCaptureStopped
+        /// The secondary system-audio transcription stopped while microphone coaching continued.
+        case systemAudioStopped
+        /// An explicit Settings reapply failed its preflight while the existing session continued.
+        case settingsChangeNotApplied
     }
 
     /// One recorded line. `imageFile` is the relative `shot-N.jpg` name on disk (the bytes the DOM
@@ -123,6 +133,18 @@ public final class ActivityLog: @unchecked Sendable {
         case .coachingStopped(let provider):
             message = "⏹ coaching stopped — \(provider.displayName) couldn't respond; check Settings → Brain"
             imageBase64 = nil
+        case .transcriptionStopped:
+            message = "⏹ coaching stopped — transcription connection was lost; check jarvis-debug.log"
+            imageBase64 = nil
+        case .audioCaptureStopped:
+            message = "⏹ coaching stopped — audio capture became unavailable; check jarvis-debug.log"
+            imageBase64 = nil
+        case .systemAudioStopped:
+            message = "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log"
+            imageBase64 = nil
+        case .settingsChangeNotApplied:
+            message = "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain"
+            imageBase64 = nil
         }
         queue.async { [self] in
             guard let dir else { return }
@@ -215,6 +237,7 @@ public final class ActivityLog: @unchecked Sendable {
         if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
         if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
         if m.hasPrefix("⏹ coaching stopped") { return "think" }
+        if m.hasPrefix("⚠️") { return "think" }
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
         return ""
@@ -228,6 +251,8 @@ public final class ActivityLog: @unchecked Sendable {
         return m.hasPrefix("🗣 heard") || m.hasPrefix("⌨️ hint shortcut")
             || m.hasPrefix("👁 looking at your screen") || m.hasPrefix("💬")
             || m.hasPrefix("⏹ coaching stopped")
+            || m.hasPrefix("⚠️ system audio stopped")
+            || m.hasPrefix("⚠️ settings change wasn't applied")
     }
 
     /// The empty page shell: dark theme, a header with a live count, the row container, the lightbox

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -40,14 +40,14 @@ public extension UserFacingError {
               severity: .degraded)
     }
 
-    /// The selected CLI passed preflight but an actual coaching request failed.
-    /// The session cannot coach, so fail loudly and stop instead of leaving the listening indicator
-    /// green while every later turn is discarded.
+    /// The selected CLI passed preflight but an actual coaching request failed. The session cannot
+    /// coach, so stop without activating the app; the Activity log gets a discreet fixed notice and
+    /// the detailed reason stays in diagnostics.
     static func brainCLIStopped(provider: String, signInCommand: String,
                                 reason: String) -> UserFacingError {
         .init(title: "\(provider) couldn't respond",
               message: "\(reason)\n\nCoaching has stopped. Run \u{201C}\(signInCommand)\u{201D} in Terminal, or choose another brain provider in Settings \u{2192} Brain, then Start again.",
-              severity: .fatal)
+              severity: .terminal)
     }
 
     /// Audio capture couldn't be built or started. `reason` is the human-readable cause from the capture

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -23,24 +23,31 @@ public extension UserFacingError {
               severity: .warning)
     }
 
-    /// The selected CLI is installed but definitively signed out (Codex: `auth.json` is its only
-    /// credential store, so an absent marker is authoritative). Every brain turn would fail, so
-    /// refuse the Start instead of opening a pipeline that can never coach. Same preflight
-    /// semantics as `brainCLIMissing`: alert, but never stop a session that's already running.
+    /// The selected CLI is installed but definitively signed out. Every brain turn would fail, so
+    /// refuse the Start instead of opening a pipeline that can never coach. Same preflight semantics
+    /// as `brainCLIMissing`: alert, but never stop a session that's already running.
     static func brainCLINotSignedIn(provider: String) -> UserFacingError {
         .init(title: "\(provider) isn't signed in",
               message: "Sign in by running the \(provider) command once in Terminal, or switch the brain provider in Settings \u{2192} Brain, then press Start again.",
               severity: .warning)
     }
 
-    /// The selected CLI is installed but its sign-in couldn't be confirmed (Claude Code may keep
-    /// credentials only in the macOS Keychain, which Jarvis deliberately doesn't probe). A false
-    /// negative is possible, so this is a degraded notice, not a Start blocker — but it makes a
-    /// never-working brain visible in the debug log instead of silent.
+    /// The selected CLI is installed but its status probe failed or timed out. That is not proof of
+    /// being signed out, so this is a degraded notice rather than a Start blocker.
     static func brainCLISignInUnconfirmed(provider: String) -> UserFacingError {
         .init(title: "\(provider) sign-in unconfirmed",
               message: "Couldn't confirm \(provider) is signed in \u{2014} coaching turns may fail. If they do, run the CLI once in Terminal to sign in, then Stop and Start.",
               severity: .degraded)
+    }
+
+    /// The selected CLI passed preflight but an actual coaching request failed.
+    /// The session cannot coach, so fail loudly and stop instead of leaving the listening indicator
+    /// green while every later turn is discarded.
+    static func brainCLIStopped(provider: String, signInCommand: String,
+                                reason: String) -> UserFacingError {
+        .init(title: "\(provider) couldn't respond",
+              message: "\(reason)\n\nCoaching has stopped. Run \u{201C}\(signInCommand)\u{201D} in Terminal, or choose another brain provider in Settings \u{2192} Brain, then Start again.",
+              severity: .fatal)
     }
 
     /// Audio capture couldn't be built or started. `reason` is the human-readable cause from the capture

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-/// The catalog of the app's user-facing failures: the single source of truth for *which* failures are
-/// loud (`.fatal` → alert + stop) versus quiet (`.degraded`). It owns the title + severity policy of each
-/// named failure; dynamic copy composed at the failure site (e.g. a capture reason) is passed through.
-/// Call sites reference these so the loudness policy is centralized and unit-testable.
+/// The catalog of the app's user-facing failures: the single source of truth for each failure's
+/// lifecycle consequence. Presentation additionally depends on startup versus runtime context; no
+/// runtime severity may reveal UI. Dynamic copy composed at the failure site (e.g. a capture reason)
+/// is passed through. Call sites reference these so the policy is centralized and unit-testable.
 public extension UserFacingError {
     /// No API key on Start. Realtime voice transcription always runs on the OpenAI key — whichever
     /// brain provider is selected — so the session never comes up: fatal.
@@ -56,12 +56,18 @@ public extension UserFacingError {
         .init(title: "Couldn't start audio capture", message: reason, severity: .fatal)
     }
 
+    /// Audio capture started, then became unavailable after a route rebuild. Coaching cannot
+    /// continue, but a runtime failure must stop without activating the app.
+    static func captureStopped(reason: String) -> UserFacingError {
+        .init(title: "Audio capture stopped", message: reason, severity: .terminal)
+    }
+
     /// The mic ("me") transcription socket gave up (bad key / quota / network) — NOT a mic-hardware
-    /// failure (that's `captureFailed`). Coaching can't continue, so it's fatal.
+    /// failure (that's `captureStopped`). Coaching can't continue, so stop without revealing UI.
     static var transcriptionStopped: UserFacingError {
         .init(title: "Transcription stopped",
               message: "Jarvis lost its connection to the transcription service (often a bad API key, quota, or network issue). Coaching has stopped.",
-              severity: .fatal)
+              severity: .terminal)
     }
 
     /// The system-audio ("them") socket gave up. The mic still works, so this is a graceful degrade —

--- a/Sources/JarvisCore/Diagnostics/UserFacingError.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError.swift
@@ -1,23 +1,26 @@
 import Foundation
 
-/// A failure worth showing the user. The model is Foundation-only and lives in Core so the decision
-/// of *how loud* a failure is (alert? stop the session?) is unit-testable; the App-layer `ErrorReporter`
-/// only renders it. Construct one at any failure site and hand it to the reporter.
+/// A failure worth reporting. The model is Foundation-only and lives in Core so the decision of
+/// *how loud* a failure is (alert? stop the session?) is unit-testable; the App-layer
+/// `ErrorReporter` only applies it. Construct one at any failure site and hand it to the reporter.
 public struct UserFacingError: Error, Sendable, Equatable {
     /// How the reporter should react. `.fatal` interrupts the user and tears the session down;
+    /// `.terminal` tears the session down without activating the app (for ghost-safe failures whose
+    /// discreet notice is recorded elsewhere);
     /// `.warning` interrupts without touching a running session (a *preflight* failure — the thing
     /// that failed never started, so there is nothing to tear down and a live session must survive,
     /// e.g. an in-place restart aborted because the brain CLI vanished); `.degraded` is a
     /// non-blocking notice the session survives (logged, not alerted).
     public enum Severity: Sendable, Equatable {
         case fatal
+        case terminal
         case warning
         case degraded
 
         /// Whether the reporter pops a modal alert for this severity.
-        public var showsAlert: Bool { self != .degraded }
+        public var showsAlert: Bool { self == .fatal || self == .warning }
         /// Whether the reporter tears down the running session for this severity.
-        public var stopsSession: Bool { self == .fatal }
+        public var stopsSession: Bool { self == .fatal || self == .terminal }
     }
 
     public let title: String

--- a/Sources/JarvisCore/Diagnostics/UserFacingError.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError.swift
@@ -2,12 +2,21 @@ import Foundation
 
 /// A failure worth reporting. The model is Foundation-only and lives in Core so the decision of
 /// *how loud* a failure is (alert? stop the session?) is unit-testable; the App-layer
-/// `ErrorReporter` only applies it. Construct one at any failure site and hand it to the reporter.
+/// `ErrorReporter` only applies it. Construct one at any failure site and hand it to the reporter
+/// with the context in which it happened.
 public struct UserFacingError: Error, Sendable, Equatable {
-    /// How the reporter should react. `.fatal` interrupts the user and tears the session down;
+    /// Where the failure originated. Startup failures may interrupt the explicit Start action;
+    /// runtime failures must preserve ghost mode even if their lifecycle consequence stops the
+    /// session before the reporter reaches the main actor.
+    public enum PresentationContext: Sendable, Equatable {
+        case startup
+        case runtime
+    }
+
+    /// How the reporter should react. `.fatal` tears the session down and permits a startup alert;
     /// `.terminal` tears the session down without activating the app (for ghost-safe failures whose
     /// discreet notice is recorded elsewhere);
-    /// `.warning` interrupts without touching a running session (a *preflight* failure — the thing
+    /// `.warning` permits a startup alert without touching a running session (a *preflight* failure — the thing
     /// that failed never started, so there is nothing to tear down and a live session must survive,
     /// e.g. an in-place restart aborted because the brain CLI vanished); `.degraded` is a
     /// non-blocking notice the session survives (logged, not alerted).
@@ -21,6 +30,13 @@ public struct UserFacingError: Error, Sendable, Equatable {
         public var showsAlert: Bool { self == .fatal || self == .warning }
         /// Whether the reporter tears down the running session for this severity.
         public var stopsSession: Bool { self == .fatal || self == .terminal }
+
+        /// Runtime presentation is forbidden regardless of severity. The context is captured at
+        /// the failure site, so teardown cannot race a queued main-actor alert into appearing after
+        /// the session has already stopped.
+        public func showsAlert(in context: PresentationContext) -> Bool {
+            context == .startup && showsAlert
+        }
     }
 
     public let title: String

--- a/Sources/JarvisOverlay/OverlayBoxPanel.swift
+++ b/Sources/JarvisOverlay/OverlayBoxPanel.swift
@@ -175,7 +175,7 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
         // Re-assert capture exclusion on every show — defense-in-depth against an activation-policy
         // flip dropping `sharingType` (same reason as OverlayCaptionPanel.show).
         reassertCaptureExclusion()
-        panel.orderFrontRegardless()
+        panel.orderFrontRegardless() // ghost-mode-allowed: capture-excluded coaching overlay
     }
 
     public func hide() {
@@ -215,7 +215,7 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
             isPreviewing = true
             reassertCaptureExclusion()
             setEntriesText(Self.sampleEntries)
-            panel.orderFrontRegardless()
+            panel.orderFrontRegardless() // ghost-mode-allowed: capture-excluded coaching overlay
         } else if isPreviewing {
             isPreviewing = false
             rerender()                                  // restore the real log…

--- a/Sources/JarvisOverlay/OverlayCaptionPanel.swift
+++ b/Sources/JarvisOverlay/OverlayCaptionPanel.swift
@@ -170,7 +170,7 @@ public final class OverlayCaptionPanel: NSObject, OverlayRendering, OverlayCapti
         }
         label.stringValue = tip.lines[line]
         resizeToFit()   // grow the panel so a long line isn't clipped
-        panel.orderFrontRegardless()
+        panel.orderFrontRegardless() // ghost-mode-allowed: capture-excluded coaching overlay
         active = (tip, line + 1)
         scheduleTick(after: tip.seconds[line]) { $0.gapThenAdvance() }
     }
@@ -250,7 +250,7 @@ public final class OverlayCaptionPanel: NSObject, OverlayRendering, OverlayCapti
             isPreviewing = true
             label.stringValue = Self.previewText
             resizeToFit()
-            panel.orderFrontRegardless()
+            panel.orderFrontRegardless() // ghost-mode-allowed: capture-excluded coaching overlay
         } else if isPreviewing {
             isPreviewing = false
             // If the caption was switched off *during* the preview, `setEnabled(false)` deferred its

--- a/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
@@ -2,9 +2,8 @@ import Testing
 import Foundation
 @testable import JarvisCore
 
-/// Detection runs against a real, throwaway home-directory fixture (no production probe seam):
-/// executables are actual 0755 files, auth markers actual files — only `home` and `pathVariable`
-/// are injected, the same way `BrainPreferences` takes a `UserDefaults(suiteName:)`.
+/// Detection runs against a real, throwaway home-directory fixture: executables are actual 0755
+/// shell scripts, so Claude auth tests exercise the production subprocess + JSON parsing path.
 @Suite struct AgentCLIDetectorTests {
     private let fm = FileManager.default
 
@@ -16,11 +15,13 @@ import Foundation
         return url
     }
 
-    /// Create a real executable file at `dir/name`.
-    private func installBinary(_ name: String, in dir: URL) throws {
+    /// Create a real executable file at `dir/name`. The default exits without a status document,
+    /// which represents an installed CLI whose sign-in state cannot be checked.
+    private func installBinary(_ name: String, in dir: URL,
+                               script: String = "#!/bin/sh\nexit 2\n") throws {
         try fm.createDirectory(at: dir, withIntermediateDirectories: true)
         #expect(fm.createFile(atPath: dir.appendingPathComponent(name).path,
-                              contents: Data("#!/bin/sh\n".utf8),
+                              contents: Data(script.utf8),
                               attributes: [.posixPermissions: 0o755]))
     }
 
@@ -45,7 +46,7 @@ import Foundation
         let d = AgentCLIDetector(home: home, pathVariable: "/nonexistent:\(bin.path)")
         let cli = d.detect(.claudeCode)
         #expect(cli?.executableURL.path == bin.appendingPathComponent("claude").path)
-        #expect(cli?.authenticated == false)
+        #expect(cli?.authenticationStatus == .unknown)
     }
 
     @Test func fallsBackToKnownInstallDirsWhenPATHIsMinimal() throws {
@@ -77,23 +78,45 @@ import Foundation
         #expect(d.detect(.claudeCode) == nil)
     }
 
-    @Test func claudeAuthDetectedViaCredentialsFile() throws {
+    @Test func claudeAuthStatusCommandReportsSignedIn() throws {
         let home = try makeHome()
-        try installBinary("claude", in: home.appendingPathComponent(".local/bin"))
-        try write("{}", to: home.appendingPathComponent(".claude/.credentials.json"))
-        let d = AgentCLIDetector(home: home, pathVariable: nil)
-        #expect(d.detect(.claudeCode)?.authenticated == true)
+        try installBinary("claude", in: home.appendingPathComponent(".claude/local"), script: """
+            #!/bin/sh
+            printf '%s\\n' '{"loggedIn":true,"authMethod":"claude.ai"}'
+            exit 0
+            """)
+        let d = AgentCLIDetector(home: home, pathVariable: nil, authStatusTimeout: 10)
+        #expect(d.detect(.claudeCode)?.authenticationStatus == .signedIn)
     }
 
-    @Test func claudeAuthDetectedViaOAuthAccountMarker() throws {
-        // macOS default stores credentials in the Keychain (unprobeable without a prompt); the
-        // oauthAccount record in ~/.claude.json is the visible sign-in marker there.
+    @Test func claudeAuthStatusOverridesStaleOAuthAccountMarker() throws {
         let home = try makeHome()
-        try installBinary("claude", in: home.appendingPathComponent(".local/bin"))
+        try installBinary("claude", in: home.appendingPathComponent(".claude/local"), script: """
+            #!/bin/sh
+            printf '%s\\n' '{"loggedIn":false,"authMethod":"none"}'
+            exit 1
+            """)
         try write(#"{"oauthAccount":{"emailAddress":"x@y.z"}}"#,
                   to: home.appendingPathComponent(".claude.json"))
+        let d = AgentCLIDetector(home: home, pathVariable: nil, authStatusTimeout: 10)
+        #expect(d.detect(.claudeCode)?.authenticationStatus == .signedOut)
+    }
+
+    @Test func claudeAuthStatusFailureIsUnknown() throws {
+        let home = try makeHome()
+        try installBinary("claude", in: home.appendingPathComponent(".claude/local"))
         let d = AgentCLIDetector(home: home, pathVariable: nil)
-        #expect(d.detect(.claudeCode)?.authenticated == true)
+        #expect(d.detect(.claudeCode)?.authenticationStatus == .unknown)
+    }
+
+    @Test func claudeAuthStatusProbeIsBounded() throws {
+        let home = try makeHome()
+        try installBinary("claude", in: home.appendingPathComponent(".claude/local"), script: """
+            #!/bin/sh
+            sleep 1
+            """)
+        let d = AgentCLIDetector(home: home, pathVariable: nil, authStatusTimeout: 0.01)
+        #expect(d.detect(.claudeCode)?.authenticationStatus == .unknown)
     }
 
     @Test func codexAuthDetectedViaAuthJSON() throws {
@@ -101,7 +124,7 @@ import Foundation
         try installBinary("codex", in: home.appendingPathComponent(".local/bin"))
         try write("{}", to: home.appendingPathComponent(".codex/auth.json"))
         let d = AgentCLIDetector(home: home, pathVariable: nil)
-        #expect(d.detect(.codexCLI)?.authenticated == true)
+        #expect(d.detect(.codexCLI)?.authenticationStatus == .signedIn)
     }
 
     @Test func missingBinaryDetectsNothing() throws {

--- a/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
@@ -1,5 +1,10 @@
 import Testing
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 @testable import JarvisCore
 
 /// Detection runs against a real, throwaway home-directory fixture: executables are actual 0755
@@ -117,6 +122,31 @@ import Foundation
             """)
         let d = AgentCLIDetector(home: home, pathVariable: nil, authStatusTimeout: 0.01)
         #expect(d.detect(.claudeCode)?.authenticationStatus == .unknown)
+    }
+
+    @Test func claudeAuthStatusProbeDoesNotWaitForInheritedChildStdout() throws {
+        let home = try makeHome()
+        let childPID = home.appendingPathComponent("child.pid")
+        let childFinished = home.appendingPathComponent("child-finished")
+        try installBinary("claude", in: home.appendingPathComponent(".claude/local"), script: """
+            #!/bin/sh
+            (trap '' HUP; sleep 5; touch "$HOME/child-finished") &
+            printf '%s\\n' "$!" > "$HOME/child.pid"
+            exit 2
+            """)
+        let d = AgentCLIDetector(home: home, pathVariable: nil, authStatusTimeout: 0.01)
+
+        let status = d.detect(.claudeCode)?.authenticationStatus
+        defer {
+            if let contents = try? String(contentsOf: childPID, encoding: .utf8),
+               let pid = pid_t(contents.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                kill(pid, SIGKILL)
+            }
+        }
+
+        #expect(status == .unknown)
+        #expect(!fm.fileExists(atPath: childFinished.path),
+                "the auth probe must return without waiting for a child that inherited stdout")
     }
 
     @Test func codexAuthDetectedViaAuthJSON() throws {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -658,6 +658,28 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(recorder.messages == ["test brain failed"])
     }
 
+    @Test func terminalBrainErrorDropsCoalescedAndLaterTriggers() async {
+        let clock = ManualClock(now: 0)
+        let gate = AsyncGate()
+        let brain = GatedThrowingBrain(gate: gate)
+        let recorder = BrainFailureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: brain, clock: clock,
+            onBrainFailure: { recorder.record($0) }
+        )
+        transcript.append(.init(speaker: .me, text: "first substantial question", at: 0))
+        async let first = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+        transcript.append(.init(speaker: .me, text: "second substantial question", at: 1))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .busy)
+        await gate.release()
+        #expect(await first == .brainError)
+        #expect(await driver.handleTrigger(.turnEnd) == .brainError)
+        #expect(brain.callCount == 1)
+        #expect(recorder.messages == ["gated brain failed"])
+    }
+
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
     /// prompt — reply, look at the screen, or stay_silent — but must answer with one of them.
     @Test func everyAudioTurnRequiresAToolCall() async {
@@ -718,6 +740,24 @@ final class GatedBrain: BrainClient, @unchecked Sendable {
         record()
         await gate.enter()
         return response
+    }
+}
+
+/// A throwing brain with the same one-shot gate, so a second trigger can pend before the terminal
+/// failure is released.
+final class GatedThrowingBrain: BrainClient, @unchecked Sendable {
+    private let gate: AsyncGate
+    private let lock = NSLock()
+    private var _callCount = 0
+    var callCount: Int { lock.lock(); defer { lock.unlock() }; return _callCount }
+    init(gate: AsyncGate) { self.gate = gate }
+    private func recordCall() { lock.lock(); _callCount += 1; lock.unlock() }
+    func respond(messages: [ChatMessage], tools: [ToolDef],
+                 toolChoice: ToolChoice) async throws -> BrainResponse {
+        recordCall()
+        await gate.enter()
+        throw NSError(domain: "test", code: 401,
+                      userInfo: [NSLocalizedDescriptionKey: "gated brain failed"])
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -78,11 +78,14 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     private func makeDriver(brain: BrainClient, summarizer: BrainClient? = nil,
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
-                            clock: Clock, config: Config = .default) -> (CoachDriver, RollingTranscript) {
+                            clock: Clock, config: Config = .default,
+                            onBrainFailure: (@Sendable (String) -> Void)? = nil)
+        -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
         let driver = CoachDriver(
             config: config, transcript: transcript,
-            brain: brain, summarizer: summarizer, screen: screen, overlay: overlay, clock: clock
+            brain: brain, summarizer: summarizer, screen: screen, overlay: overlay, clock: clock,
+            onBrainFailure: onBrainFailure
         )
         return (driver, transcript)
     }
@@ -643,6 +646,18 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .brainError)
     }
 
+    @Test func brainErrorReportsTheFailureReason() async {
+        let recorder = BrainFailureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: ThrowingBrain(), clock: ManualClock(now: 0),
+            onBrainFailure: { recorder.record($0) }
+        )
+        transcript.append(.init(speaker: .me, text: "please help with this problem", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .brainError)
+        #expect(recorder.messages == ["test brain failed"])
+    }
+
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
     /// prompt — reply, look at the screen, or stay_silent — but must answer with one of them.
     @Test func everyAudioTurnRequiresAToolCall() async {
@@ -676,8 +691,17 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 /// A brain that always throws, to exercise the `.brainError` outcome.
 final class ThrowingBrain: BrainClient, @unchecked Sendable {
     func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice) async throws -> BrainResponse {
-        throw NSError(domain: "test", code: 401)
+        throw NSError(domain: "test", code: 401,
+                      userInfo: [NSLocalizedDescriptionKey: "test brain failed"])
     }
+}
+
+/// Lock-guarded because `CoachDriver`'s failure callback is `@Sendable`.
+final class BrainFailureRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [String] = []
+    var messages: [String] { lock.lock(); defer { lock.unlock() }; return recorded }
+    func record(_ message: String) { lock.lock(); recorded.append(message); lock.unlock() }
 }
 
 /// A brain that parks inside `respond` until released, so a second concurrent trigger can be

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -10,6 +10,7 @@ import Foundation
         #expect(ActivityLog.cssClass(for: "🤫 quiet for 8s") == "hear")
         #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
         #expect(ActivityLog.cssClass(for: "… nothing useful to add, staying silent") == "think")
+        #expect(ActivityLog.cssClass(for: "⏹ coaching stopped — Claude Code couldn't respond") == "think")
         #expect(ActivityLog.cssClass(for: "Jarvis realtime error event: oops") == "err")
         #expect(ActivityLog.cssClass(for: "Jarvis: coaching started.") == "")
         // A spoken tip can legitimately contain "failed"; it must stay a 💬 say line.
@@ -101,6 +102,23 @@ import Foundation
         #expect(jsonl.contains(#"heard (them): \"How would you optimize it?\""#))
         #expect(!jsonl.contains("item"))
         #expect(!jsonl.contains("recovered"))
+    }
+
+    @Test func coachingStoppedPersistsOnlyADiscreetHumanFacingNotice() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        log.record(.coachingStopped(provider: .claudeCode))
+        let snapshot = log.attach { _ in }
+
+        let row = try #require(snapshot.rows.first)
+        #expect(row.contains("coaching stopped"))
+        #expect(row.contains("Claude Code"))
+        #expect(row.contains("Settings"))
+        #expect(!row.contains("OAuth"))
+        #expect(ActivityLog.isHumanFacing(
+            message: "⏹ coaching stopped — Claude Code couldn't respond; check Settings → Brain",
+            imageFile: nil
+        ))
     }
 
     /// Shared temp-dir helper (also used by SessionStoreTests). Owner-only dir, like the real app.

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -121,6 +121,35 @@ import Foundation
         ))
     }
 
+    @Test func runtimeFailureNoticesStayFixedAndDiagnosticFree() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        log.record(.transcriptionStopped)
+        log.record(.audioCaptureStopped)
+        log.record(.systemAudioStopped)
+        log.record(.settingsChangeNotApplied)
+        let snapshot = log.attach { _ in }
+
+        #expect(snapshot.rows.count == 4)
+        #expect(snapshot.rows[0].contains("transcription connection was lost"))
+        #expect(snapshot.rows[1].contains("audio capture became unavailable"))
+        #expect(snapshot.rows[2].contains("microphone coaching continues"))
+        #expect(snapshot.rows[3].contains("current coaching session continues"))
+        for row in snapshot.rows {
+            #expect(!row.contains("OAuth"))
+            #expect(!row.contains("AirPods"))
+            #expect(!row.contains("quota"))
+        }
+        #expect(ActivityLog.isHumanFacing(
+            message: "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log",
+            imageFile: nil
+        ))
+        #expect(ActivityLog.isHumanFacing(
+            message: "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain",
+            imageFile: nil
+        ))
+    }
+
     /// Shared temp-dir helper (also used by SessionStoreTests). Owner-only dir, like the real app.
     static func tmp() -> URL {
         let d = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
@@ -47,11 +47,24 @@ import Testing
     }
 
     @Test func brainCLISignInUnconfirmedStaysQuiet() {
-        // The heuristic marker (Claude, Keychain-only credentials) can false-negative, so this must
-        // warn without blocking the session.
+        // A failed/timed-out probe is unknown rather than proof of logout, so warn without blocking.
         let e = UserFacingError.brainCLISignInUnconfirmed(provider: "Claude Code")
         #expect(e.severity == .degraded)
         #expect(!e.severity.showsAlert)
         #expect(!e.severity.stopsSession)
+    }
+
+    @Test func brainCLIRuntimeFailureAlertsStopsAndExplainsRecovery() {
+        let e = UserFacingError.brainCLIStopped(
+            provider: "Claude Code",
+            signInCommand: "claude auth login",
+            reason: "OAuth session expired"
+        )
+        #expect(e.severity == .fatal)
+        #expect(e.severity.showsAlert)
+        #expect(e.severity.stopsSession)
+        #expect(e.title.contains("Claude Code"))
+        #expect(e.message.contains("OAuth session expired"))
+        #expect(e.message.contains("claude auth login"))
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
@@ -17,8 +17,18 @@ import Testing
         #expect(e.message.contains("no input device"))
     }
 
-    @Test func transcriptionStoppedIsFatal() {
-        #expect(UserFacingError.transcriptionStopped.severity == .fatal)
+    @Test func runtimeCaptureFailureStopsQuietlyAndCarriesReason() {
+        let e = UserFacingError.captureStopped(reason: "route disappeared")
+        #expect(e.severity == .terminal)
+        #expect(e.severity.stopsSession)
+        #expect(!e.severity.showsAlert)
+        #expect(e.message.contains("route disappeared"))
+    }
+
+    @Test func transcriptionStoppedIsTerminal() {
+        #expect(UserFacingError.transcriptionStopped.severity == .terminal)
+        #expect(UserFacingError.transcriptionStopped.severity.stopsSession)
+        #expect(!UserFacingError.transcriptionStopped.severity.showsAlert)
     }
 
     @Test func systemAudioStoppedStaysQuiet() {

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
@@ -54,14 +54,14 @@ import Testing
         #expect(!e.severity.stopsSession)
     }
 
-    @Test func brainCLIRuntimeFailureAlertsStopsAndExplainsRecovery() {
+    @Test func brainCLIRuntimeFailureStopsQuietlyAndKeepsDiagnosticRecoveryDetail() {
         let e = UserFacingError.brainCLIStopped(
             provider: "Claude Code",
             signInCommand: "claude auth login",
             reason: "OAuth session expired"
         )
-        #expect(e.severity == .fatal)
-        #expect(e.severity.showsAlert)
+        #expect(e.severity == .terminal)
+        #expect(!e.severity.showsAlert)
         #expect(e.severity.stopsSession)
         #expect(e.title.contains("Claude Code"))
         #expect(e.message.contains("OAuth session expired"))

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
@@ -23,6 +23,20 @@ import Testing
         #expect(!UserFacingError.Severity.degraded.stopsSession)
     }
 
+    @Test func runtimeNeverAlertsForAnySeverity() {
+        let severities: [UserFacingError.Severity] = [.fatal, .terminal, .warning, .degraded]
+        for severity in severities {
+            #expect(!severity.showsAlert(in: .runtime))
+        }
+    }
+
+    @Test func startupPreservesSeverityAlertPolicy() {
+        #expect(UserFacingError.Severity.fatal.showsAlert(in: .startup))
+        #expect(UserFacingError.Severity.warning.showsAlert(in: .startup))
+        #expect(!UserFacingError.Severity.terminal.showsAlert(in: .startup))
+        #expect(!UserFacingError.Severity.degraded.showsAlert(in: .startup))
+    }
+
     @Test func carriesFields() {
         let e = UserFacingError(title: "T", message: "M", severity: .fatal)
         #expect(e.title == "T")

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
@@ -13,6 +13,11 @@ import Testing
         #expect(!UserFacingError.Severity.warning.stopsSession)
     }
 
+    @Test func terminalStopsWithoutAlert() {
+        #expect(!UserFacingError.Severity.terminal.showsAlert)
+        #expect(UserFacingError.Severity.terminal.stopsSession)
+    }
+
     @Test func degradedNeitherAlertsNorStops() {
         #expect(!UserFacingError.Severity.degraded.showsAlert)
         #expect(!UserFacingError.Severity.degraded.stopsSession)

--- a/scripts/check-ghost-mode.sh
+++ b/scripts/check-ghost-mode.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Any AppKit call that can reveal Jarvis must be an explicit, reviewed exception. Keeping the marker
+# on the exact call site makes a newly introduced alert/window/browser/sound fail the normal gate
+# instead of relying on a future manual audit to notice it.
+pattern='NSAlert\(|(NSApp|NSApplication\.shared)\.(activate|setActivationPolicy)|makeKeyAndOrderFront|\.makeKey\(|orderFrontRegardless|\.orderFront\(|beginSheet\(|NSWorkspace\.shared\.open|NSSound|AudioServicesPlaySystemSound|requestUserAttention|UNUserNotification|NSUserNotification|\.runModal\('
+
+if violations="$(rg -n "$pattern" Sources/JarvisApp Sources/JarvisOverlay \
+    | rg -v 'ghost-mode-allowed')"; then
+    echo "Ghost-mode presentation APIs require an inline ghost-mode-allowed exception:" >&2
+    echo "$violations" >&2
+    exit 1
+fi
+
+echo "Ghost-mode presentation API guard passed."

--- a/scripts/check-ghost-mode.sh
+++ b/scripts/check-ghost-mode.sh
@@ -7,8 +7,20 @@ cd "$(dirname "$0")/.."
 # instead of relying on a future manual audit to notice it.
 pattern='NSAlert\(|(NSApp|NSApplication\.shared)\.(activate|setActivationPolicy)|makeKeyAndOrderFront|\.makeKey\(|orderFrontRegardless|\.orderFront\(|beginSheet\(|NSWorkspace\.shared\.open|NSSound|AudioServicesPlaySystemSound|requestUserAttention|UNUserNotification|NSUserNotification|\.runModal\('
 
-if violations="$(rg -n "$pattern" Sources/JarvisApp Sources/JarvisOverlay \
-    | rg -v 'ghost-mode-allowed')"; then
+scan_status=0
+matches="$(/usr/bin/grep -RInE "$pattern" Sources/JarvisApp Sources/JarvisOverlay)" || scan_status=$?
+if [ "$scan_status" -gt 1 ]; then
+    echo "Ghost-mode presentation API scan failed; refusing to pass without a complete scan." >&2
+    exit "$scan_status"
+fi
+
+filter_status=0
+violations="$(printf '%s' "$matches" | /usr/bin/grep -v 'ghost-mode-allowed')" || filter_status=$?
+if [ "$filter_status" -gt 1 ]; then
+    echo "Ghost-mode presentation API exception filtering failed; refusing to pass." >&2
+    exit "$filter_status"
+fi
+if [ -n "$violations" ]; then
     echo "Ghost-mode presentation APIs require an inline ghost-mode-allowed exception:" >&2
     echo "$violations" >&2
     exit 1

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+./scripts/check-ghost-mode.sh
+
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's
 # already on the toolchain path, so plain `swift test` works — detect which toolchain is active.

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -126,7 +126,7 @@ plugins ship only with full Xcode, and Jarvis builds **CLT-only** (see
 |---|---|---|
 | **AggregateEchoCapture** | The whole capture path: one **private Core Audio aggregate device** = the built-in mic (`me`, clock master) + a system-output **process tap** (`them`, drift-compensated onto the mic's clock). A single IOProc delivers both sample-synced at the device's **native rate** — the one-clock case AEC3 needs; the capture **reads that rate and resamples mic+tap up to 48 kHz** for AEC3 (a no-op when the device is already 48 kHz). So **any input device works** — built-in, USB, 44.1 kHz gear, or AirPods (Bluetooth HFP at 16/24 kHz) — instead of the old hard 48 kHz pin that silently failed to start on Bluetooth mics. Inside the callback it runs AEC3 (tap = far reference, mic = near), removing the other side's speaker bleed from the mic *before* transcription — no headphones, and double-talk works (measured 30–50 dB cancellation). The untouched resampled tap remains the `them` source while a separate padded/truncated copy aligns AEC; wire delivery is serialized off the realtime IOProc. Then both sides downsample to 24 kHz. Replaces the old separate `AVAudioEngine` mic + `SCStream`. | Core Audio (`AudioHardwareCreateProcessTap`, private aggregate device, drift compensation) + `AVAudioConverter` resampling + WebRTC **AEC3**. |
 | **WebRTCEchoCanceller** | AEC3 echo canceller driven at 48 kHz on 10 ms frames inside the capture IOProc; far reference first, then the mic cleaned in place. | WebRTC **AEC3** (`webrtc-audio-processing`), vendored static + zero-dylib via `scripts/build-aec.sh`. |
-| **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` (in Core) decides the response — `fatal` pops an `NSAlert` and tears the session down, `warning` alerts without touching a running session (preflight refusals), `degraded` is logged only — so no startup failure is ever silent. The only place an *error* `NSAlert` is raised (confirmation prompts aside); diagnostics stay in `JarvisLog`. | AppKit (`NSAlert`). |
+| **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` decides the lifecycle consequence; an explicit startup/runtime context decides presentation. Startup failures may alert, but runtime failures never activate Jarvis or present UI even when they stop the session. Fixed redacted notices go to Activity and raw detail stays in `JarvisLog`. | AppKit (`NSAlert`) for startup only. |
 | **Transcriber** | Maintain a rolling, speaker-labeled, **spoken-time timestamped** transcript; emit turn-end events and backing-off silence checks (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. A per-`item_id` ledger reconciles out-of-order delta/completed/failed/VAD events and salvages streamed text; an item with no usable words is logged as diagnostic metadata and cannot enter the transcript or trigger the brain. A privacy-preserving continuity witness records content-free capture/delivery/socket/server checkpoints and locally derived activity intervals, so the session log can locate a future gap without retaining PCM or adding pseudo-speech to model context. A socket is ready only after the server acknowledges its configuration; active ping/pong probes, send/receive errors, and startup timeouts all drive the same reconnect path. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
 | **CoachDriver** | The event loop. On every substantive trigger (plus every silence check and hint keypress), call the brain with the session memory + transcript delta + timing context and tools, route tool calls, and compact the memory when it grows long. No cooldown/rate cap — restraint is the model's; the only client-side skip is the filler-only turn-end gate (`TurnSubstance`). | `gpt-5.5` (vision + tool-use) with `gpt-5.4-mini` for memory summaries — or a local Claude Code / Codex CLI on the user's subscription (see [§4 Local CLI brain providers](#local-cli-brain-providers)). |
 | **ScreenTool** | Fulfill `capture_screen`: silently shoot the **active window** (default scope) — the window-server frontmost, on whichever display, clean even when partially covered — and attach an **on-device OCR** of the shot to the tool result so the model reads exact text instead of pixels. Falls back to a full-display capture (no OCR) — the Settings-chosen display in Entire-display scope, the main display when no window is eligible; the overlay window is excluded either way. See [settings-window.md](./settings-window.md#capture-scope). | macOS `screencapture` CLI + Apple Vision (`VNRecognizeTextRequest`). |
@@ -160,19 +160,23 @@ all routes — it's a near-passthrough on earbuds (no acoustic echo to cancel). 
 mic* are HFP narrowband and low-fidelity regardless of resampling; for input quality, use the
 built-in mic.
 
-### Failure surfacing — fail loud
+### Failure surfacing — startup loud, runtime ghost
 
 Every user-facing failure flows through one `ErrorReporter`: severity on a Foundation-only
-`UserFacingError` decides the response (`fatal` → `NSAlert` + session teardown; `warning` →
-`NSAlert` only, for preflight refusals that must not kill a live session; `degraded` →
-log only), so a startup failure can never again flip the menu green and silently revert. Per-failure
-copy and severity live in a Core **catalog** (`UserFacingError+Catalog`), the single source of truth
-for *which* failures are loud — unit-tested in Core (e.g. the system-audio degrade must stay quiet),
-since `JarvisApp` itself can't be headlessly tested and the `NSAlert` display stays a manual smoke
-check. Realtime health is a visible state rather than a fatal-only event: startup stays gray,
-reconnect attempts are shown, and microphone-only mode is explicit when the secondary system-audio
-socket cannot recover. Diagnostics remain `JarvisLog`'s job; `ErrorReporter` owns surfacing +
-lifecycle consequence.
+`UserFacingError` decides the lifecycle consequence while an explicit context captured at the
+failure site decides presentation. Startup failures caused by an explicit Start may alert; every
+runtime context suppresses alerts unconditionally, including after teardown, so a queued main-actor
+report cannot reveal Jarvis during screen sharing. Terminal brain, microphone-transcription, and
+audio-capture failures stop silently; the system-audio failure degrades to microphone-only. Each
+records fixed non-sensitive Activity copy while dynamic reasons remain only in `JarvisLog`.
+
+Ghost mode applies from a live pipeline through terminal teardown: no autonomous activation, alert,
+window, browser, notification, attention request, or sound is allowed outside the nonactivating,
+capture-excluded caption and box overlays. The persistent menu-bar item and user-invoked
+Settings/Activity surfaces are explicit exceptions, as is unavoidable macOS privacy UI. The Core
+presentation matrix is unit-tested, and `scripts/check-ghost-mode.sh` rejects unreviewed presentation
+API calls from the normal test gate. Realtime health remains visible only through the existing
+menu-bar status; `ErrorReporter` owns failure lifecycle and permitted startup surfacing.
 
 ## 4. Data Flow & Cost Model
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -239,8 +239,11 @@ memory, retries, and traffic recording are all unchanged — only the transport 
   practice. Codex runs `--sandbox read-only`; Claude runs with its persona replaced
   (`--system-prompt`) and no settings sources, and the one reasoning-effort setting maps onto each
   CLI's own scale.
-- **Installed CLIs are auto-detected** (`AgentCLIDetector`: file probes over $PATH + known install
-  dirs + on-disk auth markers — no subprocess, no Keychain prompt), so selecting one is one click.
+- **Installed CLIs are auto-detected.** `AgentCLIDetector` discovers binaries through file probes
+  over $PATH + known install dirs. Claude's actual sign-in state comes from its non-billing
+  `auth status --json` command under a short timeout, because stale account metadata can survive an
+  expired OAuth session; Codex uses its auth-file marker. Settings distinguishes signed in, signed
+  out, and an unavailable probe, and Start refuses a confirmed logout.
 - **The OpenAI key stays required**: transcription always runs on the Realtime API. A CLI provider
   moves the brain/summarizer/evaluator off the key, not the ears. **Latency is the tradeoff**,
   though a modest one now that every turn is one model call: measured coach turns run ~2.6s (text)

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -462,15 +462,18 @@
 - **Chose:** Keep CLI binary discovery as file probes, but determine Claude Code authentication by
   running its non-billing `claude auth status --json` command under a short timeout. Model the result
   as signed in, signed out, or unknown; Settings shows all three, Start refuses only a confirmed
-  logout, and an actual coaching failure still stops the unusable session loudly. Codex continues to
-  use its auth-file marker.
+  logout, and an actual coaching failure stops the unusable session without activating the app. A
+  fixed provider-only Activity notice explains that coaching stopped; the detailed error remains in
+  `jarvis-debug.log`. Codex continues to use its auth-file marker.
 - **Why:** Session `2026-07-18_15-25-46_366D` had an expired OAuth session, but the persistent
   `oauthAccount` metadata made Settings claim Claude was signed in. Claude's own status command reads
   its real credential store without making a model request and correctly distinguishes that stale
   marker from a working login.
 - **Rejected:** (a) Trusting the account marker as signed in — it caused the false status. (b) Treating
   every failed probe as signed out — a slow or broken executable is unknown, not proof of logout.
-  (c) Making a model request as preflight — it bills usage and duplicates the first real turn.
+  (c) Making a model request as preflight — it bills usage and duplicates the first real turn. (d)
+  Showing a modal alert for a mid-session failure — activating Jarvis can expose it during screen
+  sharing and breaks the app's ghost behavior.
 - **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
 - **Detail:** [settings-window.md → Brain](./settings-window.md#brain),
   `Sources/JarvisCore/Brain/AgentCLIDetector.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -315,6 +315,7 @@
 - **Chose:** A `BrainProvider` selection (Settings → Brain): the OpenAI Responses API (default), or a locally installed **Claude Code** / **Codex** CLI spawned per turn (`CLIBrainClient` behind the same `BrainClient` protocol), so the brain — coach, summarizer, evaluator — bills to the user's existing Claude / ChatGPT **subscription** instead of the metered key. CLIs are auto-detected by pure file probes (`AgentCLIDetector`: $PATH + known install dirs + on-disk auth markers; no subprocess, no Keychain prompt) so selection is one radio click. Tool use rides a prompt-embedded JSON protocol generated from the same `ToolDef`s; every turn is a single model call — screenshots reach Claude inline as base64 image blocks (stream-json input, all built-in tools disabled) and Codex as 0600 session-dir files via `-i` (`--sandbox read-only`); both CLIs run with session persistence off so no transcript copy lands in their own stores. The API-key section merged into the Brain tab — the key stays required for Realtime transcription regardless of provider.
 - **Why:** For a subscription holder, per-turn API billing is the product's dominant marginal cost; the CLIs expose the same frontier models under flat-rate plans the user already pays for. The `BrainClient` seam meant the driver, client-managed memory, retry, and traffic audit all carry over unchanged; detection-by-file-probe keeps the Settings tab instant and side-effect-free.
 - **Rejected:** (a) Wiring the CLIs' MCP interfaces for native tool calling — a protocol server + handshake per turn for three tools; the JSON-line protocol does the same job with a parser that tolerates prose/fences and degrades a forced `speak` to speaking the raw reply. (b) Auth verification by running the CLI at detection time — slow, may bill a request, and a Keychain prompt from `security` would be worse; the marker heuristic is a UI hint, with failures surfacing loudly at Start. (c) Replacing transcription too — the CLIs have no realtime audio surface; the OpenAI key remains the ears.
+- **Superseded in part by:** 2026-07-18 — Claude sign-in uses Claude's bounded auth-status command. Binary discovery and Codex's auth marker stand.
 - **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers), [settings-window.md → Brain](./settings-window.md#brain); egress note in [sandbox.md](./sandbox.md#data-egress).
 
 ### 2026-07-16 — Realtime transcript integrity is tracked per audio item
@@ -455,3 +456,21 @@
 - **Supersedes:** 2026-06-13 — One mode for v1: LeetCode Coach.
 - **Detail:** [architecture.md §2](./architecture.md#2-core-loop),
   `Sources/JarvisCore/Coach/ToolDefs.swift`.
+
+### 2026-07-18 — Claude sign-in uses Claude's bounded auth-status command
+
+- **Chose:** Keep CLI binary discovery as file probes, but determine Claude Code authentication by
+  running its non-billing `claude auth status --json` command under a short timeout. Model the result
+  as signed in, signed out, or unknown; Settings shows all three, Start refuses only a confirmed
+  logout, and an actual coaching failure still stops the unusable session loudly. Codex continues to
+  use its auth-file marker.
+- **Why:** Session `2026-07-18_15-25-46_366D` had an expired OAuth session, but the persistent
+  `oauthAccount` metadata made Settings claim Claude was signed in. Claude's own status command reads
+  its real credential store without making a model request and correctly distinguishes that stale
+  marker from a working login.
+- **Rejected:** (a) Trusting the account marker as signed in — it caused the false status. (b) Treating
+  every failed probe as signed out — a slow or broken executable is unknown, not proof of logout.
+  (c) Making a model request as preflight — it bills usage and duplicates the first real turn.
+- **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
+- **Detail:** [settings-window.md → Brain](./settings-window.md#brain),
+  `Sources/JarvisCore/Brain/AgentCLIDetector.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -477,3 +477,27 @@
 - **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
 - **Detail:** [settings-window.md → Brain](./settings-window.md#brain),
   `Sources/JarvisCore/Brain/AgentCLIDetector.swift`.
+
+### 2026-07-18 — Runtime failures preserve ghost mode
+
+- **Chose:** Treat startup and runtime failure presentation as separate policy. An explicit Start may
+  show a failure alert before a session exists; once a pipeline is live, every error path remains
+  non-presenting through terminal teardown. Terminal brain, microphone-transcription, and capture
+  failures stop silently; the system-audio path degrades silently. Fixed, non-sensitive notices go
+  to Activity and dynamic details go only to `jarvis-debug.log`. Activity evaluation/report opening
+  and history confirmation are disabled and race-guarded while coaching runs. A static gate requires
+  an inline reviewed exception on every API capable of presenting, activating, opening a URL,
+  requesting attention, notifying, or sounding.
+- **Why:** A modal or browser appearing during screen sharing exposes the assistant precisely when a
+  runtime failure makes it most likely. Severity alone also races: teardown can finish before a
+  queued main-actor alert executes. Capturing startup/runtime context at the failure site makes the
+  invariant independent of later session state, and the source guard prevents direct AppKit bypasses.
+- **Rejected:** (a) Alerting on terminal failures — operationally clear but violates ghost mode. (b)
+  Reading only current session state when the UI task executes — teardown turns a runtime failure
+  into a false startup state. (c) Hiding the persistent menu-bar item or blocking user-opened
+  Settings/Activity — those are named product surfaces and explicit user actions, not autonomous
+  disclosure. macOS privacy indicators remain unavoidable.
+- **Supersedes in part:** 2026-06-23 — Capture adapts to any input rate; startup fails loud. Startup
+  still fails loud; mid-session failures do not.
+- **Detail:** [architecture.md → Failure surfacing](./architecture.md#failure-surfacing--startup-loud-runtime-ghost),
+  `Sources/JarvisCore/Diagnostics/UserFacingError.swift`, `scripts/check-ghost-mode.sh`.

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -114,8 +114,9 @@ known install dirs, while Claude sign-in uses its non-billing `auth status --jso
 short timeout because account metadata can outlive an expired OAuth session. Codex keeps using its
 auth-file marker. The radios show **signed in**, **signed out**, or **sign-in unknown**; a confirmed
 logout refuses Start, while an unavailable probe warns but does not falsely claim logout. An actual
-CLI request can still fail after preflight; Jarvis then shows the provider error and stops the
-unusable coaching session with the provider's sign-in command.
+CLI request can still fail after preflight; Jarvis then stops the unusable coaching session without
+activating the app, adds a discreet provider-only notice to Activity, and keeps the detailed error
+and sign-in command in `jarvis-debug.log`.
 
 **Model + effort.** A **Model** dropdown drawn from `BrainModelCatalog` per provider (OpenAI ids for
 the API; CLI aliases like `sonnet` for the CLIs, plus a "CLI default" entry meaning "no model flag" —

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -52,7 +52,7 @@ so an unwrapped fixed-frame view would ride the bottom edge in a taller window).
 | `BrainSection` | "Brain" | yes | Everything that decides who answers a coaching turn, in one tab: the provider radios (OpenAI API / Claude Code / Codex CLI — see [Brain](#brain)), a per-provider model dropdown, the reasoning-effort dropdown (one global setting, mapped onto each provider's scale), and the OpenAI API-key controls (`APIKeyControls`: an `NSSecureTextField` that saves to an owner-only file and restarts the pipeline if already running). Takes effect on the next Start. |
 | `OverlaySection` | "Overlay" | yes | Two groups, one per overlay surface — **Overlay Caption** (the transient on-screen tip) and **Overlay Box** (the persistent response history). Each has a header with an On/Off toggle (an `NSSwitch` + "On"/"Off" label) and a one-line description. When a surface is **on** it also shows its Text Size + Opacity sliders (with live readouts) and a live sample, **only while the Overlay tab is selected** (`didBecomeActive`/`didResignActive`); when **off**, its sliders and sample are hidden and the layout collapses. Persists via `OverlayAppearance`. |
 | `DisplaySection` | "Screen" | yes | One dropdown — the capture scope: **Active window** (default) or one **Entire display** entry per connected display; persists via `ScreenCapturePreferences`. Applies to the next screenshot. |
-| `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `fillsTab == true` so the log stretches with the window. Its header carries **Evaluate** — one click sends the selected session's recorded LLM wire traffic (`brain-traffic.jsonl`) to the brain model at high effort for a context-engineering audit (`SessionEvaluator`), saved as `eval-report.md` in the session dir and opened in the browser as a rendered `eval-report.html` page (`EvalReportPage`) whose **Copy as Markdown** button hands the raw report to an agent chat; once a session has a saved report the button flips to **Open report**. Only *finished* conversations qualify: the button is disabled while the selected session is the live, still-running one (a mid-session audit would judge half a story) and re-enables once Stop has drained any in-flight turn — the cancelled request's final traffic line must land before the audit reads the file. |
+| `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `fillsTab == true` so the log stretches with the window. Its header shows the selected session's exact directory ID in a selectable field with **Copy ID**, and carries **Evaluate** — one click sends the selected session's recorded LLM wire traffic (`brain-traffic.jsonl`) to the brain model at high effort for a context-engineering audit (`SessionEvaluator`), saved as `eval-report.md` in the session dir and opened in the browser as a rendered `eval-report.html` page (`EvalReportPage`) whose **Copy as Markdown** button hands the raw report to an agent chat; once a session has a saved report the button flips to **Open report**. Only *finished* conversations qualify: the button is disabled while the selected session is the live, still-running one (a mid-session audit would judge half a story) and re-enables once Stop has drained any in-flight turn — the cancelled request's final traffic line must land before the audit reads the file. |
 
 `AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. All four sections
 are always present.
@@ -109,11 +109,13 @@ The Brain tab owns the whole "who answers a coaching turn" decision, persisted t
 installed **Claude Code** / **Codex CLI** — in which case coaching turns are spawned as CLI
 subprocesses and billed to the user's existing Claude / ChatGPT *subscription* instead of the key
 (`CLIBrainClient`; see [architecture.md](./architecture.md#local-cli-brain-providers)). Installed
-CLIs are auto-detected by `AgentCLIDetector` — pure file probes over $PATH + the CLIs' known install
-dirs and on-disk auth markers, re-run every time the tab is shown, so no subprocess is spawned and
-switching to a detected CLI is a single click. An uninstalled CLI shows as "not installed" and is
-disabled; a detected-but-unconfirmed sign-in still selects (the auth probe is a hint — macOS
-Keychain-only credentials are invisible to it).
+CLIs are auto-detected by `AgentCLIDetector`: binary discovery is a pure file probe over $PATH + the
+known install dirs, while Claude sign-in uses its non-billing `auth status --json` command under a
+short timeout because account metadata can outlive an expired OAuth session. Codex keeps using its
+auth-file marker. The radios show **signed in**, **signed out**, or **sign-in unknown**; a confirmed
+logout refuses Start, while an unavailable probe warns but does not falsely claim logout. An actual
+CLI request can still fail after preflight; Jarvis then shows the provider error and stops the
+unusable coaching session with the provider's sign-in command.
 
 **Model + effort.** A **Model** dropdown drawn from `BrainModelCatalog` per provider (OpenAI ids for
 the API; CLI aliases like `sonnet` for the CLIs, plus a "CLI default" entry meaning "no model flag" —
@@ -190,7 +192,7 @@ from an old entire-display selection never steers them.
 | `Sources/JarvisApp/Settings/NSScreen+DisplayTitles.swift` | Display naming for the dropdown's entire-display entries |
 | `Sources/JarvisApp/Settings/ActivitySection.swift` | Activity tab |
 | `Sources/JarvisCore/Brain/BrainProvider.swift` | The three providers |
-| `Sources/JarvisCore/Brain/AgentCLIDetector.swift` | CLI auto-detection (binary + auth markers) |
+| `Sources/JarvisCore/Brain/AgentCLIDetector.swift` | CLI binary discovery + bounded authentication-status detection |
 | `Sources/JarvisCore/Brain/BrainModelCatalog.swift` | Curated per-provider model lists (`BrainModel`) |
 | `Sources/JarvisCore/Brain/ReasoningEffort.swift` | The four effort levels |
 | `Sources/JarvisCore/Config/BrainPreferences.swift` | UserDefaults persistence + validation |

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -24,16 +24,18 @@ not acknowledge audio appends; server audio-clock progress retires only a safe p
 replacement socket replays the rest after a half-open failure. A live Wi-Fi reconnect run confirms
 that speech captured during the outage returns after recovery. The brain can also run through a
 locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
-those providers and keeps the OpenAI API-key path available.
+those providers, reports Claude's current sign-in state from its bounded status command, and keeps
+the OpenAI API-key path available. A failed CLI coaching request surfaces the provider error and
+stops the unusable session instead of leaving the listening state green.
 
 ## Next action
 
 Run the live prompt smoke on a fresh session: show an interview question without speaking its
 details, ask “Jarvis, how can I solve this in one pass?”, and confirm the first action is
 exactly one `capture_screen` followed by a screen-specific reply. Then ask a fully stated behavioral
-question and confirm it can answer without an unnecessary capture. Finish the remaining in-app CLI provider
-smoke: select a detected Claude Code or Codex provider, confirm a coaching turn and screen request,
-and confirm a missing CLI fails Start loudly. The standard release checklist remains in
+question and confirm it can answer without an unnecessary capture. Finish the in-app Claude Code
+provider smoke: confirm Settings shows it signed in, then confirm a coaching turn and screen request.
+Also confirm a missing or signed-out CLI fails loudly. The standard release checklist remains in
 [build-and-run.md](./build-and-run.md).
 
 ## Built
@@ -43,7 +45,7 @@ thin OS shell, verified by the smoke run.
 
 - `Sources/JarvisCore/Audio/` — transactional PCM + utterance buffering, adaptive content-free activity detection, non-destructive AEC reference alignment, and system-audio timeline preservation (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`, `AdaptiveAudioActivityDetector`, `EchoReferenceAlignment`, `SystemAudioTimeline`).
 - `Sources/JarvisCore/Transcription/` — realtime session wire contract, per-item event ledger, and rolling transcript (`RealtimeSession`, `RealtimeTranscriptionLedger`, `Transcript`, `NoiseReduction`).
-- `Sources/JarvisCore/Brain/` — the LLM integration: the `BrainClient` contract (`Brain`), `OpenAIBrainClient`, `CLIBrainClient` + `AgentCLIProcessRunner` + `AgentCLIDetector` (the local Claude Code / Codex brain providers), `RetryingBrainClient`, `BrainProvider`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
+- `Sources/JarvisCore/Brain/` — the LLM integration: the `BrainClient` contract (`Brain`), `OpenAIBrainClient`, `CLIBrainClient` + `AgentCLIProcessRunner` + `AgentCLIDetector`/`AgentCLIAuthenticationStatus` (the local Claude Code / Codex brain providers and sign-in state), `RetryingBrainClient`, `BrainProvider`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
 - `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver`, `CoachHistory` (client-managed session memory), `ToolDefs` (coach tools + system prompt).
 - `Sources/JarvisCore/Triggers/` — turn/silence trigger detection, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
 - `Sources/JarvisCore/Screen/` — the model-triggered screen-capture tool contract + window-scoped capture logic (`ScreenCapture`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`).
@@ -51,11 +53,11 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + brain/screen preferences (`Config`, `Secrets`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
 - `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation (single-call in-app **and** the agentic dev-side audit's prompt/transcript prep), user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `AgenticEvaluation`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
-- `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`).
+- `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`, including terminal CLI brain failures).
 - `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain (provider + model + API key) / Overlay / Screen / Activity sections).
 - `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.
-- `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the one-click **Evaluate** session audit.
+- `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with an exact selectable/copyable session ID and the one-click **Evaluate** session audit.
 - `Sources/EvalPrep/main.swift` — the Foundation-only CLI half of the agentic session audit; `scripts/eval-session.sh` drives it through an agentic CLI (`claude -p` / `codex exec`) over the repo + session dir (see the 2026-07-17 [decision](./decisions.md)).
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 C edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
 - `.github/workflows/release.yml` + `scripts/package-app.sh` — automated releases: release-please Release PR → Developer ID-signed, notarized, stapled `Jarvis-<version>.zip` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -25,8 +25,9 @@ replacement socket replays the rest after a half-open failure. A live Wi-Fi reco
 that speech captured during the outage returns after recovery. The brain can also run through a
 locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
 those providers, reports Claude's current sign-in state from its bounded status command, and keeps
-the OpenAI API-key path available. A failed CLI coaching request surfaces the provider error and
-stops the unusable session instead of leaving the listening state green.
+the OpenAI API-key path available. A failed CLI coaching request stops the unusable session without
+activating the app, leaves a discreet provider-only Activity notice, and keeps the detailed reason
+in `jarvis-debug.log` instead of leaving the listening state green.
 
 ## Next action
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -27,7 +27,10 @@ locally installed Claude Code or Codex CLI on the user's subscription; Settings 
 those providers, reports Claude's current sign-in state from its bounded status command, and keeps
 the OpenAI API-key path available. A failed CLI coaching request stops the unusable session without
 activating the app, leaves a discreet provider-only Activity notice, and keeps the detailed reason
-in `jarvis-debug.log` instead of leaving the listening state green.
+in `jarvis-debug.log` instead of leaving the listening state green. The same runtime ghost-mode rule
+now covers microphone transcription, audio-route loss, in-place CLI preflight, and Activity-audit
+completion: no runtime error autonomously activates Jarvis, opens a browser, or presents a modal;
+fixed notices remain available in Activity. The gate statically rejects unreviewed presentation APIs.
 
 ## Next action
 
@@ -54,7 +57,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + brain/screen preferences (`Config`, `Secrets`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
 - `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation (single-call in-app **and** the agentic dev-side audit's prompt/transcript prep), user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `AgenticEvaluation`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
-- `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (severity-driven `NSAlert`, including terminal CLI brain failures).
+- `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (startup alerts plus an unconditional no-presentation runtime policy).
 - `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain (provider + model + API key) / Overlay / Screen / Activity sections).
 - `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.


### PR DESCRIPTION
## Summary

- detect Claude Code authentication through its bounded, non-billing `auth status --json` command and show signed-in, signed-out, or unknown state in Settings
- show the selected Activity session's exact directory ID in a selectable field with a one-click Copy ID button
- enforce a hard runtime ghost-mode policy: failures may stop or degrade coaching, but cannot activate Jarvis, present a modal/window, open a browser, notify, request attention, or play a sound
- record fixed, non-sensitive Activity notices for CLI, microphone-transcription, audio-capture, system-audio, and live Settings-reapply failures while keeping dynamic details in `jarvis-debug.log`
- disable and race-guard Activity evaluation, report opening, and Clear history while coaching is running
- add a static presentation-API guard to the normal test gate and document the invariant and its explicit exceptions

## Root cause

Session `2026-07-18_15-25-46_366D` reached Claude Code, but its first brain invocation failed because the OAuth session had expired and could not be refreshed. Jarvis treated persistent `oauthAccount` metadata as proof of authentication, so Settings showed a false signed-in state. The runtime request failure was written only to diagnostics, leaving the session unable to coach without a discreet user-facing explanation.

A follow-up sub-agent audit found that ghost behavior was not general: terminal microphone transcription loss and an audio-route rebuild failure still flowed through fatal `NSAlert` presentation; a live CLI preflight recheck could show a warning; and a past-session Activity evaluation could finish after a new session began and open a browser or alert.

## User impact

Confirmed Claude logout now blocks Start, while an unavailable status probe is shown as unknown. Once a coaching pipeline is live, presentation context is captured at the failure site and every runtime severity is non-presenting even if teardown completes before the main-actor report executes. Terminal CLI, microphone, and capture failures stop silently; system-audio loss degrades to microphone-only. Activity receives only fixed redacted notices.

Explicit startup failures may still alert before a session exists. The persistent menu-bar item, user-invoked Settings/Activity surfaces, and unavoidable macOS privacy UI are named exceptions; the caption and box remain the only automatic windows, both nonactivating and capture-excluded.

## Validation

- `swift build && ./scripts/run-tests.sh`
  - ghost-mode presentation API guard passed
  - 421 tests in 53 suites passed
  - the opt-in live screen-capture test remained skipped
- `claude auth status --json` reports `loggedIn: true` after re-authentication
- review regressions cover inherited stdout, terminal coalescing, Start-while-draining classification, and single Settings auth probing

## Manual follow-up

- In-app Claude coaching-turn, runtime-failure Activity notice, and Activity Copy ID smoke checks remain to be run.