### PR TITLE
docs: fix dead live-smoke-checklist link in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ behavior, it's `JarvisOverlay`. If no subsystem fits and it's a generic helper, 
 - **Expectations:** add/extend tests for behavior changes. Don't add production seams or hooks just to
   enable a test — make the test adapt instead.
 - `JarvisApp` is intentionally **not** unit-tested — its behavior needs live TCC permissions, a mic,
-  and screen capture. Verify it with the [live smoke checklist](./README.md#live-smoke-checklist).
+  and screen capture. Verify it with the [live smoke checklist](./wiki/build-and-run.md#live-smoke-checklist).
 - **Before claiming anything works, run `./scripts/run-tests.sh` and read the output.** Evidence, not
   assertion.
 


### PR DESCRIPTION
Repoints the `live smoke checklist` link in `CLAUDE.md:141` from `./README.md#live-smoke-checklist` (a nonexistent anchor — `README.md` has no such section) to `./wiki/build-and-run.md#live-smoke-checklist`, where the `## Live smoke checklist` section actually lives. Link text is unchanged.

This aligns with CLAUDE.md's own convention that the wiki is the operational source of truth.

Docs-only change; no code touched. (Build/test gate can't run on this Linux CI runner since the project is macOS-only and requires AppKit, but no code was changed.)

Fixes #96

Generated with [Claude Code](https://claude.ai/code)