### PR TITLE
feat(eval): harden session audit against counting errors and envelope confusion

### DIFF
--- a/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
+++ b/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
@@ -63,12 +63,28 @@ public enum AgenticEvaluation {
         YOUR WORKSPACE is a checkout of the Jarvis source repository. The audited session lives at:
             \(sessionDirPath)
         with these inputs in that directory:
-          - `\(transcriptFilename)` — the session's wire-level LLM traffic rendered one block per API \
-        call, in order. This is your PRIMARY input. To keep it compact, content byte-identical to the \
-        previous same-tag call is elided and marked "(unchanged)" — those markers are exactly where \
-        the prompt cache SHOULD be hitting. Each response block includes the raw usage object \
-        (`input_tokens_details.cached_tokens` vs `input_tokens` is the per-call cache hit rate).
-          - `\(BrainTrafficLog.filename)` — the same traffic un-elided, if you need to inspect a full body.
+          - `\(transcriptFilename)` — the session's wire-level LLM traffic. It OPENS with a \
+        "=== deterministic metrics ===" table computed from the raw traffic (per-call and \
+        session-total input / cache-read / cache-write / output tokens and cost, plus a per-model \
+        breakdown). TRUST those numbers and quote them; never recompute a total by eye. The rest is \
+        one block per API call, in order — your PRIMARY narrative input. To keep it compact, content \
+        byte-identical to the previous same-tag call is elided and marked "(unchanged)" — those \
+        markers are exactly where the prompt cache SHOULD be hitting.
+          - `\(BrainTrafficLog.filename)` — the same traffic un-elided. Because the transcript elides \
+        byte-identical repeats, ANY cardinal count (stub occurrences, OCR dumps, marker repetitions) \
+        MUST be counted here, not from the elided transcript.
+
+        Two provider envelopes appear, sometimes in one session — read the right fields for each:
+          - OpenAI Responses: `response.usage` with `input_tokens`, \
+        `input_tokens_details.cached_tokens` (automatic prefix-cache hit), `output_tokens`; a \
+        truncated run shows `status:"incomplete"`. No per-call dollar cost.
+          - Local CLI (`claude -p`): `response.cli` with `total_cost_usd`, a call-level `usage` \
+        carrying Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and a \
+        `modelUsage` map (per-model usage + cost, including internal sidecar models like a haiku \
+        pass). Anthropic caching is BLOCK-level: a fresh, non-persisted `claude -p` turn sends the \
+        whole conversation as one block, so it can only cache-hit the reused `--system-prompt` — a \
+        small, flat cross-turn cache-read is that serialization (verify against \
+        `Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift`), NOT history rewriting.
           - `shot-N.jpg` — the screenshots the model actually saw (base64 was redacted from the traffic).
           - a prior `\(reportFilename)`, if this session was audited before.
 
@@ -109,8 +125,10 @@ public enum AgenticEvaluation {
           - `[hypothesis]` — plausible from the traffic but not (or not yet) checked against the code.
 
         Cite call numbers (call #N) as evidence throughout. If the data doesn't support a finding, say \
-        so rather than speculating. Output ONLY the markdown report — it is saved verbatim as \
-        `\(reportFilename)` in the session directory.
+        so rather than speculating. Before finalizing, re-check every number in your draft against the \
+        metrics table and against `\(BrainTrafficLog.filename)`, and correct or delete any that \
+        disagree. Output ONLY the markdown report — it is saved as `\(reportFilename)` in the session \
+        directory (the harness prepends a one-line provenance stamp, so don't add your own).
         """
     }
 }

--- a/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
+++ b/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
@@ -65,8 +65,10 @@ public enum AgenticEvaluation {
         with these inputs in that directory:
           - `\(transcriptFilename)` — the session's wire-level LLM traffic. It OPENS with a \
         "=== deterministic metrics ===" table computed from the raw traffic (per-call and \
-        session-total input / cache-read / cache-write / output tokens and cost, plus a per-model \
-        breakdown). TRUST those numbers and quote them; never recompute a total by eye. The rest is \
+        aggregate input / cache-read / cache-write / output tokens and cost, plus a per-model \
+        breakdown). Trust its known numbers and availability labels: `—` means unavailable, not zero, \
+        and a `known (N unavailable)` value is partial, not a session total. Quote only what the table \
+        supports; never recompute a total by eye. The rest is \
         one block per API call, in order — your PRIMARY narrative input. To keep it compact, content \
         byte-identical to the previous same-tag call is elided and marked "(unchanged)" — those \
         markers are exactly where the prompt cache SHOULD be hitting.
@@ -74,10 +76,12 @@ public enum AgenticEvaluation {
         byte-identical repeats, ANY cardinal count (stub occurrences, OCR dumps, marker repetitions) \
         MUST be counted here, not from the elided transcript.
 
-        Two provider envelopes appear, sometimes in one session — read the right fields for each:
+        Provider records can appear together — read the right fields for each:
           - OpenAI Responses: `response.usage` with `input_tokens`, \
-        `input_tokens_details.cached_tokens` (automatic prefix-cache hit), `output_tokens`; a \
-        truncated run shows `status:"incomplete"`. No per-call dollar cost.
+        `input_tokens_details.cached_tokens` (automatic prefix-cache hit), optional \
+        `cache_write_tokens`, and `output_tokens`; a truncated run shows `status:"incomplete"`. No \
+        per-call dollar cost. OpenAI `input_tokens` includes cached input, so mixed-provider token \
+        totals are kept separate.
           - Local CLI (`claude -p`): `response.cli` with `total_cost_usd`, a call-level `usage` \
         carrying Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and a \
         `modelUsage` map (per-model usage + cost, including internal sidecar models like a haiku \
@@ -85,6 +89,8 @@ public enum AgenticEvaluation {
         whole conversation as one block, so it can only cache-hit the reused `--system-prompt` — a \
         small, flat cross-turn cache-read is that serialization (verify against \
         `Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift`), NOT history rewriting.
+          - Codex CLI: the recorded response currently has the reply and exit status but no token, \
+        cache, or cost usage. Those cells must stay unavailable; never interpret them as zero.
           - `shot-N.jpg` — the screenshots the model actually saw (base64 was redacted from the traffic).
           - a prior `\(reportFilename)`, if this session was audited before.
 

--- a/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
@@ -253,17 +253,21 @@ public struct SessionEvaluator: Sendable {
     into a summary by a separate "summarizer" client.
 
     The user message opens with a "=== deterministic metrics ===" table computed from the raw traffic \
-    (per-call and session-total input / cache-read / cache-write / output tokens and cost, plus a \
-    per-model breakdown). TRUST those numbers and interpret them; NEVER recompute a total by eye — \
-    quote the table. It follows with the session's complete wire-level LLM traffic, one block per API \
+    (per-call and aggregate input / cache-read / cache-write / output tokens and cost, plus a \
+    per-model breakdown). Trust its known numbers and availability labels: `—` means unavailable, not \
+    zero, and a `known (N unavailable)` value is partial, not a session total. Quote only what the \
+    table supports; NEVER recompute a total by eye. It follows with the session's complete wire-level \
+    LLM traffic, one block per API \
     call, in order. To keep it compact: content byte-identical to the previous call with the same tag \
     is elided and explicitly marked "(unchanged)" — those markers are where the prompt cache SHOULD \
     be hitting; base64 screenshots are redacted to a stub.
 
-    Two provider envelopes appear, sometimes in one session — read the right fields for each:
+    Provider records can appear together — read the right fields for each:
       - OpenAI Responses: `response.usage` with `input_tokens`, `input_tokens_details.cached_tokens` \
-    (the automatic prefix-cache hit; hit rate = cached_tokens / input_tokens), `output_tokens`; a \
-    truncated run shows `status:"incomplete"`. There is no per-call dollar cost.
+    (the automatic prefix-cache hit; hit rate = cached_tokens / input_tokens), optional \
+    `cache_write_tokens`, and `output_tokens`; a truncated run shows `status:"incomplete"`. There is \
+    no per-call dollar cost. OpenAI `input_tokens` includes cached input, so mixed-provider token \
+    totals are kept separate.
       - Local CLI (`claude -p`): `response.cli` with `total_cost_usd`, a call-level `usage` carrying \
     Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and a `modelUsage` \
     map with per-model usage + cost (including the CLI's internal sidecar models, e.g. a haiku pass). \
@@ -271,6 +275,8 @@ public struct SessionEvaluator: Sendable {
     sends the whole conversation as one giant block, so it can only ever cache-hit the reused \
     `--system-prompt` — a small, flat cache-read across turns is that serialization, NOT the harness \
     rewriting history. Do not attribute it to cache-busting without checking which envelope this is.
+      - Codex CLI: the recorded response currently has the reply and exit status but no token, cache, \
+    or cost usage. Those cells must stay unavailable; never interpret them as zero.
 
     Before finalizing, re-check every number you wrote against the metrics table and correct or delete \
     any that disagree. This transcript ELIDES byte-identical repeats, so it cannot support cardinal \

--- a/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEvaluator.swift
@@ -61,15 +61,24 @@ public struct SessionEvaluator: Sendable {
         let response = try await brain.respond(
             messages: [.system(Self.evalInstructions), .user(transcript)],
             tools: [], toolChoice: .auto)
-        guard let report = response.outputText, !report.isEmpty else {
+        guard let text = response.outputText, !text.isEmpty else {
             throw EvaluationError.emptyReport
         }
+        // Stamp provenance so a reader knows this is the wire-only audit, not the code-reading one.
+        let report = Self.provenanceStamp + "\n\n" + text
         // A failed write is tolerable: the report is still shown; only "Open report" reuse is lost.
         _ = FileManager.default.createFile(
             atPath: sessionDir.appendingPathComponent(Self.reportFilename).path,
             contents: Data(report.utf8), attributes: [.posixPermissions: 0o600])
         return report
     }
+
+    /// Prepended to every single-call report. This path audits the wire transcript only; the
+    /// code-reading agentic audit (`AgenticEvaluation` via `scripts/eval-session.sh`) is preferred
+    /// for a real audit — see the note it stamps.
+    static let provenanceStamp =
+        "> _Produced by the single-call `SessionEvaluator` (in-app wire-only audit). For a "
+        + "code-verified audit with `[confirmed]`/`[hypothesis]` labels, run `scripts/eval-session.sh`._"
 
     // MARK: - Transcript rendering (pure, testable)
 
@@ -108,7 +117,12 @@ public struct SessionEvaluator: Sendable {
             }
             blocks.append(lines.joined(separator: "\n"))
         }
-        return blocks.joined(separator: "\n\n")
+        guard !blocks.isEmpty else { return "" }
+        // Lead with the deterministic metrics table (computed, not eyeballed) so the auditor
+        // interprets numbers instead of summing usage blobs by hand — the source of the 2026-07-19
+        // audit's cost/cache arithmetic errors. Empty traffic still renders "" (callers guard on it).
+        let body = blocks.joined(separator: "\n\n")
+        return SessionMetrics.render(jsonl: jsonl) + "\n\n" + body
     }
 
     private static func renderRequest(_ request: [String: Any], tag: String,
@@ -238,11 +252,31 @@ public struct SessionEvaluator: Sendable {
     append-only so the provider's prompt cache keeps hitting; old history is periodically compacted \
     into a summary by a separate "summarizer" client.
 
-    The user message is the session's complete wire-level LLM traffic, one block per API call, in \
-    order. To keep it compact: content that is byte-identical to the previous call with the same tag \
+    The user message opens with a "=== deterministic metrics ===" table computed from the raw traffic \
+    (per-call and session-total input / cache-read / cache-write / output tokens and cost, plus a \
+    per-model breakdown). TRUST those numbers and interpret them; NEVER recompute a total by eye — \
+    quote the table. It follows with the session's complete wire-level LLM traffic, one block per API \
+    call, in order. To keep it compact: content byte-identical to the previous call with the same tag \
     is elided and explicitly marked "(unchanged)" — those markers are where the prompt cache SHOULD \
-    be hitting; base64 screenshots are redacted to a stub. Each response block includes the raw \
-    usage object (input_tokens_details.cached_tokens vs input_tokens is the cache hit rate).
+    be hitting; base64 screenshots are redacted to a stub.
+
+    Two provider envelopes appear, sometimes in one session — read the right fields for each:
+      - OpenAI Responses: `response.usage` with `input_tokens`, `input_tokens_details.cached_tokens` \
+    (the automatic prefix-cache hit; hit rate = cached_tokens / input_tokens), `output_tokens`; a \
+    truncated run shows `status:"incomplete"`. There is no per-call dollar cost.
+      - Local CLI (`claude -p`): `response.cli` with `total_cost_usd`, a call-level `usage` carrying \
+    Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and a `modelUsage` \
+    map with per-model usage + cost (including the CLI's internal sidecar models, e.g. a haiku pass). \
+    Anthropic caching is BLOCK-level, not automatic-prefix: a fresh, non-persisted `claude -p` turn \
+    sends the whole conversation as one giant block, so it can only ever cache-hit the reused \
+    `--system-prompt` — a small, flat cache-read across turns is that serialization, NOT the harness \
+    rewriting history. Do not attribute it to cache-busting without checking which envelope this is.
+
+    Before finalizing, re-check every number you wrote against the metrics table and correct or delete \
+    any that disagree. This transcript ELIDES byte-identical repeats, so it cannot support cardinal \
+    counts of repeated content (stub occurrences, OCR dumps, marker repetitions); take call counts \
+    from the metrics table and, for any other count the table doesn't give, say it is not determinable \
+    from the elided transcript rather than guessing.
 
     Write a markdown report with exactly these sections:
 

--- a/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Deterministic, pure-Swift accounting of a session's brain traffic: per-call and session-total
+/// token / cache / cost numbers computed straight from `brain-traffic.jsonl` and rendered as a table
+/// that leads the evaluation transcript (see `SessionEvaluator.renderTranscript`).
+///
+/// Why this exists: the auditor is an LLM, and the 2026-07-19 session audit's factual slips (total
+/// cost off by $0.20, a "cache_creation climbs monotonically" claim that actually zigzagged) all came
+/// from a model doing arithmetic over ~20 JSON usage blobs *by eye*. So we compute the numbers here,
+/// once, correctly, and tell the model to interpret them and never recompute totals itself.
+///
+/// Both provider envelopes are handled, because the same session file can mix them:
+///   - **OpenAI Responses** — `response.usage`: `input_tokens`, `input_tokens_details.cached_tokens`
+///     (the automatic prefix-cache hit), `output_tokens` (reasoning tokens included). No per-call
+///     dollar cost is recorded, so cost renders as "—".
+///   - **Local CLI** (`claude -p`, `CLIBrainClient`) — `response.cli`: `total_cost_usd`, a call-level
+///     `usage` with Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and
+///     a `modelUsage` map that breaks usage + cost out per model — including the CLI's own internal
+///     sidecar models (e.g. its haiku pass), which the call-level `usage` alone would hide.
+enum SessionMetrics {
+    /// One row of the per-call table. `perModel` attributes this call's usage to the concrete
+    /// model(s) that served it (a CLI turn can touch a main model plus a sidecar).
+    struct Call {
+        let number: Int
+        let tag: String
+        let model: String
+        let status: Int?
+        let ms: Int?
+        var input = 0
+        var cacheRead = 0
+        var cacheWrite = 0
+        var output = 0
+        var cost: Double?
+        var perModel: [String: ModelTotals] = [:]
+    }
+
+    /// Accumulated usage for one model, across one or many calls.
+    struct ModelTotals {
+        var input = 0
+        var cacheRead = 0
+        var cacheWrite = 0
+        var output = 0
+        var cost: Double?
+        var calls = 0
+
+        mutating func add(_ other: ModelTotals) {
+            input += other.input
+            cacheRead += other.cacheRead
+            cacheWrite += other.cacheWrite
+            output += other.output
+            calls += other.calls
+            if let c = other.cost { cost = (cost ?? 0) + c }
+        }
+    }
+
+    // MARK: - Rendering
+
+    /// The metrics block that leads the transcript, or "" when there is no traffic (so callers'
+    /// empty-transcript guards still fire). Call numbering matches `SessionEvaluator.renderTranscript`
+    /// exactly — both count one call per JSON-parseable line, in file order.
+    static func render(jsonl: String) -> String {
+        let calls = parse(jsonl: jsonl)
+        guard !calls.isEmpty else { return "" }
+
+        var lines: [String] = []
+        lines.append(
+            "=== deterministic metrics (computed from \(BrainTrafficLog.filename); interpret these — do NOT recompute totals by eye) ===")
+        lines.append("")
+        lines.append("| call | tag | model | HTTP | ms | input | cache read | cache write | output | cost |")
+        lines.append("|--:|---|---|--:|--:|--:|--:|--:|--:|--:|")
+        for c in calls {
+            lines.append("| \(c.number) | \(c.tag) | \(c.model) | \(c.status.map(String.init) ?? "—") "
+                + "| \(c.ms.map(String.init) ?? "—") | \(c.input) | \(c.cacheRead) | \(c.cacheWrite) "
+                + "| \(c.output) | \(money(c.cost)) |")
+        }
+
+        let costs = calls.compactMap(\.cost)
+        let costTotal = costs.isEmpty ? nil : costs.reduce(0, +)
+        lines.append("")
+        lines.append("session totals: \(calls.count) calls · input \(sum(calls, \.input)) "
+            + "· cache-read \(sum(calls, \.cacheRead)) · cache-write \(sum(calls, \.cacheWrite)) "
+            + "· output \(sum(calls, \.output)) · cost \(money(costTotal))")
+
+        var perModel: [String: ModelTotals] = [:]
+        for c in calls {
+            for (name, totals) in c.perModel { perModel[name, default: ModelTotals()].add(totals) }
+        }
+        if !perModel.isEmpty {
+            lines.append("")
+            lines.append("per-model totals (includes provider-internal sidecar models):")
+            lines.append("| model | calls | input | cache read | cache write | output | cost |")
+            lines.append("|---|--:|--:|--:|--:|--:|--:|")
+            for name in perModel.keys.sorted() {
+                let t = perModel[name]!
+                lines.append("| \(name) | \(t.calls) | \(t.input) | \(t.cacheRead) | \(t.cacheWrite) "
+                    + "| \(t.output) | \(money(t.cost)) |")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - Parsing (pure)
+
+    /// Parse every JSON-parseable line into a `Call`. Malformed lines are skipped but still advance
+    /// nothing (they aren't counted), so numbering stays aligned with the rendered transcript.
+    static func parse(jsonl: String) -> [Call] {
+        var calls: [Call] = []
+        var number = 0
+        for raw in jsonl.split(separator: "\n", omittingEmptySubsequences: true) {
+            guard let entry = (try? JSONSerialization.jsonObject(with: Data(raw.utf8))) as? [String: Any]
+            else { continue }
+            number += 1
+            let request = entry["request"] as? [String: Any]
+            let model = request?["model"] as? String ?? "?"
+            var call = Call(number: number,
+                            tag: entry["tag"] as? String ?? "?",
+                            model: model,
+                            status: entry["status"] as? Int,
+                            ms: entry["ms"] as? Int)
+            let response = entry["response"] as? [String: Any]
+
+            if let cli = response?["cli"] as? [String: Any] {
+                call.cost = double(cli["total_cost_usd"])
+                if let usage = cli["usage"] as? [String: Any] {
+                    call.input = int(usage["input_tokens"])
+                    call.cacheRead = int(usage["cache_read_input_tokens"])
+                    call.cacheWrite = int(usage["cache_creation_input_tokens"])
+                    call.output = int(usage["output_tokens"])
+                }
+                if let modelUsage = cli["modelUsage"] as? [String: Any], !modelUsage.isEmpty {
+                    for (name, value) in modelUsage {
+                        guard let d = value as? [String: Any] else { continue }
+                        call.perModel[name] = ModelTotals(
+                            input: int(first(d, "inputTokens", "input_tokens")),
+                            cacheRead: int(first(d, "cacheReadInputTokens", "cache_read_input_tokens")),
+                            cacheWrite: int(first(d, "cacheCreationInputTokens", "cache_creation_input_tokens")),
+                            output: int(first(d, "outputTokens", "output_tokens")),
+                            cost: double(first(d, "costUSD", "cost_usd")),
+                            calls: 1)
+                    }
+                } else {
+                    call.perModel[model] = ModelTotals(input: call.input, cacheRead: call.cacheRead,
+                                                       cacheWrite: call.cacheWrite, output: call.output,
+                                                       cost: call.cost, calls: 1)
+                }
+            } else if let usage = response?["usage"] as? [String: Any] {
+                call.input = int(usage["input_tokens"])
+                call.cacheRead = int((usage["input_tokens_details"] as? [String: Any])?["cached_tokens"])
+                call.output = int(usage["output_tokens"])
+                call.perModel[model] = ModelTotals(input: call.input, cacheRead: call.cacheRead,
+                                                   cacheWrite: 0, output: call.output,
+                                                   cost: nil, calls: 1)
+            }
+            calls.append(call)
+        }
+        return calls
+    }
+
+    // MARK: - Small helpers
+
+    private static func sum(_ calls: [Call], _ key: KeyPath<Call, Int>) -> Int {
+        calls.reduce(0) { $0 + $1[keyPath: key] }
+    }
+
+    /// Format a dollar amount to 4 dp, or "—" when no cost was recorded (OpenAI never records one).
+    private static func money(_ value: Double?) -> String {
+        value.map { String(format: "$%.4f", $0) } ?? "—"
+    }
+
+    /// First non-nil value among the given keys — lets one reader handle both camelCase (`modelUsage`)
+    /// and snake_case (`usage`) spellings the CLI envelope mixes.
+    private static func first(_ dict: [String: Any], _ keys: String...) -> Any? {
+        for key in keys where dict[key] != nil { return dict[key] }
+        return nil
+    }
+
+    private static func int(_ any: Any?) -> Int {
+        (any as? NSNumber)?.intValue ?? 0
+    }
+
+    private static func double(_ any: Any?) -> Double? {
+        (any as? NSNumber)?.doubleValue
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
@@ -1,55 +1,63 @@
 import Foundation
 
-/// Deterministic, pure-Swift accounting of a session's brain traffic: per-call and session-total
-/// token / cache / cost numbers computed straight from `brain-traffic.jsonl` and rendered as a table
-/// that leads the evaluation transcript (see `SessionEvaluator.renderTranscript`).
+/// Deterministic, pure-Swift accounting of a session's brain traffic: per-call and aggregate token /
+/// cache / cost numbers computed straight from `brain-traffic.jsonl` and rendered as a table that
+/// leads the evaluation transcript (see `SessionEvaluator.renderTranscript`). Missing telemetry stays
+/// unavailable — it is never silently converted to a factual zero or omitted from a partial total.
 ///
 /// Why this exists: the auditor is an LLM, and the 2026-07-19 session audit's factual slips (total
 /// cost off by $0.20, a "cache_creation climbs monotonically" claim that actually zigzagged) all came
 /// from a model doing arithmetic over ~20 JSON usage blobs *by eye*. So we compute the numbers here,
 /// once, correctly, and tell the model to interpret them and never recompute totals itself.
 ///
-/// Both provider envelopes are handled, because the same session file can mix them:
+/// Provider records are handled separately because the same session file can mix them:
 ///   - **OpenAI Responses** — `response.usage`: `input_tokens`, `input_tokens_details.cached_tokens`
-///     (the automatic prefix-cache hit), `output_tokens` (reasoning tokens included). No per-call
-///     dollar cost is recorded, so cost renders as "—".
+///     (the automatic prefix-cache hit), optional `cache_write_tokens`, and `output_tokens`
+///     (reasoning tokens included). No per-call dollar cost is recorded, so cost renders as "—".
 ///   - **Local CLI** (`claude -p`, `CLIBrainClient`) — `response.cli`: `total_cost_usd`, a call-level
 ///     `usage` with Anthropic's `cache_creation_input_tokens` / `cache_read_input_tokens` split, and
 ///     a `modelUsage` map that breaks usage + cost out per model — including the CLI's own internal
 ///     sidecar models (e.g. its haiku pass), which the call-level `usage` alone would hide.
+///   - **Codex CLI** — the response record has no token, cache, or cost usage, so those values remain
+///     unavailable rather than becoming zero.
 enum SessionMetrics {
     /// One row of the per-call table. `perModel` attributes this call's usage to the concrete
     /// model(s) that served it (a CLI turn can touch a main model plus a sidecar).
     struct Call {
         let number: Int
         let tag: String
+        let provider: String
         let model: String
         let status: Int?
         let ms: Int?
-        var input = 0
-        var cacheRead = 0
-        var cacheWrite = 0
-        var output = 0
+        var input: Int?
+        var cacheRead: Int?
+        var cacheWrite: Int?
+        var output: Int?
         var cost: Double?
         var perModel: [String: ModelTotals] = [:]
     }
 
     /// Accumulated usage for one model, across one or many calls.
     struct ModelTotals {
-        var input = 0
-        var cacheRead = 0
-        var cacheWrite = 0
-        var output = 0
+        var input: Int?
+        var cacheRead: Int?
+        var cacheWrite: Int?
+        var output: Int?
         var cost: Double?
         var calls = 0
 
         mutating func add(_ other: ModelTotals) {
-            input += other.input
-            cacheRead += other.cacheRead
-            cacheWrite += other.cacheWrite
-            output += other.output
+            guard calls > 0 else {
+                self = other
+                return
+            }
+            input = SessionMetrics.combined(input, other.input)
+            cacheRead = SessionMetrics.combined(cacheRead, other.cacheRead)
+            cacheWrite = SessionMetrics.combined(cacheWrite, other.cacheWrite)
+            output = SessionMetrics.combined(output, other.output)
+            cost = SessionMetrics.combined(cost, other.cost)
             calls += other.calls
-            if let c = other.cost { cost = (cost ?? 0) + c }
         }
     }
 
@@ -70,16 +78,31 @@ enum SessionMetrics {
         lines.append("|--:|---|---|--:|--:|--:|--:|--:|--:|--:|")
         for c in calls {
             lines.append("| \(c.number) | \(c.tag) | \(c.model) | \(c.status.map(String.init) ?? "—") "
-                + "| \(c.ms.map(String.init) ?? "—") | \(c.input) | \(c.cacheRead) | \(c.cacheWrite) "
-                + "| \(c.output) | \(money(c.cost)) |")
+                + "| \(c.ms.map(String.init) ?? "—") | \(number(c.input)) | \(number(c.cacheRead)) "
+                + "| \(number(c.cacheWrite)) | \(number(c.output)) | \(money(c.cost)) |")
         }
 
-        let costs = calls.compactMap(\.cost)
-        let costTotal = costs.isEmpty ? nil : costs.reduce(0, +)
         lines.append("")
-        lines.append("session totals: \(calls.count) calls · input \(sum(calls, \.input)) "
-            + "· cache-read \(sum(calls, \.cacheRead)) · cache-write \(sum(calls, \.cacheWrite)) "
-            + "· output \(sum(calls, \.output)) · cost \(money(costTotal))")
+        let providers = Dictionary(grouping: calls, by: \.provider)
+        if providers.count == 1 {
+            lines.append("session totals: \(calls.count) calls · \(totals(calls))")
+        } else {
+            // OpenAI input includes cached input while Anthropic reports uncached input separately.
+            // Do not manufacture a cross-provider token total from fields with different semantics.
+            lines.append("session totals: \(calls.count) calls · cost \(totalMoney(calls, \.cost))")
+            lines.append("")
+            lines.append("provider totals (token meanings differ; do not sum across providers):")
+            lines.append("| provider | calls | input | cache read | cache write | output | cost |")
+            lines.append("|---|--:|--:|--:|--:|--:|--:|")
+            for provider in providers.keys.sorted() {
+                let providerCalls = providers[provider]!
+                lines.append("| \(provider) | \(providerCalls.count) | \(totalNumber(providerCalls, \.input)) "
+                    + "| \(totalNumber(providerCalls, \.cacheRead)) "
+                    + "| \(totalNumber(providerCalls, \.cacheWrite)) "
+                    + "| \(totalNumber(providerCalls, \.output)) "
+                    + "| \(totalMoney(providerCalls, \.cost)) |")
+            }
+        }
 
         var perModel: [String: ModelTotals] = [:]
         for c in calls {
@@ -92,8 +115,8 @@ enum SessionMetrics {
             lines.append("|---|--:|--:|--:|--:|--:|--:|")
             for name in perModel.keys.sorted() {
                 let t = perModel[name]!
-                lines.append("| \(name) | \(t.calls) | \(t.input) | \(t.cacheRead) | \(t.cacheWrite) "
-                    + "| \(t.output) | \(money(t.cost)) |")
+                lines.append("| \(name) | \(t.calls) | \(number(t.input)) | \(number(t.cacheRead)) "
+                    + "| \(number(t.cacheWrite)) | \(number(t.output)) | \(money(t.cost)) |")
             }
         }
         return lines.joined(separator: "\n")
@@ -111,13 +134,14 @@ enum SessionMetrics {
             else { continue }
             number += 1
             let request = entry["request"] as? [String: Any]
+            let response = entry["response"] as? [String: Any]
             let model = request?["model"] as? String ?? "?"
             var call = Call(number: number,
                             tag: entry["tag"] as? String ?? "?",
+                            provider: providerName(request: request, response: response),
                             model: model,
                             status: entry["status"] as? Int,
                             ms: entry["ms"] as? Int)
-            let response = entry["response"] as? [String: Any]
 
             if let cli = response?["cli"] as? [String: Any] {
                 call.cost = double(cli["total_cost_usd"])
@@ -145,11 +169,20 @@ enum SessionMetrics {
                 }
             } else if let usage = response?["usage"] as? [String: Any] {
                 call.input = int(usage["input_tokens"])
-                call.cacheRead = int((usage["input_tokens_details"] as? [String: Any])?["cached_tokens"])
+                let details = usage["input_tokens_details"] as? [String: Any]
+                call.cacheRead = int(details?["cached_tokens"])
+                call.cacheWrite = int(details?["cache_write_tokens"])
                 call.output = int(usage["output_tokens"])
                 call.perModel[model] = ModelTotals(input: call.input, cacheRead: call.cacheRead,
-                                                   cacheWrite: 0, output: call.output,
+                                                   cacheWrite: call.cacheWrite, output: call.output,
                                                    cost: nil, calls: 1)
+            }
+            if call.perModel.isEmpty {
+                // Errors and Codex calls have no usage envelope. Keep the requested model visible in
+                // the per-model table, but propagate unavailable values through any later aggregate.
+                call.perModel[model] = ModelTotals(input: call.input, cacheRead: call.cacheRead,
+                                                   cacheWrite: call.cacheWrite, output: call.output,
+                                                   cost: call.cost, calls: 1)
             }
             calls.append(call)
         }
@@ -158,11 +191,34 @@ enum SessionMetrics {
 
     // MARK: - Small helpers
 
-    private static func sum(_ calls: [Call], _ key: KeyPath<Call, Int>) -> Int {
-        calls.reduce(0) { $0 + $1[keyPath: key] }
+    private static func totals(_ calls: [Call]) -> String {
+        "input \(totalNumber(calls, \.input)) · cache-read \(totalNumber(calls, \.cacheRead)) "
+            + "· cache-write \(totalNumber(calls, \.cacheWrite)) "
+            + "· output \(totalNumber(calls, \.output)) · cost \(totalMoney(calls, \.cost))"
     }
 
-    /// Format a dollar amount to 4 dp, or "—" when no cost was recorded (OpenAI never records one).
+    private static func totalNumber(_ calls: [Call], _ key: KeyPath<Call, Int?>) -> String {
+        let known = calls.compactMap { $0[keyPath: key] }
+        return availability(String(known.reduce(0, +)), known: known.count, total: calls.count)
+    }
+
+    private static func totalMoney(_ calls: [Call], _ key: KeyPath<Call, Double?>) -> String {
+        let known = calls.compactMap { $0[keyPath: key] }
+        let rendered = String(format: "$%.4f", known.reduce(0, +))
+        return availability(rendered, known: known.count, total: calls.count)
+    }
+
+    private static func availability(_ value: String, known: Int, total: Int) -> String {
+        guard known > 0 else { return "—" }
+        let unavailable = total - known
+        return unavailable == 0 ? value : "\(value) known (\(unavailable) unavailable)"
+    }
+
+    private static func number(_ value: Int?) -> String {
+        value.map(String.init) ?? "—"
+    }
+
+    /// Format a dollar amount to 4 dp, or "—" when no cost was recorded.
     private static func money(_ value: Double?) -> String {
         value.map { String(format: "$%.4f", $0) } ?? "—"
     }
@@ -174,11 +230,34 @@ enum SessionMetrics {
         return nil
     }
 
-    private static func int(_ any: Any?) -> Int {
-        (any as? NSNumber)?.intValue ?? 0
+    private static func int(_ any: Any?) -> Int? {
+        (any as? NSNumber)?.intValue
     }
 
     private static func double(_ any: Any?) -> Double? {
         (any as? NSNumber)?.doubleValue
+    }
+
+    private static func combined(_ lhs: Int?, _ rhs: Int?) -> Int? {
+        guard let lhs, let rhs else { return nil }
+        return lhs + rhs
+    }
+
+    private static func combined(_ lhs: Double?, _ rhs: Double?) -> Double? {
+        guard let lhs, let rhs else { return nil }
+        return lhs + rhs
+    }
+
+    private static func providerName(request: [String: Any]?, response: [String: Any]?) -> String {
+        switch request?["provider"] as? String {
+        case BrainProvider.claudeCode.rawValue: return BrainProvider.claudeCode.displayName
+        case BrainProvider.codexCLI.rawValue: return BrainProvider.codexCLI.displayName
+        case BrainProvider.openAI.rawValue: return BrainProvider.openAI.displayName
+        case .some(let provider): return provider
+        case nil:
+            // Direct OpenAI requests are the wire body itself and do not carry Jarvis's provider key.
+            return response?["cli"] == nil ? BrainProvider.openAI.displayName
+                                           : BrainProvider.claudeCode.displayName
+        }
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
@@ -34,6 +34,23 @@ import Foundation
         #expect(prompt.contains(AgenticEvaluation.reportFilename))
     }
 
+    /// The prompt teaches both provider envelopes and both cache models, points at the deterministic
+    /// metrics, requires cardinal counts from the un-elided record, and asks for a self-check — the
+    /// four failure modes the 2026-07-19 audit exhibited.
+    @Test func promptTeachesEnvelopesCacheModelsCountingAndSelfCheck() {
+        let prompt = AgenticEvaluation.prompt(sessionDirPath: "/tmp/session")
+        #expect(prompt.contains("deterministic metrics"))
+        #expect(prompt.contains("input_tokens_details.cached_tokens"))
+        #expect(prompt.contains("total_cost_usd"))
+        #expect(prompt.contains("modelUsage"))
+        #expect(prompt.contains("BLOCK-level"))
+        #expect(prompt.contains("--system-prompt"))
+        // Cardinal counts must come from the un-elided jsonl, not the elided transcript.
+        #expect(prompt.contains(BrainTrafficLog.filename))
+        #expect(prompt.contains("MUST be counted here"))
+        #expect(prompt.contains("re-check every number"))
+    }
+
     /// Shares the report filename with the single-call path, so "Show report" and the viewer find a
     /// report whichever evaluator produced it.
     @Test func reportFilenameMatchesSingleCallPath() {

--- a/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
@@ -34,15 +34,18 @@ import Foundation
         #expect(prompt.contains(AgenticEvaluation.reportFilename))
     }
 
-    /// The prompt teaches both provider envelopes and both cache models, points at the deterministic
-    /// metrics, requires cardinal counts from the un-elided record, and asks for a self-check — the
-    /// four failure modes the 2026-07-19 audit exhibited.
+    /// The prompt teaches each provider record and cache model, preserves unavailable metrics,
+    /// requires cardinal counts from the un-elided record, and asks for a self-check.
     @Test func promptTeachesEnvelopesCacheModelsCountingAndSelfCheck() {
         let prompt = AgenticEvaluation.prompt(sessionDirPath: "/tmp/session")
         #expect(prompt.contains("deterministic metrics"))
         #expect(prompt.contains("input_tokens_details.cached_tokens"))
+        #expect(prompt.contains("cache_write_tokens"))
         #expect(prompt.contains("total_cost_usd"))
         #expect(prompt.contains("modelUsage"))
+        #expect(prompt.contains("Codex CLI"))
+        #expect(prompt.contains("unavailable, not zero"))
+        #expect(prompt.contains("known (N unavailable)"))
         #expect(prompt.contains("BLOCK-level"))
         #expect(prompt.contains("--system-prompt"))
         // Cardinal counts must come from the un-elided jsonl, not the elided transcript.

--- a/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
@@ -128,14 +128,18 @@ private final class CannedBrain: BrainClient, @unchecked Sendable {
         #expect(metrics.lowerBound < firstCall.lowerBound)
     }
 
-    /// The audit prompt must teach both provider envelopes (so the auditor reads the right usage
-    /// fields), point at the computed metrics, and require a self-verification pass.
+    /// The audit prompt teaches each provider record, preserves unavailable metrics, points at the
+    /// computed values, and requires a self-verification pass.
     @Test func evalInstructionsTeachEnvelopesMetricsAndSelfCheck() {
         let p = SessionEvaluator.evalInstructions
         #expect(p.contains("deterministic metrics"))
         #expect(p.contains("input_tokens_details.cached_tokens"))
+        #expect(p.contains("cache_write_tokens"))
         #expect(p.contains("total_cost_usd"))
         #expect(p.contains("modelUsage"))
+        #expect(p.contains("Codex CLI"))
+        #expect(p.contains("unavailable, not zero"))
+        #expect(p.contains("known (N unavailable)"))
         #expect(p.contains("re-check every number"))
     }
 

--- a/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionEvaluatorTests.swift
@@ -112,6 +112,33 @@ private final class CannedBrain: BrainClient, @unchecked Sendable {
         #expect(out.contains("assistant → function_call capture_screen({})"))
     }
 
+    /// The transcript now leads with the deterministic metrics table, before the first call block,
+    /// so the auditor reads computed numbers before any usage blob.
+    @Test func transcriptLeadsWithDeterministicMetrics() throws {
+        let call = try line(request: ["model": "gpt-5.5", "input": [userItem("hi")]],
+                            response: ["status": "completed", "output": [],
+                                       "usage": ["input_tokens": 100,
+                                                 "input_tokens_details": ["cached_tokens": 40],
+                                                 "output_tokens": 12]])
+        let out = SessionEvaluator.renderTranscript(jsonl: call)
+        #expect(out.hasPrefix("=== deterministic metrics"))
+        #expect(out.contains("| call | tag | model |"))
+        let metrics = try #require(out.range(of: "deterministic metrics"))
+        let firstCall = try #require(out.range(of: "=== call #1"))
+        #expect(metrics.lowerBound < firstCall.lowerBound)
+    }
+
+    /// The audit prompt must teach both provider envelopes (so the auditor reads the right usage
+    /// fields), point at the computed metrics, and require a self-verification pass.
+    @Test func evalInstructionsTeachEnvelopesMetricsAndSelfCheck() {
+        let p = SessionEvaluator.evalInstructions
+        #expect(p.contains("deterministic metrics"))
+        #expect(p.contains("input_tokens_details.cached_tokens"))
+        #expect(p.contains("total_cost_usd"))
+        #expect(p.contains("modelUsage"))
+        #expect(p.contains("re-check every number"))
+    }
+
     @Test func evaluateSendsTranscriptAndPersistsOwnerOnlyReport() async throws {
         let dir = ActivityLogTests.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let traffic = BrainTrafficLog(); traffic.enable(directory: dir)
@@ -122,7 +149,9 @@ private final class CannedBrain: BrainClient, @unchecked Sendable {
         let brain = CannedBrain(text: "## Context engineering\nall good")
         let report = try await SessionEvaluator(brain: brain).evaluate(sessionDir: dir)
 
-        #expect(report == "## Context engineering\nall good")
+        // The model's text is preserved verbatim, preceded by the provenance stamp.
+        #expect(report.hasSuffix("## Context engineering\nall good"))
+        #expect(report.contains(SessionEvaluator.provenanceStamp))
         #expect(brain.received.first?.role == .system)
         #expect(brain.received.last?.text?.contains("=== call #1 · coach") == true)
         let url = dir.appendingPathComponent(SessionEvaluator.reportFilename)

--- a/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
@@ -19,32 +19,45 @@ import Foundation
         #expect(SessionMetrics.render(jsonl: "not json\n{bad}") == "")
     }
 
-    /// OpenAI Responses usage: cached_tokens is the cache read, there is no cache write, and cost is
-    /// unknown (renders as "—"). Session totals sum across calls.
+    /// OpenAI Responses usage keeps an explicit zero distinct from unavailable telemetry and reads
+    /// the newer cache-write field when the provider emits it. API cost remains unavailable.
     @Test func rendersOpenAIUsageAndTotals() throws {
         let first = try line(request: ["model": "gpt-5.5"],
                              response: ["usage": ["input_tokens": 100,
-                                                  "input_tokens_details": ["cached_tokens": 40],
+                                                  "input_tokens_details": ["cached_tokens": 40,
+                                                                           "cache_write_tokens": 25],
                                                   "output_tokens": 12]])
         let second = try line(request: ["model": "gpt-5.5"],
                               response: ["usage": ["input_tokens": 200,
-                                                   "input_tokens_details": ["cached_tokens": 150],
+                                                   "input_tokens_details": ["cached_tokens": 0,
+                                                                            "cache_write_tokens": 0],
                                                    "output_tokens": 20]])
         let out = SessionMetrics.render(jsonl: "\(first)\n\(second)")
 
         #expect(out.hasPrefix("=== deterministic metrics"))
-        // Per-call: input 100, cache read 40, cache write 0, output 12, cost unknown.
-        #expect(out.contains("| 1 | coach | gpt-5.5 | 200 | 500 | 100 | 40 | 0 | 12 | — |"))
-        // Session totals sum both calls.
-        #expect(out.contains("session totals: 2 calls · input 300 · cache-read 190 · cache-write 0 · output 32 · cost —"))
+        #expect(out.contains("| 1 | coach | gpt-5.5 | 200 | 500 | 100 | 40 | 25 | 12 | — |"))
+        #expect(out.contains("| 2 | coach | gpt-5.5 | 200 | 500 | 200 | 0 | 0 | 20 | — |"))
+        #expect(out.contains("session totals: 2 calls · input 300 · cache-read 40 · cache-write 25 · output 32 · cost —"))
     }
 
-    /// A transport-error call (no response) still gets a row — with its HTTP/ms and zeroed usage —
-    /// so the auditor sees it happened without a usage blob to eyeball.
-    @Test func rendersTransportErrorCallWithZeroUsage() throws {
+    @Test func rendersUnavailableOpenAICacheWriteAsUnknown() throws {
+        let call = try line(request: ["model": "gpt-5.5"],
+                            response: ["usage": ["input_tokens": 100,
+                                                 "input_tokens_details": ["cached_tokens": 40],
+                                                 "output_tokens": 12]])
+        let out = SessionMetrics.render(jsonl: call)
+
+        #expect(out.contains("| 1 | coach | gpt-5.5 | 200 | 500 | 100 | 40 | — | 12 | — |"))
+        #expect(out.contains("session totals: 1 calls · input 100 · cache-read 40 · cache-write — · output 12 · cost —"))
+    }
+
+    /// A transport error has no response usage. The call happened, but every usage value is unknown.
+    @Test func rendersTransportErrorCallWithUnknownUsage() throws {
         let failed = try line(status: nil, request: ["model": "gpt-5.5"], error: "timed out")
         let out = SessionMetrics.render(jsonl: failed)
-        #expect(out.contains("| 1 | coach | gpt-5.5 | — | 500 | 0 | 0 | 0 | 0 | — |"))
+        #expect(out.contains("| 1 | coach | gpt-5.5 | — | 500 | — | — | — | — | — |"))
+        #expect(out.contains("session totals: 1 calls · input — · cache-read — · cache-write — · output — · cost —"))
+        #expect(out.contains("| gpt-5.5 | 1 | — | — | — | — | — |"))
     }
 
     /// Local CLI (`claude -p`) envelope: cost from `total_cost_usd`, the Anthropic cache
@@ -75,5 +88,58 @@ import Foundation
         #expect(out.contains("per-model totals"))
         #expect(out.contains("| claude-haiku-4-5 | 1 | 500 | 0 | 0 | 30 | $0.0400 |"))
         #expect(out.contains("| claude-opus-4-8 | 1 | 4 | 1285 | 12000 | 200 | $1.4000 |"))
+    }
+
+    /// Codex's recorded response has no usage envelope. Successful execution must not become a
+    /// deterministic claim that the call consumed zero tokens and cost nothing.
+    @Test func rendersCodexUsageAsUnavailable() throws {
+        let call = try line(request: ["provider": "codex-cli", "model": "gpt-5.4"],
+                            response: ["exitCode": 0, "reply": "hi"])
+        let out = SessionMetrics.render(jsonl: call)
+
+        #expect(out.contains("| 1 | coach | gpt-5.4 | 200 | 500 | — | — | — | — | — |"))
+        #expect(out.contains("session totals: 1 calls · input — · cache-read — · cache-write — · output — · cost —"))
+        #expect(out.contains("| gpt-5.4 | 1 | — | — | — | — | — |"))
+    }
+
+    /// Mixed providers get provider-specific token totals because OpenAI input includes cache hits
+    /// while Anthropic reports uncached/cache-read/cache-write values separately. Known Claude cost
+    /// remains explicitly partial instead of masquerading as the whole-session cost.
+    @Test func separatesMixedProviderTokensAndLabelsPartialCost() throws {
+        let openAI = try line(request: ["model": "gpt-5.5"],
+                              response: ["usage": ["input_tokens": 100,
+                                                   "input_tokens_details": ["cached_tokens": 40],
+                                                   "output_tokens": 10]])
+        let claude = try line(
+            request: ["provider": "claude-code", "model": "opus"],
+            response: ["cli": ["total_cost_usd": 1.5,
+                                "usage": ["input_tokens": 2,
+                                          "cache_read_input_tokens": 50,
+                                          "cache_creation_input_tokens": 100,
+                                          "output_tokens": 20]]])
+        let out = SessionMetrics.render(jsonl: "\(openAI)\n\(claude)")
+
+        #expect(out.contains("session totals: 2 calls · cost $1.5000 known (1 unavailable)"))
+        #expect(out.contains("provider totals (token meanings differ; do not sum across providers)"))
+        #expect(out.contains("| Claude Code | 1 | 2 | 50 | 100 | 20 | $1.5000 |"))
+        #expect(out.contains("| OpenAI API | 1 | 100 | 40 | — | 10 | — |"))
+        #expect(!out.contains("input 102"))
+    }
+
+    /// A field can be known for only part of a same-provider session. Preserve the known subtotal and
+    /// state the unavailable-call count instead of either dropping it or presenting it as complete.
+    @Test func labelsPartialSameProviderMetric() throws {
+        let first = try line(request: ["model": "gpt-5.5"],
+                             response: ["usage": ["input_tokens": 100,
+                                                  "input_tokens_details": ["cached_tokens": 40,
+                                                                           "cache_write_tokens": 25],
+                                                  "output_tokens": 10]])
+        let second = try line(request: ["model": "gpt-5.5"],
+                              response: ["usage": ["input_tokens": 200,
+                                                   "input_tokens_details": ["cached_tokens": 50],
+                                                   "output_tokens": 20]])
+        let out = SessionMetrics.render(jsonl: "\(first)\n\(second)")
+
+        #expect(out.contains("cache-write 25 known (1 unavailable)"))
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
@@ -1,0 +1,79 @@
+import Testing
+import Foundation
+@testable import JarvisCore
+
+@Suite struct SessionMetricsTests {
+    /// One traffic line in the on-disk shape `BrainTrafficLog` writes.
+    private func line(tag: String = "coach", status: Int? = 200, ms: Int = 500,
+                      request: [String: Any], response: [String: Any]? = nil,
+                      error: String? = nil) throws -> String {
+        var entry: [String: Any] = ["t": "10:00:00", "tag": tag, "ms": ms, "request": request]
+        entry["status"] = status
+        entry["response"] = response
+        entry["error"] = error
+        return try #require(String(data: JSONSerialization.data(withJSONObject: entry), encoding: .utf8))
+    }
+
+    @Test func emptyTrafficRendersNothing() {
+        #expect(SessionMetrics.render(jsonl: "") == "")
+        #expect(SessionMetrics.render(jsonl: "not json\n{bad}") == "")
+    }
+
+    /// OpenAI Responses usage: cached_tokens is the cache read, there is no cache write, and cost is
+    /// unknown (renders as "—"). Session totals sum across calls.
+    @Test func rendersOpenAIUsageAndTotals() throws {
+        let first = try line(request: ["model": "gpt-5.5"],
+                             response: ["usage": ["input_tokens": 100,
+                                                  "input_tokens_details": ["cached_tokens": 40],
+                                                  "output_tokens": 12]])
+        let second = try line(request: ["model": "gpt-5.5"],
+                              response: ["usage": ["input_tokens": 200,
+                                                   "input_tokens_details": ["cached_tokens": 150],
+                                                   "output_tokens": 20]])
+        let out = SessionMetrics.render(jsonl: "\(first)\n\(second)")
+
+        #expect(out.hasPrefix("=== deterministic metrics"))
+        // Per-call: input 100, cache read 40, cache write 0, output 12, cost unknown.
+        #expect(out.contains("| 1 | coach | gpt-5.5 | 200 | 500 | 100 | 40 | 0 | 12 | — |"))
+        // Session totals sum both calls.
+        #expect(out.contains("session totals: 2 calls · input 300 · cache-read 190 · cache-write 0 · output 32 · cost —"))
+    }
+
+    /// A transport-error call (no response) still gets a row — with its HTTP/ms and zeroed usage —
+    /// so the auditor sees it happened without a usage blob to eyeball.
+    @Test func rendersTransportErrorCallWithZeroUsage() throws {
+        let failed = try line(status: nil, request: ["model": "gpt-5.5"], error: "timed out")
+        let out = SessionMetrics.render(jsonl: failed)
+        #expect(out.contains("| 1 | coach | gpt-5.5 | — | 500 | 0 | 0 | 0 | 0 | — |"))
+    }
+
+    /// Local CLI (`claude -p`) envelope: cost from `total_cost_usd`, the Anthropic cache
+    /// creation/read split from `cli.usage`, and per-model rows from `modelUsage` — including the
+    /// internal sidecar (haiku) pass the call-level usage alone would hide.
+    @Test func rendersCLIEnvelopeCostCacheSplitAndSidecarModels() throws {
+        let cli: [String: Any] = [
+            "total_cost_usd": 1.44,
+            "usage": ["input_tokens": 4, "cache_creation_input_tokens": 12000,
+                      "cache_read_input_tokens": 1285, "output_tokens": 200],
+            "modelUsage": [
+                "claude-opus-4-8": ["inputTokens": 4, "outputTokens": 200,
+                                    "cacheReadInputTokens": 1285, "cacheCreationInputTokens": 12000,
+                                    "costUSD": 1.40],
+                "claude-haiku-4-5": ["inputTokens": 500, "outputTokens": 30,
+                                     "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0,
+                                     "costUSD": 0.04],
+            ],
+        ]
+        let call = try line(ms: 900, request: ["model": "(CLI default)"],
+                            response: ["exitCode": 0, "reply": "hi", "cli": cli])
+        let out = SessionMetrics.render(jsonl: call)
+
+        // Per-call: the cache creation/read split and the dollar cost, all from the CLI envelope.
+        #expect(out.contains("| 1 | coach | (CLI default) | 200 | 900 | 4 | 1285 | 12000 | 200 | $1.4400 |"))
+        #expect(out.contains("session totals: 1 calls · input 4 · cache-read 1285 · cache-write 12000 · output 200 · cost $1.4400"))
+        // The per-model table breaks out both the main model and the sidecar haiku pass.
+        #expect(out.contains("per-model totals"))
+        #expect(out.contains("| claude-haiku-4-5 | 1 | 500 | 0 | 0 | 30 | $0.0400 |"))
+        #expect(out.contains("| claude-opus-4-8 | 1 | 4 | 1285 | 12000 | 200 | $1.4000 |"))
+    }
+}

--- a/scripts/eval-session.sh
+++ b/scripts/eval-session.sh
@@ -79,6 +79,15 @@ case "$AGENT" in
 esac
 mv "$REPORT_TMP" "$REPORT"
 
+# Stamp provenance so a reader knows this is the code-reading agentic audit (not the in-app
+# wire-only SessionEvaluator, which stamps its own). Prepend as one line, keeping the report
+# owner-only from birth; the HTML render below picks it up because it reads this .md back.
+STAMP="> _Produced by the agentic evaluator (\`$AGENT\` over the repo + session); recommendations labelled [confirmed] were checked against the code._"
+STAMPED_TMP="$REPORT.stamped"
+trap 'rm -f "$REPORT_TMP" "$STAMPED_TMP"' EXIT
+(umask 077; { printf '%s\n\n' "$STAMP"; cat "$REPORT"; } > "$STAMPED_TMP")
+mv "$STAMPED_TMP" "$REPORT"
+
 # Render the browsable page (with its Copy-as-Markdown button) from what the agent wrote.
 HTML="$(swift run EvalPrep --html "$SESSION_DIR")"
 echo "✓ report written to $REPORT"

--- a/scripts/eval-session.sh
+++ b/scripts/eval-session.sh
@@ -82,7 +82,7 @@ mv "$REPORT_TMP" "$REPORT"
 # Stamp provenance so a reader knows this is the code-reading agentic audit (not the in-app
 # wire-only SessionEvaluator, which stamps its own). Prepend as one line, keeping the report
 # owner-only from birth; the HTML render below picks it up because it reads this .md back.
-STAMP="> _Produced by the agentic evaluator (\`$AGENT\` over the repo + session); recommendations labelled [confirmed] were checked against the code._"
+STAMP="> _Produced by the agentic evaluator (\`$AGENT\` over the repo + session); the auditor was instructed to check recommendations labelled [confirmed] against the code._"
 STAMPED_TMP="$REPORT.stamped"
 trap 'rm -f "$REPORT_TMP" "$STAMPED_TMP"' EXIT
 (umask 077; { printf '%s\n\n' "$STAMP"; cat "$REPORT"; } > "$STAMPED_TMP")


### PR DESCRIPTION
Hardens the session evaluator against the factual errors and provider-envelope misdiagnosis found in the 2026-07-19 audit. The evaluator now computes usage directly from raw traffic and keeps unavailable telemetry explicit rather than inventing zeroes or complete totals.

## Changes

1. **Availability-aware deterministic metrics** — `SessionMetrics` computes per-call, single-provider session, provider-specific, and per-model usage directly from `brain-traffic.jsonl`. Missing values render as `—`; partial aggregates render as `known (N unavailable)`.
2. **Honest mixed-provider accounting** — OpenAI and Anthropic token totals stay provider-specific because their input-token fields have different semantics. Session cost is labeled partial unless every call records cost.
3. **Current provider records** — OpenAI cache writes are read from `input_tokens_details.cache_write_tokens` when present; older OpenAI, Codex CLI, and transport-error records keep unavailable usage unknown rather than reporting zero.
4. **Provider/cache guidance** — both evaluator prompts explain OpenAI Responses, Claude Code, and Codex CLI records, their cache semantics, and how to interpret unavailable or partial metrics.
5. **Agentic audit provenance** — reports state that the auditor was instructed to verify `[confirmed]` recommendations against the checkout, without turning an unvalidated model label into a harness guarantee.
6. **Self-verification and raw counting** — auditors must re-check numeric claims against the metrics block and count repeated content from the un-elided `brain-traffic.jsonl`.

## Verification

- Replayed `.jarvis/2026-07-19_11-23-27_6C73`: 20 calls, input 40, cache-read 23,130, cache-write 132,910, output 1,359, cost $1.4388.
- Exercised mixed OpenAI/Claude, Codex-without-usage, transport-error, OpenAI cache-write, explicit-zero, and partial-same-provider fixtures through `EvalPrep`.
- Evaluator-focused suites: 23 tests passed.
- Full gate: `swift build && ./scripts/run-tests.sh` — 435 tests across 54 suites passed.
- `bash -n scripts/eval-session.sh` and `git diff --check` passed.

Fixes #90

Generated with [Claude Code](https://claude.ai/code)