### PR TITLE
fix(brain): prevent Codex provider stalls

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -87,6 +87,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                            model: self.brainPreferences.model(for: provider).id,
                                            reasoningEffort: ReasoningEffort.high.rawValue,
                                            workDirectory: self.currentSessionDir ?? self.logDirectory(),
+                                           codexSupportedFeatures: cli.supportedFeatures,
                                            timeout: 600)   // a big session transcript takes minutes, not seconds
                 return SessionEvaluator(brain: brain)
             }
@@ -246,11 +247,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                        model: brainPreferences.model(for: brainProvider).id,
                                        reasoningEffort: brainPreferences.effort.rawValue,
                                        workDirectory: sessionDir,
+                                       codexSupportedFeatures: cli.supportedFeatures,
                                        traffic: sessionTraffic, trafficTag: "coach")
             summarizer = CLIBrainClient(provider: brainProvider, executable: cli.executableURL,
                                         model: BrainModelCatalog.summarizerModelID(for: brainProvider),
                                         reasoningEffort: ReasoningEffort.low.rawValue,
                                         workDirectory: sessionDir,
+                                        codexSupportedFeatures: cli.supportedFeatures,
                                         traffic: sessionTraffic, trafficTag: "summarizer")
         } else {
             coachBase = OpenAIBrainClient(apiKey: key, model: brainPreferences.model.id,

--- a/Sources/JarvisCore/Brain/AgentCLIDetector.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIDetector.swift
@@ -5,10 +5,10 @@ import Darwin
 import Glibc
 #endif
 
-/// Finds installed `claude` / `codex` CLIs and checks their sign-in state. Binary discovery stays a
-/// pure filesystem probe. Claude authentication comes from its non-billing `auth status --json`
-/// command because its on-disk account marker can survive an expired OAuth session; the command is
-/// bounded so Settings cannot hang on a broken CLI. Codex's auth file remains authoritative.
+/// Finds installed `claude` / `codex` CLIs and checks the local facts Jarvis needs before invoking
+/// them. Binary discovery stays a pure filesystem probe. Bounded, non-billing local commands read
+/// Claude's authoritative auth status and Codex's advertised feature names; Codex's auth file marker
+/// remains authoritative.
 public struct AgentCLIDetector: Sendable {
     private let home: URL
     private let pathVariable: String?
@@ -32,8 +32,12 @@ public struct AgentCLIDetector: Sendable {
     public func detect(_ provider: BrainProvider) -> DetectedAgentCLI? {
         guard let name = provider.cliExecutableName else { return nil }
         guard let url = firstExecutable(named: name) else { return nil }
-        return DetectedAgentCLI(provider: provider, executableURL: url,
-                                authenticationStatus: authenticationStatus(provider, executable: url))
+        return DetectedAgentCLI(
+            provider: provider,
+            executableURL: url,
+            authenticationStatus: authenticationStatus(provider, executable: url),
+            supportedFeatures: provider == .codexCLI ? codexSupportedFeatures(executable: url) : []
+        )
     }
 
     /// The common install locations consulted after $PATH — the single source of truth, also used
@@ -84,16 +88,45 @@ public struct AgentCLIDetector: Sendable {
         let loggedIn: Bool
     }
 
-    /// The status document is tiny. This is only a runaway-output backstop for a broken wrapper,
+    /// Both probe documents are tiny. This is only a runaway-output backstop for a broken wrapper,
     /// and keeps the post-timeout pipe drain bounded in both time and memory.
-    private static let maxClaudeAuthStatusBytes = 64 * 1_024
+    private static let maxProbeOutputBytes = 64 * 1_024
 
     /// Claude's own status command reads whichever credential store that installation uses and does
     /// not make a model request. A malformed result or timeout is `unknown`, never "signed out".
     private func claudeAuthenticationStatus(executable: URL) -> AgentCLIAuthenticationStatus {
+        guard let output = runProbe(executable: executable,
+                                    arguments: ["auth", "status", "--json"]),
+              let status = try? JSONDecoder().decode(ClaudeAuthStatus.self, from: output.data)
+        else { return .unknown }
+        return status.loggedIn ? .signedIn : .signedOut
+    }
+
+    /// `--disable <feature>` rejects unknown names. Probe the installed binary's compiled feature
+    /// registry so Jarvis passes only names that installation advertises. Failure falls back to no
+    /// feature flags; the direct-response prompt, isolated project root, read-only sandbox, and short
+    /// timeout still bound the call without making an older or renamed CLI unusable.
+    private func codexSupportedFeatures(executable: URL) -> Set<String> {
+        guard let output = runProbe(executable: executable, arguments: ["features", "list"]),
+              output.status == 0,
+              let text = String(data: output.data, encoding: .utf8)
+        else { return [] }
+        return Set(text.split(separator: "\n").compactMap { line in
+            line.split(whereSeparator: \.isWhitespace).first.map(String.init)
+        })
+    }
+
+    private struct ProbeOutput {
+        let data: Data
+        let status: Int32
+    }
+
+    /// Run one local, non-model status/capability command under the same bounded process policy for
+    /// both CLIs. No API key is inherited, and stderr is irrelevant to the machine-readable probe.
+    private func runProbe(executable: URL, arguments: [String]) -> ProbeOutput? {
         let process = Process()
         process.executableURL = executable
-        process.arguments = ["auth", "status", "--json"]
+        process.arguments = arguments
         process.standardInput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         let stdout = Pipe()
@@ -111,7 +144,7 @@ public struct AgentCLIDetector: Sendable {
         do {
             try process.run()
         } catch {
-            return .unknown
+            return nil
         }
 
         // `Process` termination callbacks can be delayed while the test runner or app is busy.
@@ -126,17 +159,15 @@ public struct AgentCLIDetector: Sendable {
         process.waitUntilExit()
         terminator.cancel()
         killer.cancel()
-        let data = Self.readAvailableOutput(stdout.fileHandleForReading)
-        guard let status = try? JSONDecoder().decode(ClaudeAuthStatus.self, from: data) else {
-            return .unknown
-        }
-        return status.loggedIn ? .signedIn : .signedOut
+        let data = Self.readAvailableOutput(stdout.fileHandleForReading,
+                                            maxBytes: Self.maxProbeOutputBytes)
+        return ProbeOutput(data: data, status: process.terminationStatus)
     }
 
     /// Drain only bytes already available after the wrapper exits. A wrapper may leave a child
     /// holding the inherited stdout pipe open; a blocking `readDataToEndOfFile()` would then defeat
     /// the process watchdog while waiting for that unrelated child to close its writer.
-    private static func readAvailableOutput(_ handle: FileHandle) -> Data {
+    private static func readAvailableOutput(_ handle: FileHandle, maxBytes: Int) -> Data {
         let descriptor = handle.fileDescriptor
         let flags = fcntl(descriptor, F_GETFL)
         guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) >= 0 else {
@@ -147,8 +178,8 @@ public struct AgentCLIDetector: Sendable {
 
         var output = Data()
         var buffer = [UInt8](repeating: 0, count: 4_096)
-        while output.count < maxClaudeAuthStatusBytes {
-            let capacity = min(buffer.count, maxClaudeAuthStatusBytes - output.count)
+        while output.count < maxBytes {
+            let capacity = min(buffer.count, maxBytes - output.count)
             let count = read(descriptor, &buffer, capacity)
             if count > 0 {
                 output.append(contentsOf: buffer.prefix(Int(count)))

--- a/Sources/JarvisCore/Brain/AgentCLIProcessRunner.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIProcessRunner.swift
@@ -137,9 +137,12 @@ public enum AgentCLIProcessRunner {
         // Only a SIGTERM exit counts as our timeout — the flag alone could race a normal exit that
         // lands just as the watchdog fires.
         if timedOut.get() && process.terminationReason == .uncaughtSignal {
+            let stderr = String(decoding: stderrBox.get(), as: UTF8.self)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let detail = stderr.isEmpty ? "" : "; stderr: \(String(stderr.suffix(2_000)))"
             throw NSError(domain: "AgentCLIProcessRunner", code: NSURLErrorTimedOut, userInfo: [
                 NSLocalizedDescriptionKey:
-                    "\(run.executable.lastPathComponent) timed out after \(Int(run.timeout))s",
+                    "\(run.executable.lastPathComponent) timed out after \(Int(run.timeout))s\(detail)",
             ])
         }
         return AgentCLIOutput(stdout: String(decoding: stdoutBox.get(), as: UTF8.self),

--- a/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
@@ -71,18 +71,25 @@ extension CLIBrainClient {
             // (deleted after the run). read-only sandbox: the brain must not touch the filesystem
             // beyond reading its inputs. The final reply lands in --output-last-message (stdout is
             // a human-formatted log). --ephemeral mirrors claude's --no-session-persistence: no
-            // rollout transcript in ~/.codex/sessions/. --ignore-user-config mirrors claude's
-            // --setting-sources ""/--strict-mcp-config: no personal config, instructions, or MCP
-            // servers ahead of the harness's own protocol (auth still comes from CODEX_HOME per the
-            // CLI's docs); mcp_servers={} stays as belt and braces. "CLI default" model therefore
-            // means codex's built-in default here. Verified against codex-cli 0.144.
+            // rollout transcript in ~/.codex/sessions/. --ignore-user-config removes config.toml,
+            // but NOT AGENTS.md or project discovery; explicit root/doc overrides keep the coding
+            // harness out of this decision-only call. Codex has no general disable-all-tools flag,
+            // so turn off its current agentic feature surfaces. The prompt below covers remaining
+            // non-feature-gated built-ins, while read-only stays the enforcement backstop. Auth
+            // still comes from CODEX_HOME. "CLI default" means the built-in default. Verified
+            // against codex-cli 0.144.5.
             let replyFile = workDirectory.appendingPathComponent("cli-reply-\(UUID().uuidString.prefix(8)).txt")
             var transientFiles = [replyFile]
             var args = ["exec", "--skip-git-repo-check", "--sandbox", "read-only", "--ephemeral",
-                        "--ignore-user-config",
+                        "--ignore-user-config", "--ignore-rules",
                         "--output-last-message", replyFile.path,
                         "-c", "mcp_servers={}",
+                        "-c", "project_root_markers=[]",
+                        "-c", "project_doc_max_bytes=0",
                         "-c", "model_reasoning_effort=\(Self.codexEffort(reasoningEffort))"]
+            for feature in Self.codexDisabledAgentFeatures {
+                args += ["--disable", feature]
+            }
             if !model.isEmpty { args += ["-m", model] }
             var blocks: [String] = []
             var auditInput: [[String: Any]] = []
@@ -99,7 +106,8 @@ extension CLIBrainClient {
                     auditInput.append(["type": "image", "image": Self.imageStub(base64)])
                 }
             }
-            var document = instructions.isEmpty ? "" : instructions + "\n\n"
+            var document = Self.codexDirectResponseInstruction + "\n\n"
+            if !instructions.isEmpty { document += instructions + "\n\n" }
             document += "## Conversation\n\n" + blocks.joined(separator: "\n\n")
             if !tools.isEmpty { document += "\n\nAnswer now, following the tool protocol." }
             auditRequest["input"] = auditInput
@@ -113,6 +121,28 @@ extension CLIBrainClient {
             preconditionFailure("guarded in init")
         }
     }
+
+    /// Codex is a coding agent even under `exec`; these stable 0.144 feature gates remove the
+    /// built-in surfaces that can turn a three-way text decision into an agentic run. Keep this
+    /// list narrow: an unknown feature name makes a future CLI reject the whole invocation.
+    static let codexDisabledAgentFeatures = [
+        "apps",
+        "browser_use",
+        "code_mode_host",
+        "computer_use",
+        "goals",
+        "image_generation",
+        "multi_agent",
+        "plugins",
+        "shell_tool",
+        "unified_exec",
+    ]
+
+    static let codexDirectResponseInstruction = """
+        Answer this decision request immediately without inspecting files, running commands,
+        browsing, planning, delegating, or invoking any Codex built-in tool. The capture_screen,
+        speak, and stay_silent names below are an output JSON protocol, not callable Codex tools.
+        """
 
     /// One stream-json user message carrying the whole conversation: text blocks coalesced,
     /// screenshots as inline base64 image blocks in their original positions. Inline images are why

--- a/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
@@ -74,10 +74,10 @@ extension CLIBrainClient {
             // rollout transcript in ~/.codex/sessions/. --ignore-user-config removes config.toml,
             // but NOT AGENTS.md or project discovery; explicit root/doc overrides keep the coding
             // harness out of this decision-only call. Codex has no general disable-all-tools flag,
-            // so turn off its current agentic feature surfaces. The prompt below covers remaining
-            // non-feature-gated built-ins, while read-only stays the enforcement backstop. Auth
-            // still comes from CODEX_HOME. "CLI default" means the built-in default. Verified
-            // against codex-cli 0.144.5.
+            // so turn off only agentic feature names advertised by this installation's bounded
+            // `features list` probe. The prompt below covers remaining/non-advertised built-ins,
+            // while read-only stays the enforcement backstop. Auth still comes from CODEX_HOME.
+            // "CLI default" means the built-in default. Verified against codex-cli 0.144.5.
             let replyFile = workDirectory.appendingPathComponent("cli-reply-\(UUID().uuidString.prefix(8)).txt")
             var transientFiles = [replyFile]
             var args = ["exec", "--skip-git-repo-check", "--sandbox", "read-only", "--ephemeral",
@@ -87,7 +87,7 @@ extension CLIBrainClient {
                         "-c", "project_root_markers=[]",
                         "-c", "project_doc_max_bytes=0",
                         "-c", "model_reasoning_effort=\(Self.codexEffort(reasoningEffort))"]
-            for feature in Self.codexDisabledAgentFeatures {
+            for feature in Self.codexDisabledAgentFeatures where codexSupportedFeatures.contains(feature) {
                 args += ["--disable", feature]
             }
             if !model.isEmpty { args += ["-m", model] }
@@ -122,9 +122,9 @@ extension CLIBrainClient {
         }
     }
 
-    /// Codex is a coding agent even under `exec`; these stable 0.144 feature gates remove the
-    /// built-in surfaces that can turn a three-way text decision into an agentic run. Keep this
-    /// list narrow: an unknown feature name makes a future CLI reject the whole invocation.
+    /// Codex is a coding agent even under `exec`; these feature gates remove built-in surfaces that
+    /// can turn a three-way text decision into an agentic run. The invocation intersects this list
+    /// with the installed CLI's advertised features, so renamed or unavailable names are omitted.
     static let codexDisabledAgentFeatures = [
         "apps",
         "browser_use",

--- a/Sources/JarvisCore/Brain/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient.swift
@@ -23,6 +23,9 @@ public struct CLIBrainClient: BrainClient, @unchecked Sendable {
     /// starts at `low`), `-c model_reasoning_effort=…` on Codex (which accepts ours unchanged).
     let reasoningEffort: String
     let workDirectory: URL
+    /// Feature names advertised by this Codex installation. Empty is the compatible fallback: never
+    /// send a guessed `--disable` value that an older or renamed CLI would reject.
+    let codexSupportedFeatures: Set<String>
     let timeout: TimeInterval
     let traffic: BrainTrafficLog?
     let trafficTag: String
@@ -40,6 +43,7 @@ public struct CLIBrainClient: BrainClient, @unchecked Sendable {
                 model: String,
                 reasoningEffort: String = ReasoningEffort.default.rawValue,
                 workDirectory: URL,
+                codexSupportedFeatures: Set<String> = [],
                 timeout: TimeInterval? = nil,
                 traffic: BrainTrafficLog? = nil,
                 trafficTag: String = "coach",
@@ -50,6 +54,7 @@ public struct CLIBrainClient: BrainClient, @unchecked Sendable {
         self.model = model
         self.reasoningEffort = reasoningEffort
         self.workDirectory = workDirectory
+        self.codexSupportedFeatures = codexSupportedFeatures
         self.timeout = timeout ?? (provider == .codexCLI
                                    ? Self.codexDefaultTimeout : Self.defaultTimeout)
         self.traffic = traffic

--- a/Sources/JarvisCore/Brain/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient.swift
@@ -31,13 +31,16 @@ public struct CLIBrainClient: BrainClient, @unchecked Sendable {
     /// A CLI turn pays process startup + agentic overhead on top of model latency, so the hang
     /// backstop sits well above the API client's. Still a backstop, not a latency knob.
     public static let defaultTimeout: TimeInterval = 120
+    /// Healthy Codex coach turns take seconds. A silent agent-runtime stall must not leave the
+    /// listening session green for two minutes while later transcript turns only batch behind it.
+    public static let codexDefaultTimeout: TimeInterval = 30
 
     public init(provider: BrainProvider,
                 executable: URL,
                 model: String,
                 reasoningEffort: String = ReasoningEffort.default.rawValue,
                 workDirectory: URL,
-                timeout: TimeInterval = CLIBrainClient.defaultTimeout,
+                timeout: TimeInterval? = nil,
                 traffic: BrainTrafficLog? = nil,
                 trafficTag: String = "coach",
                 run: Runner? = nil) {
@@ -47,7 +50,8 @@ public struct CLIBrainClient: BrainClient, @unchecked Sendable {
         self.model = model
         self.reasoningEffort = reasoningEffort
         self.workDirectory = workDirectory
-        self.timeout = timeout
+        self.timeout = timeout ?? (provider == .codexCLI
+                                   ? Self.codexDefaultTimeout : Self.defaultTimeout)
         self.traffic = traffic
         self.trafficTag = trafficTag
         self.run = run ?? { try await AgentCLIProcessRunner.run($0) }

--- a/Sources/JarvisCore/Brain/DetectedAgentCLI.swift
+++ b/Sources/JarvisCore/Brain/DetectedAgentCLI.swift
@@ -5,11 +5,16 @@ public struct DetectedAgentCLI: Sendable, Equatable {
     public let provider: BrainProvider
     public let executableURL: URL
     public let authenticationStatus: AgentCLIAuthenticationStatus
+    /// Feature names advertised by a Codex CLI's local `features list` command. Empty for Claude or
+    /// when the bounded probe is unavailable, so callers never guess flags an installation rejects.
+    public let supportedFeatures: Set<String>
 
     public init(provider: BrainProvider, executableURL: URL,
-                authenticationStatus: AgentCLIAuthenticationStatus) {
+                authenticationStatus: AgentCLIAuthenticationStatus,
+                supportedFeatures: Set<String> = []) {
         self.provider = provider
         self.executableURL = executableURL
         self.authenticationStatus = authenticationStatus
+        self.supportedFeatures = supportedFeatures
     }
 }

--- a/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
@@ -151,10 +151,39 @@ import Glibc
 
     @Test func codexAuthDetectedViaAuthJSON() throws {
         let home = try makeHome()
-        try installBinary("codex", in: home.appendingPathComponent(".local/bin"))
+        let bin = home.appendingPathComponent("fakebin")
+        try installBinary("codex", in: bin, script: """
+            #!/bin/sh
+            if [ "$1" = "features" ] && [ "$2" = "list" ]; then
+                printf '%s\\n' 'shell_tool stable true' 'code_mode_host stable true'
+                exit 0
+            fi
+            exit 2
+            """)
         try write("{}", to: home.appendingPathComponent(".codex/auth.json"))
-        let d = AgentCLIDetector(home: home, pathVariable: nil)
-        #expect(d.detect(.codexCLI)?.authenticationStatus == .signedIn)
+        let d = AgentCLIDetector(home: home, pathVariable: bin.path, authStatusTimeout: 10)
+        let cli = d.detect(.codexCLI)
+        #expect(cli?.authenticationStatus == .signedIn)
+        #expect(cli?.supportedFeatures == ["shell_tool", "code_mode_host"])
+    }
+
+    @Test func codexFeatureProbeFailureFallsBackToNoGuessedFlags() throws {
+        let home = try makeHome()
+        let bin = home.appendingPathComponent("fakebin")
+        try installBinary("codex", in: bin)
+        let d = AgentCLIDetector(home: home, pathVariable: bin.path)
+        #expect(d.detect(.codexCLI)?.supportedFeatures == [])
+    }
+
+    @Test func codexFeatureProbeIsBounded() throws {
+        let home = try makeHome()
+        let bin = home.appendingPathComponent("fakebin")
+        try installBinary("codex", in: bin, script: """
+            #!/bin/sh
+            exec sleep 1
+            """)
+        let d = AgentCLIDetector(home: home, pathVariable: bin.path, authStatusTimeout: 0.01)
+        #expect(d.detect(.codexCLI)?.supportedFeatures == [])
     }
 
     @Test func missingBinaryDetectsNothing() throws {

--- a/Tests/JarvisCoreTests/Brain/AgentCLIProcessRunnerTests.swift
+++ b/Tests/JarvisCoreTests/Brain/AgentCLIProcessRunnerTests.swift
@@ -35,15 +35,19 @@ import Foundation
     }
 
     @Test func hungProcessIsTerminatedAtTimeout() async {
-        // /bin/sleep directly (not `sh -c "sleep 30"`): a shell would FORK sleep, and the orphan
-        // holding the inherited pipe write-ends stalls corelibs-Foundation's exit detection on Linux
-        // until the grandchild dies — which would test the orphan, not the watchdog.
-        let run = AgentCLIRun(executable: URL(fileURLWithPath: "/bin/sleep"),
-                              arguments: ["30"], stdin: nil,
+        // `exec` replaces the shell instead of forking sleep, so the timeout tests the watchdog and
+        // also proves partial provider diagnostics survive into the reported error.
+        let run = AgentCLIRun(executable: URL(fileURLWithPath: "/bin/sh"),
+                              arguments: ["-c", "echo startup-stalled 1>&2; exec /bin/sleep 30"],
+                              stdin: nil,
                               workingDirectory: FileManager.default.temporaryDirectory,
                               timeout: 0.3)
-        await #expect(throws: (any Error).self) {
+        do {
             _ = try await AgentCLIProcessRunner.run(run)
+            Issue.record("expected timeout")
+        } catch {
+            #expect(error.localizedDescription.contains("timed out"))
+            #expect(error.localizedDescription.contains("startup-stalled"))
         }
     }
 }

--- a/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
@@ -154,7 +154,17 @@ import Foundation
         let run = try #require(captured.value)
         #expect(run.arguments.contains("exec"))
         #expect(run.arguments.contains("--ephemeral"))            // no rollout transcript in ~/.codex
-        #expect(run.arguments.contains("--ignore-user-config"))   // no personal config/rules injected
+        #expect(run.arguments.contains("--ignore-user-config"))   // no personal config injected
+        #expect(run.arguments.contains("--ignore-rules"))         // no exec-policy discovery
+        #expect(run.arguments.contains("project_root_markers=[]"))
+        #expect(run.arguments.contains("project_doc_max_bytes=0"))
+        let disabled = Set(zip(run.arguments, run.arguments.dropFirst()).compactMap {
+            flag, value in flag == "--disable" ? value : nil
+        })
+        #expect(disabled == Set(CLIBrainClient.codexDisabledAgentFeatures))
+        #expect(run.stdin?.hasPrefix(CLIBrainClient.codexDirectResponseInstruction) == true)
+        #expect(run.stdin?.contains("not callable Codex tools") == true)
+        #expect(run.timeout == CLIBrainClient.codexDefaultTimeout)
         #expect(run.arguments.contains("-i"))
         #expect(!run.arguments.contains("-m"))          // empty model = the CLI's own default
         guard case .staySilent = response.toolCalls.first else {

--- a/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
@@ -28,9 +28,14 @@ import Foundation
 
     private func client(_ provider: BrainProvider, workDir: URL, model: String = "sonnet",
                         effort: String = "low",
+                        codexSupportedFeatures: Set<String>? = nil,
                         run: @escaping CLIBrainClient.Runner) -> CLIBrainClient {
         CLIBrainClient(provider: provider, executable: URL(fileURLWithPath: "/fake/bin/cli"),
-                       model: model, reasoningEffort: effort, workDirectory: workDir, run: run)
+                       model: model, reasoningEffort: effort, workDirectory: workDir,
+                       codexSupportedFeatures: codexSupportedFeatures
+                           ?? (provider == .codexCLI
+                               ? Set(CLIBrainClient.codexDisabledAgentFeatures) : []),
+                       run: run)
     }
 
     // MARK: - Claude invocation + parsing
@@ -187,6 +192,25 @@ import Foundation
         #expect(run.arguments.contains("model_reasoning_effort=none"))
         #expect(run.arguments.contains("mcp_servers={}"))
         #expect(run.arguments.contains("gpt-5.5"))
+    }
+
+    @Test func codexDisablesOnlyFeaturesAdvertisedByTheInstalledCLI() async throws {
+        let workDir = try makeWorkDir()
+        let captured = Captured<AgentCLIRun>()
+        let c = client(.codexCLI, workDir: workDir, model: "",
+                       codexSupportedFeatures: ["shell_tool", "renamed_future_feature"]) { run in
+            captured.value = run
+            return AgentCLIOutput(stdout: "", stderr: "", exitCode: 0)
+        }
+
+        _ = try? await c.respond(messages: [.user("x")], tools: [], toolChoice: .auto)
+        let arguments = try #require(captured.value).arguments
+        let disabled = zip(arguments, arguments.dropFirst()).compactMap {
+            flag, value in flag == "--disable" ? value : nil
+        }
+        #expect(disabled == ["shell_tool"])
+        #expect(!arguments.contains("code_mode_host"))
+        #expect(!arguments.contains("renamed_future_feature"))
     }
 
     @Test func claudeEffortMapsNoneToItsFloorAndPassesTheRestThrough() async throws {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -239,17 +239,20 @@ memory, retries, and traffic recording are all unchanged — only the transport 
   with `--tools ""` (every built-in disabled) a turn can't go agentic at all. Codex has no inline
   image input, so for it screenshots become 0600 files in the per-session log directory (which
   already persists every screenshot the model sees — same data posture), attached via `-i` and
-  deleted when the run finishes. Codex's feature-gated shell, code-mode, delegation, browser/app,
-  plugin, and other agentic surfaces are disabled; project-root/document discovery is suppressed;
-  and the leading instruction explicitly treats the three Jarvis tool names as an output protocol,
-  not Codex tools. `--sandbox read-only` remains the enforcement backstop for built-ins Codex does
-  not expose a disable switch for. Claude runs with its persona replaced (`--system-prompt`) and no
-  settings sources, and the one reasoning-effort setting maps onto each CLI's own scale.
+  deleted when the run finishes. A bounded local capability probe reads the installed Codex CLI's
+  advertised feature names; its supported shell, code-mode, delegation, browser/app, plugin, and
+  other agentic surfaces are disabled without guessing flags that an older or renamed CLI rejects.
+  Project-root/document discovery is suppressed, and the leading instruction explicitly treats the
+  three Jarvis tool names as an output protocol, not Codex tools. `--sandbox read-only` remains the
+  enforcement backstop for built-ins Codex does not expose a disable switch for. Claude runs with
+  its persona replaced (`--system-prompt`) and no settings sources, and the one reasoning-effort
+  setting maps onto each CLI's own scale.
 - **Installed CLIs are auto-detected.** `AgentCLIDetector` discovers binaries through file probes
   over $PATH + known install dirs. Claude's actual sign-in state comes from its non-billing
   `auth status --json` command under a short timeout, because stale account metadata can survive an
-  expired OAuth session; Codex uses its auth-file marker. Settings distinguishes signed in, signed
-  out, and an unavailable probe, and Start refuses a confirmed logout.
+  expired OAuth session; Codex uses its auth-file marker and a bounded, non-model `features list`
+  capability probe. Settings distinguishes signed in, signed out, and an unavailable auth probe,
+  and Start refuses a confirmed logout.
 - **The OpenAI key stays required**: transcription always runs on the Realtime API. A CLI provider
   moves the brain/summarizer/evaluator off the key, not the ears. **Latency is the tradeoff**,
   though a modest one now that every turn is one model call: measured coach turns run ~2.6s (text)

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -239,10 +239,12 @@ memory, retries, and traffic recording are all unchanged — only the transport 
   with `--tools ""` (every built-in disabled) a turn can't go agentic at all. Codex has no inline
   image input, so for it screenshots become 0600 files in the per-session log directory (which
   already persists every screenshot the model sees — same data posture), attached via `-i` and
-  deleted when the run finishes; its coach turns have nothing to execute, so they're single-call in
-  practice. Codex runs `--sandbox read-only`; Claude runs with its persona replaced
-  (`--system-prompt`) and no settings sources, and the one reasoning-effort setting maps onto each
-  CLI's own scale.
+  deleted when the run finishes. Codex's feature-gated shell, code-mode, delegation, browser/app,
+  plugin, and other agentic surfaces are disabled; project-root/document discovery is suppressed;
+  and the leading instruction explicitly treats the three Jarvis tool names as an output protocol,
+  not Codex tools. `--sandbox read-only` remains the enforcement backstop for built-ins Codex does
+  not expose a disable switch for. Claude runs with its persona replaced (`--system-prompt`) and no
+  settings sources, and the one reasoning-effort setting maps onto each CLI's own scale.
 - **Installed CLIs are auto-detected.** `AgentCLIDetector` discovers binaries through file probes
   over $PATH + known install dirs. Claude's actual sign-in state comes from its non-billing
   `auth status --json` command under a short timeout, because stale account metadata can survive an
@@ -254,7 +256,7 @@ memory, retries, and traffic recording are all unchanged — only the transport 
   / ~3.3s (with screenshot) on claude sonnet at low effort, ~5–8s on codex — versus the direct
   API's sub-2s target. The invocation is kept deliberately slim (persona replaced, no settings
   sources or personal codex config — `--ignore-user-config` — **zero MCP servers** via
-  `--strict-mcp-config` / `-c mcp_servers={}`, no built-in tools),
+  `--strict-mcp-config` / `-c mcp_servers={}`, and no feature-gated Codex agent tools),
   so what remains is irreducible from outside: claude's floor is ~0.7s of process overhead + model
   time; codex's is ~4.7s even for a trivial prompt because its fixed coding-agent scaffold (a
   built-in multi-thousand-token system prompt that `exec` offers no flag to replace) rides every
@@ -310,9 +312,11 @@ The always-on legs are built to survive transient failure rather than die on it:
   their retained PCM is transcribed by the replacement session instead of first emitting a partial
   or gap that the replay would duplicate. Stale speech state therefore cannot suppress silence
   coaching after reconnect. Reconnect uses capped exponential backoff.
-- **The brain call** is single-flighted (a turn can't double-speak) and runs under a generous request
-  timeout — a hang backstop set well above the reasoning-turn tail, so a slow turn is waited out, not
-  abandoned. Because client-owned memory makes every request self-contained and tool effects happen
+- **The brain call** is single-flighted (a turn can't double-speak) and runs under a provider-aware
+  request timeout. The API and Claude ceilings stay well above the reasoning-turn tail; Codex has a
+  shorter bound because a healthy decision turn takes seconds and a silent agent-runtime stall would
+  otherwise batch every later transcript turn behind it. Because client-owned memory makes every
+  request self-contained and tool effects happen
   only after a response reaches the driver, a transient transport failure or retryable server error
   gets **one immediate automatic retry** without duplicating a screenshot or spoken tip. Cancellation,
   authentication, malformed requests, rate limits, and other permanent failures do not retry. If both

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -316,6 +316,7 @@
 - **Why:** For a subscription holder, per-turn API billing is the product's dominant marginal cost; the CLIs expose the same frontier models under flat-rate plans the user already pays for. The `BrainClient` seam meant the driver, client-managed memory, retry, and traffic audit all carry over unchanged; detection-by-file-probe keeps the Settings tab instant and side-effect-free.
 - **Rejected:** (a) Wiring the CLIs' MCP interfaces for native tool calling — a protocol server + handshake per turn for three tools; the JSON-line protocol does the same job with a parser that tolerates prose/fences and degrades a forced `speak` to speaking the raw reply. (b) Auth verification by running the CLI at detection time — slow, may bill a request, and a Keychain prompt from `security` would be worse; the marker heuristic is a UI hint, with failures surfacing loudly at Start. (c) Replacing transcription too — the CLIs have no realtime audio surface; the OpenAI key remains the ears.
 - **Superseded in part by:** 2026-07-18 — Claude sign-in uses Claude's bounded auth-status command. Binary discovery and Codex's auth marker stand.
+- **Superseded in part by:** 2026-07-18 — Codex coaching invocations are isolated and bounded.
 - **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers), [settings-window.md → Brain](./settings-window.md#brain); egress note in [sandbox.md](./sandbox.md#data-egress).
 
 ### 2026-07-16 — Realtime transcript integrity is tracked per audio item
@@ -501,3 +502,28 @@
   still fails loud; mid-session failures do not.
 - **Detail:** [architecture.md → Failure surfacing](./architecture.md#failure-surfacing--startup-loud-runtime-ghost),
   `Sources/JarvisCore/Diagnostics/UserFacingError.swift`, `scripts/check-ghost-mode.sh`.
+
+### 2026-07-18 — Codex coaching invocations are isolated and bounded
+
+- **Chose:** Keep `codex exec` as the subscription-backed transport, but make a coaching turn a
+  direct-response decision rather than a coding-agent run: suppress project-root/document and rules
+  discovery, disable Codex's feature-gated shell/code-mode/delegation/browser/app/plugin surfaces,
+  explicitly forbid remaining built-in tools in the prompt, and retain read-only sandboxing as the
+  enforcement backstop. Codex gets a shorter default stall timeout than Claude, and a timed-out
+  process includes its bounded stderr tail in the session diagnostic.
+- **Why:** Session `2026-07-18_20-50-10_4AC2` reached the first Codex request, then produced no reply
+  for 62.968 seconds; Stop was the only reason it ended, so the traffic record contained only a
+  generic cancellation. The installed 0.144.5 CLI still enabled its coding-agent feature surface,
+  while Jarvis incorrectly treated `--sandbox read-only` and `--ignore-user-config` as if they
+  disabled tools and instruction discovery. That let a three-way coach decision enter Codex's much
+  heavier agent runtime, where current GPT-5.6 Sol/macOS releases also have a reported code-mode-host
+  stall/failure path.
+- **Rejected:** (a) Silently falling back to the metered API or another CLI — changes the user's
+  selected provider and billing path. (b) Keeping the two-minute generic timeout — later speech only
+  batches behind the stuck turn. (c) Treating read-only as no-tools — it limits filesystem mutation
+  but does not remove shell, delegation, browser, or other tool definitions. (d) Replacing the
+  coaching transport with Codex app-server/SDK — substantially more lifecycle and protocol surface
+  when this call needs one final text object.
+- **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
+- **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers),
+  `Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift`, `AgentCLIProcessRunner.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -507,10 +507,12 @@
 
 - **Chose:** Keep `codex exec` as the subscription-backed transport, but make a coaching turn a
   direct-response decision rather than a coding-agent run: suppress project-root/document and rules
-  discovery, disable Codex's feature-gated shell/code-mode/delegation/browser/app/plugin surfaces,
-  explicitly forbid remaining built-in tools in the prompt, and retain read-only sandboxing as the
-  enforcement backstop. Codex gets a shorter default stall timeout than Claude, and a timed-out
-  process includes its bounded stderr tail in the session diagnostic.
+  discovery, probe the installed CLI's advertised feature names and disable its supported
+  shell/code-mode/delegation/browser/app/plugin surfaces, explicitly forbid remaining built-in tools
+  in the prompt, and retain read-only sandboxing as the enforcement backstop. A missing capability
+  probe falls back to no guessed feature flags, so older or renamed CLIs are not rejected before the
+  direct-response safeguards run. Codex gets a shorter default stall timeout than Claude, and a
+  timed-out process includes its bounded stderr tail in the session diagnostic.
 - **Why:** Session `2026-07-18_20-50-10_4AC2` reached the first Codex request, then produced no reply
   for 62.968 seconds; Stop was the only reason it ended, so the traffic record contained only a
   generic cancellation. The installed 0.144.5 CLI still enabled its coding-agent feature surface,

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -25,9 +25,14 @@ replacement socket replays the rest after a half-open failure. A live Wi-Fi reco
 that speech captured during the outage returns after recovery. The brain can also run through a
 locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
 those providers, reports Claude's current sign-in state from its bounded status command, and keeps
-the OpenAI API-key path available. A failed CLI coaching request stops the unusable session without
-activating the app, leaves a discreet provider-only Activity notice, and keeps the detailed reason
-in `jarvis-debug.log` instead of leaving the listening state green. The same runtime ghost-mode rule
+the OpenAI API-key path available. Codex coaching calls suppress project instructions and its
+feature-gated agent tools, run as direct-response decisions, and stop under a provider-specific
+stall bound instead of leaving later speech batched indefinitely. A live synthetic greeting through
+the isolated Codex 0.144.5 invocation returned a valid `speak` action without entering a coding tool.
+A failed CLI coaching request
+stops the unusable session without activating the app, leaves a discreet provider-only Activity
+notice, and keeps the detailed reason in `jarvis-debug.log` instead of leaving the listening state
+green. The same runtime ghost-mode rule
 now covers microphone transcription, audio-route loss, in-place CLI preflight, and Activity-audit
 completion: no runtime error autonomously activates Jarvis, opens a browser, or presents a modal;
 fixed notices remain available in Activity. The gate statically rejects unreviewed presentation APIs.
@@ -39,8 +44,8 @@ details, ask “Jarvis, how can I solve this in one pass?”, and confirm the fi
 exactly one `capture_screen` followed by a screen-specific reply. Then ask a fully stated behavioral
 question and confirm it can answer without an unnecessary capture. Finish the in-app Claude Code
 provider smoke: confirm Settings shows it signed in, then confirm a coaching turn and screen request.
-Also confirm a missing or signed-out CLI fails loudly. The standard release checklist remains in
-[build-and-run.md](./build-and-run.md).
+Finish the in-app Codex smoke through audio and the overlay, then confirm a missing or signed-out CLI
+fails loudly. The standard release checklist remains in [build-and-run.md](./build-and-run.md).
 
 ## Built
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -27,9 +27,7 @@ locally installed Claude Code or Codex CLI on the user's subscription; Settings 
 those providers, reports Claude's current sign-in state from its bounded status command, and keeps
 the OpenAI API-key path available. Codex coaching calls suppress project instructions and its
 feature-gated agent tools, run as direct-response decisions, and stop under a provider-specific
-stall bound instead of leaving later speech batched indefinitely. A live synthetic greeting through
-the isolated Codex 0.144.5 invocation returned a valid `speak` action without entering a coding tool.
-A failed CLI coaching request
+stall bound instead of leaving later speech batched indefinitely. A failed CLI coaching request
 stops the unusable session without activating the app, leaves a discreet provider-only Activity
 notice, and keeps the detailed reason in `jarvis-debug.log` instead of leaving the listening state
 green. The same runtime ghost-mode rule


### PR DESCRIPTION
## Summary

- isolate Codex coaching turns from repository instructions, MCP servers, and feature-gated coding-agent tools
- keep a narrow Jarvis policy list of agentic Codex features, but pass `--disable` only for names the installed CLI advertises
- make Codex requests direct-response decisions with a 30-second stall bound
- preserve bounded stderr diagnostics on timeout and add regression coverage
- update the architecture, decision log, and current project status

## Why

Session `2026-07-18_20-50-10_4AC2` showed healthy transcription, but its first `codex exec` request produced no response for 62.968 seconds. Later speech batched behind that turn, and stopping Jarvis was the only reason the request ended.

Jarvis treated `--sandbox read-only` and `--ignore-user-config` as if they removed Codex's coding-agent surface. They do not: the installed 0.144.5 CLI still exposed shell/code-mode/delegation/browser/app/plugin features, and project instruction discovery remained available.

The hardcoded feature set is an intentional Jarvis safety policy, not a claim that every Codex version supports those names. `codex features list` reports availability but does not classify features as agentic or safe to disable, so disabling every advertised feature would also disable unrelated runtime capabilities. Jarvis therefore computes:

`known agentic features Jarvis wants off ∩ feature names advertised by this installed CLI`

Unknown, removed, or renamed names are never passed to `--disable`. If the bounded capability probe fails, Jarvis passes no guessed feature flags and retains the direct-response prompt, isolated project context, read-only sandbox, and stall timeout.

## Manual validation

- Ran the exact repaired Codex 0.144.5 invocation with ChatGPT authentication and a synthetic greeting; GPT-5.6 Sol returned:
  `{"tool":"speak","arguments":{"lines":["Yes, I can hear you."]}}`
- Confirmed the request exited successfully within a few seconds without invoking a coding tool.
- `./scripts/run-tests.sh --filter AgentCLIDetectorTests`: 14 passed.
- `./scripts/run-tests.sh --filter CLIBrainClientTests`: 18 passed.
- `./scripts/run-tests.sh --filter OverlayInvisibilityTests`: 18 passed.
- `swift build`: passed.
- Ghost-mode presentation guard: passed.

### Full-gate caveat

The rebased `swift build && ./scripts/run-tests.sh` run built successfully and all Codex/provider tests passed, but the existing AppKit overlay timing suite flaked under the full parallel load (`reEnabledCaptionShowsTipsAgain`, `overlayBlanksBetweenConsecutiveLines`, `overlayHidesPanelAfterQueueDrains`, and `overlayExpandsToFitLongText`). The same 18-test overlay suite passes immediately when isolated. This PR does not touch overlay code.

## Remaining live check

Run one fresh in-app greeting to cover the physical microphone → transcription → Codex → overlay path.