### PR TITLE
fix(coach): stale-context and cache-busting fixes from the session audit

### DIFF
--- a/Sources/JarvisCore/Brain/CLIBrainClient+Conversation.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient+Conversation.swift
@@ -54,6 +54,13 @@ extension CLIBrainClient {
         return sections.joined(separator: "\n\n")
     }
 
+    /// The forced-tool sentence for a `.force` turn — appended to the conversation's uncacheable
+    /// tail (the "Answer now" trailer) rather than the instructions, which must stay byte-stable.
+    static func forcedToolDirective(_ toolChoice: ToolChoice) -> String? {
+        guard case .force(let name) = toolChoice else { return nil }
+        return "You MUST call the `\(name)` tool this turn."
+    }
+
     /// The CLI-side stand-in for the Responses API's native function calling: the model is told to
     /// end its reply with one JSON object naming the tool. Generated from the same `ToolDef`s the
     /// API client sends, so the two providers stay behaviorally interchangeable.
@@ -71,10 +78,12 @@ extension CLIBrainClient {
                      + "fence, nothing after it): {\"tool\":\"<tool name>\",\"arguments\":{…}}. "
                      + "Use {} for a tool with no arguments.")
         switch toolChoice {
-        case .required:
+        case .required, .force:
+            // .force gets the SAME instructions as .required — byte-identical instructions keep the
+            // provider's prompt cache hot across the whole session (a one-turn forced hint used to
+            // rewrite the system prompt and pay two full cache misses). The forced-tool directive
+            // rides in the turn's trailer instead (`forcedToolDirective`).
             lines.append("You MUST pick exactly one tool this turn — the JSON object is your entire answer.")
-        case .force(let name):
-            lines.append("You MUST call the `\(name)` tool this turn.")
         case .auto:
             lines.append("If no tool fits, reply with plain text instead of the JSON object.")
         }

--- a/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
+++ b/Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift
@@ -58,7 +58,8 @@ extension CLIBrainClient {
                         "--tools", ""]
             if !model.isEmpty { args += ["--model", model] }
             let message = try Self.claudeStreamMessage(segments: rendered.segments,
-                                                       hasTools: !tools.isEmpty)
+                                                       hasTools: !tools.isEmpty,
+                                                       forcedTool: Self.forcedToolDirective(toolChoice))
             auditRequest["input"] = message.auditInput
             return PreparedInvocation(
                 run: AgentCLIRun(executable: executable, arguments: args, stdin: message.stdin,
@@ -109,7 +110,10 @@ extension CLIBrainClient {
             var document = Self.codexDirectResponseInstruction + "\n\n"
             if !instructions.isEmpty { document += instructions + "\n\n" }
             document += "## Conversation\n\n" + blocks.joined(separator: "\n\n")
-            if !tools.isEmpty { document += "\n\nAnswer now, following the tool protocol." }
+            if !tools.isEmpty {
+                document += "\n\nAnswer now, following the tool protocol."
+                if let forced = Self.forcedToolDirective(toolChoice) { document += " \(forced)" }
+            }
             auditRequest["input"] = auditInput
             return PreparedInvocation(
                 run: AgentCLIRun(executable: executable, arguments: args, stdin: document,
@@ -150,7 +154,7 @@ extension CLIBrainClient {
     /// file + Read tool would cost a second model round trip (and an on-disk copy). Also returns the
     /// audit copy of the content — same blocks with every image reduced to a stub — so the traffic
     /// log never receives the base64 bytes in any form.
-    static func claudeStreamMessage(segments: [Segment], hasTools: Bool)
+    static func claudeStreamMessage(segments: [Segment], hasTools: Bool, forcedTool: String? = nil)
         throws -> (stdin: String, auditInput: [[String: Any]]) {
         var content: [[String: Any]] = []
         var auditInput: [[String: Any]] = []
@@ -176,7 +180,11 @@ extension CLIBrainClient {
                 auditInput.append(["type": "image", "image": imageStub(base64)])
             }
         }
-        if hasTools { textRun.append("Answer now, following the tool protocol.") }
+        if hasTools {
+            var trailer = "Answer now, following the tool protocol."
+            if let forcedTool { trailer += " \(forcedTool)" }
+            textRun.append(trailer)
+        }
         flushText()
         let message: [String: Any] = ["type": "user",
                                       "message": ["role": "user", "content": content]]

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -356,13 +356,10 @@ public final class CoachDriver: @unchecked Sendable {
     }
 
     /// Framed so the model treats OCR as a reading aid, not gospel — recognition mangles the odd
-    /// identifier, and the screenshot stays the ground truth to verify against.
+    /// identifier, and the screenshot stays the ground truth to verify against. Opens with
+    /// `CoachHistory.ocrHeader` so commit-time collapse of superseded OCR can't drift out of sync.
     private static func recognizedTextBlock(_ text: String) -> String {
-        """
-        Text recognized on the captured window (on-device OCR — may contain errors; \
-        the screenshot image is ground truth):
-        \(text)
-        """
+        "\(CoachHistory.ocrHeader)\n\(text)"
     }
 
     // MARK: - History compaction

--- a/Sources/JarvisCore/Coach/CoachHistory.swift
+++ b/Sources/JarvisCore/Coach/CoachHistory.swift
@@ -40,9 +40,15 @@ public final class CoachHistory: @unchecked Sendable {
     /// - **Screenshots** are replaced with a text stub (observation masking). The capture's OCR text
     ///   — what the model actually reads — rides in the tool-result message and stays verbatim; the
     ///   pixels are ~1–2k tokens re-billed on every later request, and the model can always capture
-    ///   a fresh look. When the turn carries a NEW OCR block, every earlier OCR dump collapses to a
-    ///   one-line stub: near-identical screens re-billed forever, and a session-audit caught the
-    ///   model "correcting" code the user had already fixed by reading a stale dump.
+    ///   a fresh look. When the turn carries a NEW OCR block, every earlier OCR dump — committed
+    ///   history and any older capture within the same turn — collapses to a one-line stub:
+    ///   near-identical screens re-billed forever, and a session-audit caught the model
+    ///   "correcting" code the user had already fixed by reading a stale dump. Unlike the two
+    ///   tail-local rewrites above, this one re-diverges the prompt-cache prefix at the oldest
+    ///   collapsed block. That is deliberate: a bounded one-request re-read per capture (and free
+    ///   on the CLI providers, which serialize history into a single block no prefix cache can hit
+    ///   anyway) buys back ~1k stale tokens per dump on every later request plus the stale-context
+    ///   failure mode above.
     /// - **Raw passthrough items** (a response's verbatim `output` array, replayed whole within the
     ///   turn's tool loop) are CONVERTED, not kept: the `function_call` items survive as one
     ///   synthetic id-less call message — so the committed `function_call_output` never orphans —
@@ -55,8 +61,11 @@ public final class CoachHistory: @unchecked Sendable {
     public func commit(_ turn: [ChatMessage]) {
         guard !turn.isEmpty else { return }
         lock.lock(); defer { lock.unlock() }
-        if turn.contains(where: { $0.text?.contains(Self.ocrHeader) == true }) {
+        var turn = turn
+        if let newest = turn.lastIndex(where: { $0.text?.contains(Self.ocrHeader) == true }) {
             messages = messages.map(Self.collapsingSupersededOCR)
+            // One tool loop may capture more than once — only the turn's newest OCR stays verbatim.
+            for i in turn.indices where i < newest { turn[i] = Self.collapsingSupersededOCR(turn[i]) }
         }
         messages.append(contentsOf: turn.compactMap { m in
             if let raw = m.rawItemsJSON { return Self.convertRawItems(raw) }

--- a/Sources/JarvisCore/Coach/CoachHistory.swift
+++ b/Sources/JarvisCore/Coach/CoachHistory.swift
@@ -14,7 +14,17 @@ public final class CoachHistory: @unchecked Sendable {
     private let lock = NSLock()
     private var messages: [ChatMessage] = []
 
-    static let imageStub = "[an earlier screenshot was here — no longer available; call capture_screen for a fresh look]"
+    // Deliberately not an instruction: a session-audit showed the earlier "call capture_screen for
+    // a fresh look" phrasing, repeated once per stubbed screenshot in user-role history, biased the
+    // model toward capturing on every quiet turn (stay_silent was never chosen).
+    static let imageStub = "[an earlier screenshot was here — no longer available]"
+
+    /// The opening line of every OCR block the driver commits (see `CoachDriver.recognizedTextBlock`,
+    /// which builds on this constant so the two can't drift). Matched at commit time: a new capture's
+    /// OCR supersedes every earlier one, which then collapses to `ocrStub`.
+    static let ocrHeader = "Text recognized on the captured window (on-device OCR — may contain "
+        + "errors; the screenshot image is ground truth):"
+    static let ocrStub = "[an earlier screen's OCR text was here — superseded by a newer capture]"
 
     public init() {}
 
@@ -30,7 +40,9 @@ public final class CoachHistory: @unchecked Sendable {
     /// - **Screenshots** are replaced with a text stub (observation masking). The capture's OCR text
     ///   — what the model actually reads — rides in the tool-result message and stays verbatim; the
     ///   pixels are ~1–2k tokens re-billed on every later request, and the model can always capture
-    ///   a fresh look.
+    ///   a fresh look. When the turn carries a NEW OCR block, every earlier OCR dump collapses to a
+    ///   one-line stub: near-identical screens re-billed forever, and a session-audit caught the
+    ///   model "correcting" code the user had already fixed by reading a stale dump.
     /// - **Raw passthrough items** (a response's verbatim `output` array, replayed whole within the
     ///   turn's tool loop) are CONVERTED, not kept: the `function_call` items survive as one
     ///   synthetic id-less call message — so the committed `function_call_output` never orphans —
@@ -43,10 +55,21 @@ public final class CoachHistory: @unchecked Sendable {
     public func commit(_ turn: [ChatMessage]) {
         guard !turn.isEmpty else { return }
         lock.lock(); defer { lock.unlock() }
+        if turn.contains(where: { $0.text?.contains(Self.ocrHeader) == true }) {
+            messages = messages.map(Self.collapsingSupersededOCR)
+        }
         messages.append(contentsOf: turn.compactMap { m in
             if let raw = m.rawItemsJSON { return Self.convertRawItems(raw) }
             return m.imageBase64JPEG != nil ? .user(Self.imageStub) : m
         })
+    }
+
+    /// Rewrite one committed message so its OCR block (if any) becomes `ocrStub`. Text before the
+    /// block — e.g. a tool result's "screenshot captured" line — survives.
+    private static func collapsingSupersededOCR(_ m: ChatMessage) -> ChatMessage {
+        guard let text = m.text, let header = text.range(of: ocrHeader) else { return m }
+        return ChatMessage(role: m.role, text: String(text[..<header.lowerBound]) + ocrStub,
+                           toolCallId: m.toolCallId)
     }
 
     /// The commit-time conversion of a verbatim passthrough message: keep its `function_call` items

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -40,6 +40,9 @@ interviews. Help without interrupting productive thinking.
   but does not prove it.
 - You can see the screen only through capture_screen. A fresh screenshot or OCR in the current input
   counts as current screen context.
+- OCR text is a reading aid that garbles the odd token; the screenshot image is ground truth. Before
+  asserting a specific line or token is wrong, verify it in the image — if you can only see it in
+  OCR, ask about it instead of asserting.
 
 # Action policy
 Choose exactly one action on each model response, in this priority order:

--- a/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/CLIBrainClientTests.swift
@@ -244,6 +244,31 @@ import Foundation
         #expect(response.toolCalls.isEmpty)
     }
 
+    /// A one-turn forced hint must not rewrite the system prompt: instructions stay byte-identical
+    /// to a `.required` turn (they're the provider's cacheable prefix — a session audit showed the
+    /// old in-instructions directive paying two full cache misses per hint), and the directive rides
+    /// in the conversation's trailer instead.
+    @Test func forcedToolKeepsInstructionsStableAndDirectsViaTheTurn() async throws {
+        let instructionsAndStdin = { (choice: ToolChoice) async throws -> (String, String) in
+            let captured = Captured<AgentCLIRun>()
+            let c = self.client(.claudeCode, workDir: try self.makeWorkDir()) { run in
+                captured.value = run
+                return AgentCLIOutput(stdout: self.claudeEnvelope(#"{"tool":"speak","arguments":{"lines":["t"]}}"#),
+                                      stderr: "", exitCode: 0)
+            }
+            _ = try await c.respond(messages: [.system("coach prompt"), .user("help")],
+                                    tools: coachTools, toolChoice: choice)
+            let run = try #require(captured.value)
+            let sysIdx = try #require(run.arguments.firstIndex(of: "--system-prompt"))
+            return (run.arguments[sysIdx + 1], try #require(run.stdin))
+        }
+        let (requiredInstructions, requiredStdin) = try await instructionsAndStdin(.required)
+        let (forcedInstructions, forcedStdin) = try await instructionsAndStdin(.force(speakTool.name))
+        #expect(forcedInstructions == requiredInstructions)
+        #expect(forcedStdin.contains("You MUST call the `speak` tool this turn."))
+        #expect(!requiredStdin.contains("You MUST call the `speak` tool"))
+    }
+
     @Test func forcedSpeakRejectsAnotherToolAndSpeaksTheProse() async throws {
         // The Responses API enforces a forced tool server-side; the CLI protocol is prompt text,
         // so a stay_silent reply to the hint hotkey must not eat the hint.

--- a/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
@@ -50,6 +50,21 @@ import Testing
         #expect(h.snapshot().contains { $0.toolCallId == "c1" })     // tool-result pairing intact
     }
 
+    /// A single tool loop may capture more than once; only the turn's own newest OCR survives
+    /// verbatim — the earlier same-turn capture is as stale as any committed one.
+    @Test func multiCaptureTurnKeepsOnlyItsNewestOCR() {
+        let ocr = { (body: String) in "\(CoachHistory.ocrHeader)\n\(body)" }
+        let h = CoachHistory()
+        h.commit([.user("turn"),
+                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("first look"))", toolCallId: "c1"),
+                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("second look"))", toolCallId: "c2")])
+        let texts = h.snapshot().compactMap(\.text)
+        #expect(!texts.joined().contains("first look"))
+        #expect(texts.contains("screenshot captured\n\n\(CoachHistory.ocrStub)"))
+        #expect(texts.contains { $0.contains("second look") })
+        #expect(h.snapshot().contains { $0.toolCallId == "c1" })     // pairing intact, text collapsed
+    }
+
     /// Raw passthrough items live only inside their turn's tool loop — commit converts them: the
     /// function_call survives as the synthetic id-less call (so the committed tool result never
     /// orphans) and reasoning is dropped; later turns don't need it and a model switch would

--- a/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
@@ -20,6 +20,34 @@ import Testing
         #expect(!snap.contains { $0.imageBase64JPEG != nil })
         #expect(snap.filter { ($0.text ?? "").contains("no longer available") }.count == 2)   // the stubs
         #expect(snap.compactMap(\.text).first == "a")   // non-image messages untouched
+        // The stub is a neutral marker, not an instruction — "call capture_screen" phrasing in
+        // user-role history drove capture-on-every-quiet-turn in a live session audit.
+        #expect(!snap.contains { ($0.text ?? "").contains("capture_screen") })
+    }
+
+    /// A new capture's OCR supersedes every earlier dump: older blocks collapse to a one-line stub
+    /// (stale screen text misleads and re-bills), while text before the block and the newest OCR
+    /// stay verbatim.
+    @Test func newCaptureCollapsesSupersededOCR() {
+        let ocr = { (body: String) in "\(CoachHistory.ocrHeader)\n\(body)" }
+        let h = CoachHistory()
+        h.commit([.user("turn 1"),
+                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("if (min < sum)"))", toolCallId: "c1")])
+        h.commit([.user("turn 2")])                                  // no capture: nothing collapses
+        #expect(h.snapshot().contains { ($0.text ?? "").contains("if (min < sum)") })
+
+        h.commit([.user(ocr("if (sum < min)"))])                     // hint-path OCR rides as a user message
+        var texts = h.snapshot().compactMap(\.text)
+        #expect(texts.contains("screenshot captured\n\n\(CoachHistory.ocrStub)"))  // prefix survives
+        #expect(!texts.joined().contains("if (min < sum)"))          // stale body gone
+        #expect(texts.contains { $0.contains("if (sum < min)") })    // newest OCR verbatim
+
+        h.commit([.init(role: .tool, text: "screenshot captured\n\n\(ocr("rewritten"))", toolCallId: "c2")])
+        texts = h.snapshot().compactMap(\.text)
+        #expect(texts.contains(CoachHistory.ocrStub))                // the user-shaped OCR collapsed whole
+        #expect(!texts.joined().contains("if (sum < min)"))
+        #expect(texts.contains { $0.contains("rewritten") })
+        #expect(h.snapshot().contains { $0.toolCallId == "c1" })     // tool-result pairing intact
     }
 
     /// Raw passthrough items live only inside their turn's tool loop — commit converts them: the

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -34,6 +34,14 @@ import Testing
         #expect(coachSystemPrompt.contains("one pass\" without the problem"))
     }
 
+    /// Line-level claims must come from the image, not OCR — a live session audit caught the model
+    /// "correcting" an already-correct line it had misread from OCR noise.
+    @Test func coachPromptGroundsLineLevelClaimsInTheImage() {
+        #expect(coachSystemPrompt.contains("the screenshot image is ground truth"))
+        #expect(coachSystemPrompt.contains("verify it in the image"))
+        #expect(coachSystemPrompt.contains("ask about it instead of asserting"))
+    }
+
     @Test func coachPromptTreatsFreshCaptureAsSatisfyingScreenGate() {
         #expect(coachSystemPrompt.contains("A fresh screenshot or OCR in the current input"))
         #expect(coachSystemPrompt.contains("A fresh capture result satisfies the screen gate"))


### PR DESCRIPTION
Four fixes traced to verified findings in the 2026-07-19 session audit (`.jarvis/2026-07-19_11-23-27_6C73`, 20 coach calls, $1.44):

## Changes

1. **Neutral screenshot stub** (`CoachHistory.imageStub`). The old stub ended with "call capture_screen for a fresh look" — an instruction sitting in user-role history once per stubbed screenshot. In the audited session the model captured on all 5 unsolicited quiet turns and never once chose `stay_silent`. The stub is now a plain marker.

2. **Collapse superseded OCR at commit** (`CoachHistory.commit`). OCR text used to ride verbatim forever while its screenshot was stubbed; by call #20 the input carried 7 OCR dumps of the same LeetCode page (6 stale), and the model "corrected" a line the user had fixed 15 minutes earlier by reading the stalest one. A new capture's OCR now collapses every earlier dump to a one-line stub; the newest stays verbatim. `CoachDriver.recognizedTextBlock` now builds on the shared `CoachHistory.ocrHeader` so the marker can't drift.

3. **Byte-stable instructions on forced-tool turns** (`CLIBrainClient`). The hint shortcut's `.force` used to swap the "MUST call speak" sentence into the system prompt — the session's only instructions change, costing a 0-read call and a full 8,968-token cache rewrite, then a second rewrite on the revert. The directive now rides in the conversation's "Answer now" trailer (already uncacheable tail) for both claude and codex; instructions are byte-identical between `.required` and `.force`. The OpenAI provider keeps native server-side `tool_choice` enforcement.

4. **Image-over-OCR rule in the coach prompt** (`ToolDefs.swift`). Line-level "line N is wrong" claims must be verified in the screenshot image; OCR-only sightings get asked about, not asserted (call #11 hallucinated `i=replace` from OCR noise when the OCR itself read `i==replace`).

## Testing

- `swift build` clean; `./scripts/run-tests.sh --filter JarvisCoreTests`: **389/389 pass**, including 3 new tests (OCR collapse + neutral stub, instructions byte-stability under `.force` with trailer directive, prompt grounding rule).
- Full-run `OverlayInvisibilityTests` timing flakes reproduce identically on clean `main` (10 issues, same set) and pass in isolation on both — pre-existing load sensitivity, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)