### PR TITLE
fix(coach): reword OCR-only guidance — a double-check tip, not a question

### DIFF
--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -42,7 +42,7 @@ interviews. Help without interrupting productive thinking.
   counts as current screen context.
 - OCR text is a reading aid that garbles the odd token; the screenshot image is ground truth. Before
   asserting a specific line or token is wrong, verify it in the image — if you can only see it in
-  OCR, ask about it instead of asserting.
+  OCR, frame the tip as something to double-check ("verify line 18 uses ==") rather than as a defect.
 
 # Action policy
 Choose exactly one action on each model response, in this priority order:

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -35,11 +35,12 @@ import Testing
     }
 
     /// Line-level claims must come from the image, not OCR — a live session audit caught the model
-    /// "correcting" an already-correct line it had misread from OCR noise.
+    /// "correcting" an already-correct line it had misread from OCR noise. OCR-only sightings turn
+    /// into a double-check tip (the overlay is one-way; there's no dialogue to "ask" in).
     @Test func coachPromptGroundsLineLevelClaimsInTheImage() {
         #expect(coachSystemPrompt.contains("the screenshot image is ground truth"))
         #expect(coachSystemPrompt.contains("verify it in the image"))
-        #expect(coachSystemPrompt.contains("ask about it instead of asserting"))
+        #expect(coachSystemPrompt.contains("frame the tip as something to double-check"))
     }
 
     @Test func coachPromptTreatsFreshCaptureAsSatisfyingScreenGate() {


### PR DESCRIPTION
Follow-up to #89 (merged before this landed). The coach prompt's OCR rule said "if you can only see it in OCR, ask about it instead of asserting" — but the overlay is one-way, so "ask" misreads as a dialogue Jarvis can't have. The rule now says to frame an OCR-only sighting as something to double-check ("verify line 18 uses ==") rather than asserting a defect, matching the Tip style's existing one-pointed-question pattern.

Test updated to pin the new phrasing; 390/390 JarvisCoreTests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)