### PR TITLE
ci: drop duplicate push-to-main test runs; cap job timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ name: CI
 # Recording) or exercise the live capture pipeline, so a bundled artifact would carry no extra
 # signal. Bundling/signing stays a local step (scripts/build-app.sh).
 
+# PR-only on purpose: every change lands through a PR (already tested here), and a release merge
+# is re-tested by release.yml's publish gate — a push-to-main trigger would run the same suite a
+# second time on the same commit, at the 10x macOS minute multiplier. The cost of this choice:
+# a direct push to main isn't tested until the next PR or release touches it.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 # Cancel superseded runs on the same ref so a quick succession of pushes doesn't pile up.
@@ -18,6 +20,10 @@ concurrency:
 jobs:
   test:
     runs-on: macos-15
+    # Backstop, not a tuning knob: the default job timeout is 6 hours, and one hung run at the
+    # 10x macOS multiplier would burn 3600 multiplied minutes — nearly double the monthly free
+    # tier. Normal runs finish in ~1 minute.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
   # token at that point (see the evolving repo's release.yml for the worked example).
   release-please:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write # release-please labels the Release PR via the issues API
@@ -46,6 +47,10 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
     runs-on: macos-15
+    # Notarization occasionally stalls on Apple's side; without a cap, a stalled run rides the
+    # 6-hour default timeout at the 10x macOS minute multiplier. Normal publishes finish well
+    # under this.
+    timeout-minutes: 30
     permissions:
       contents: write # upload the release asset
     steps:


### PR DESCRIPTION
## Why

Cutting macOS Actions minutes (billed at a 10x multiplier). Run history over the last 12 days shows ~100 CI runs, of which **21% were `push` runs to main re-testing the exact commit their PR run had just tested** — and release merges were tested a third time by the publish gate.

## Changes

- **ci.yml**: remove the `push: [main]` trigger — PRs are tested before merge, and release merges are re-tested by release.yml's publish gate. Trade-off (noted in a comment): a direct push to main is no longer tested until the next PR or release.
- **ci.yml / release.yml**: add `timeout-minutes` caps. The 6-hour default meant one hung macOS job could burn ~3600 multiplied minutes — nearly two months of free tier.

## Expected effect

Roughly ~500 multiplied minutes/month saved (~20% of current usage), plus insurance against a single hung run blowing the quota.

🤖 Generated with [Claude Code](https://claude.com/claude-code)