### PR TITLE
ci: raise publish job timeout to 45m so notarization can't be cut off

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,11 @@ jobs:
     runs-on: macos-15
     # Notarization occasionally stalls on Apple's side; without a cap, a stalled run rides the
     # 6-hour default timeout at the 10x macOS minute multiplier. Normal publishes finish well
-    # under this.
-    timeout-minutes: 30
+    # under this. The cap must clear package-app.sh's `notarytool --wait --timeout 30m` PLUS
+    # the checkout/test/build/sign work ahead of it — at 30m the job could be killed mid-wait,
+    # leaving a draft release without its asset. 45m keeps the backstop while giving notary its
+    # full 30m window.
+    timeout-minutes: 45
     permissions:
       contents: write # upload the release asset
     steps:


### PR DESCRIPTION
## What

Raises the release `publish` job timeout from **30m → 45m**.

## Why (Codex review on #87)

The 30m job cap equalled `scripts/package-app.sh`'s `notarytool submit --wait --timeout 30m`. But the job also runs checkout, tests, cert import, and the release build *before* notarytool starts — so a notarization that runs near its 30m limit can push the whole job past 30m and get it killed mid-wait. That leaves the release a draft with no asset attached and needs a manual rerun.

45m gives Apple's notary its full 30m window plus build/test overhead, while keeping a backstop far under the 6-hour default (the reason the cap exists — a hung run bills at the 10x macOS multiplier).

Follow-up to the review comment on the merged #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)