### PR TITLE
fix(coach): recover clearly from user confusion

### DIFF
--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -68,4 +68,8 @@ the same request.
 # Tip style
 Lead with the most useful point. Be brief, concrete, encouraging, and easy to read under pressure.
 Prefer one pointed question or next step. Give a full solution only when "me" explicitly asks for it.
+If speech looks garbled, hedge the likely reading ("If you mean ...") instead of silently assuming it.
+If "me" says a tip is unclear ("huh", "I don't get it", "not clear"), do not repeat or rename the
+same explanation. Switch to one plain-language invariant plus a minimal example or tiny code template.
+For maps whose values are multiplicities, key count is not element count; name a separate element count.
 """

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -68,6 +68,33 @@ import Testing
         #expect(!coachSystemPrompt.contains("never the whole answer"))
     }
 
+    /// In a live TreeMap coaching session, "Huh?", "I don't get it", and "not very clear" drew
+    /// repeated terminology instead of a different teaching approach. Explicit confusion now
+    /// requires a concrete recovery mode rather than another rephrase.
+    @Test func coachPromptChangesApproachAfterExplicitConfusion() {
+        #expect(coachSystemPrompt.contains("\"huh\""))
+        #expect(coachSystemPrompt.contains("\"I don't get it\""))
+        #expect(coachSystemPrompt.contains("do not repeat or rename"))
+        #expect(coachSystemPrompt.contains("one plain-language invariant"))
+        #expect(coachSystemPrompt.contains("minimal example or tiny code template"))
+    }
+
+    /// The same session's ASR rendered "first" as "furs". A likely reading is useful, but it must
+    /// be labelled as an interpretation instead of being answered as certain transcript text.
+    @Test func coachPromptHedgesGarbledSpeech() {
+        #expect(coachSystemPrompt.contains("If speech looks garbled"))
+        #expect(coachSystemPrompt.contains("\"If you mean ...\""))
+        #expect(coachSystemPrompt.contains("silently assuming it"))
+    }
+
+    /// A counted TreeMap's `size()` is its distinct-key count, not its multiplicity. The session's
+    /// "small.size > k-1" tip was therefore unsafe for duplicates without a separate element count.
+    @Test func coachPromptDistinguishesKeyCountFromElementCount() {
+        #expect(coachSystemPrompt.contains("values are multiplicities"))
+        #expect(coachSystemPrompt.contains("key count is not element count"))
+        #expect(coachSystemPrompt.contains("separate element count"))
+    }
+
     /// Silence is a TOOL now: the prompt must direct the model to stay_silent (never free text),
     /// or a required tool_choice would leave it no sanctioned way to stay quiet.
     @Test func coachPromptDirectsSilenceToTheStaySilentTool() {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -82,7 +82,9 @@ moments the model judges worthwhile.
    into an array (Structured Outputs / `strict:true`), so the client never splits prose on
    punctuation — or `stay_silent`. A tool call is **required** on every model response: silence is an
    explicit tool, never plain text, so the session memory stays free of stray model prose
-   (see [decisions.md](./decisions.md)).
+   (see [decisions.md](./decisions.md)). Garbled speech and explicit confusion are recovery signals:
+   the prompt hedges likely transcript readings and switches to one plain-language invariant plus a
+   minimal example or template instead of repeating the same terminology.
 6. `speak` renders to the **Overlay**, one line at a time (per-line display time set in `Config`).
    A newer tip never interrupts one still showing — tips queue and play in order, so no hint is lost.
 


### PR DESCRIPTION
## Summary

- hedge likely readings when speech recognition appears garbled
- switch teaching approaches after explicit confusion instead of repeating or renaming the same explanation
- call out the counted-map distinction between distinct keys and total elements
- document the recovery behavior and cover each rule with prompt-contract tests

## Why

The evaluated TreeMap coaching session showed repeated terminology after the user said the explanation was unclear, silently assumed a garbled transcript reading, and briefly suggested using a map's key count as its element count. These prompt rules turn those observed failure modes into explicit coaching behavior.

## Validation

- `./scripts/run-tests.sh --filter ToolDefsTests` — 15 tests passed
- `swift build` — passed
- ghost-mode presentation API guard — passed
- `./scripts/run-tests.sh --filter OverlayInvisibilityTests` — 17 passed, 1 opt-in capture test skipped
- The exact full gate was run twice. Its build and ghost-mode phases passed; the 431-test run hit only pre-existing `OverlayInvisibilityTests` visibility/timing failures under concurrent full-suite load. That suite passes when run in isolation.