### PR TITLE
ci: run Claude workflows on the VPS self-hosted runner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,6 +16,6 @@ jobs:
       id-token: write
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-    # Optional: override the driver model (default: claude-sonnet-4-6)
-    # with:
-    #   model: claude-opus-4-7
+    with:
+      runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes
+      # model: claude-opus-4-7  # optional: override the driver model (default: claude-sonnet-4-6)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -28,3 +28,5 @@ jobs:
       actions: read
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes

--- a/.github/workflows/issue-opener.yml
+++ b/.github/workflows/issue-opener.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       BOT_PAT: ${{ secrets.BOT_PAT }}
-    # Optional: pick the engine/model (defaults: claude / claude-opus-4-8)
-    # with:
-    #   engine: claude
-    #   model: claude-sonnet-4-6
+    with:
+      runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes
+      # engine: claude          # optional (default: claude)
+      # model: claude-sonnet-4-6 # optional (default: claude-opus-4-8)

--- a/.github/workflows/issue-worker.yml
+++ b/.github/workflows/issue-worker.yml
@@ -26,7 +26,7 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       BOT_PAT: ${{ secrets.BOT_PAT }}
-    # Optional: pick the engine/model (defaults: claude / claude-opus-4-8)
-    # with:
-    #   engine: claude
-    #   model: claude-sonnet-4-6
+    with:
+      runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes
+      # engine: claude          # optional (default: claude)
+      # model: claude-sonnet-4-6 # optional (default: claude-opus-4-8)


### PR DESCRIPTION
## What

The four Claude workflow callers (`claude.yml`, `claude-code-review.yml`, `issue-opener.yml`, `issue-worker.yml`) now pass `runs-on: vps`, routing their jobs to the self-hosted runner registered on the VPS (JINGBANZ/vps-setup#18) instead of GitHub's metered Ubuntu minutes. These jobs average 2.5–4.5 minutes each, so this is the second-biggest minutes consumer after macOS CI (#87).

`release-please` in release.yml deliberately stays on `ubuntu-latest`: it's ~15s per run, and releases shouldn't depend on the VPS being reachable.

## Merge order

**Merge JINGBANZ/workflows#9 first** — it adds the `runs-on` input these callers pass; merging this PR before it makes the callers fail workflow validation.

## Notes

- The runner (`vps`, labels `self-hosted, Linux, X64, vps`) is already registered and online.
- One job runs at a time on the runner; a long issue-worker session queues (not loses) a concurrent review.
- If the VPS is down, these jobs queue until it's back — they don't fall back to GitHub-hosted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)