### PR TITLE
feat(brain): switch providers during live sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,10 @@ The squash-merge subject carries the PR number (`type: summary (#N)`).
   `scripts/check-ghost-mode.sh` can enforce the boundary in the normal test gate.
 - **Keep human activity separate from agent diagnostics.** `ActivityLog` is the human-facing coaching
   record: only finalized interviewer/user speech, manual hint requests, screens Jarvis actually viewed,
-  tips Jarvis displayed, and fixed typed runtime-failure notices belong there. Lifecycle, transport,
-  retry, raw error, timing, and diagnosis details go through `jlog` to `jarvis-debug.log`. Never
-  mirror `jlog` into `ActivityLog`; record the corresponding typed activity event explicitly.
+  tips Jarvis displayed, fixed typed brain-change notices, and fixed typed runtime-failure notices
+  belong there. Lifecycle, transport, retry, raw error, timing, and diagnosis details go through
+  `jlog` to `jarvis-debug.log`. Never mirror `jlog` into `ActivityLog`; record the corresponding typed
+  activity event explicitly.
 - **The only screen-/audio-derived data persisted to disk is the per-session log directory** (the
   activity log — spoken tips, transcribed "heard:" lines, the screenshots the model looked at — plus
   the wire-level brain traffic record and its on-demand evaluation report). It is written every run to an

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -37,6 +37,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// In-flight coaching turns, so Stop can cancel one mid-brain-call (otherwise it could speak
     /// after the user pressed Stop).
     private var turns: TurnTaskBox?
+    /// The running session's event loop. Stored so Brain Settings can replace only its model clients
+    /// without restarting transcription or discarding the session's transcript/history.
+    private var coachDriver: CoachDriver?
     /// The global hint hotkey. Lives for the whole app run; its callback beeps when no session runs.
     private var hotkeys: HotkeyController?
     /// Fires an on-demand hint for the running session. Non-nil only while running — set in `start()`,
@@ -127,6 +130,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // running, reflecting the real outcome back into the menu state.
         let sections: [SettingsSection] = [
             BrainSection(preferences: brainPreferences, detector: AgentCLIDetector(),
+                         onPreferencesChanged: { [weak self] cli in
+                self?.applyBrainPreferencesToRunningSession(detectedCLI: cli)
+            },
                          keyStore: secretFile, onKeySaved: { [weak self] _ in
                 guard let self, self.transcriber != nil else { return }
                 // Re-saving a key while running only re-applies it to the pipeline — it is NOT a new
@@ -168,6 +174,121 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// The three pieces that must change together when the selected brain changes. The failure
+    /// callback belongs to the provider too: CLI failures are terminal, while an OpenAI request
+    /// failure remains retryable on a later coaching turn.
+    private struct BrainRuntime {
+        let coach: BrainClient
+        let summarizer: BrainClient
+        let onFailure: (@Sendable (String) -> Void)?
+    }
+
+    /// Check the selected local provider before disturbing a live session. OpenAI needs no provider
+    /// preflight; a missing/signed-out CLI leaves the current brain intact and reports fixed Activity
+    /// copy while raw detection detail stays in the debug log.
+    private func preflightBrainProvider(_ provider: BrainProvider,
+                                        detectedCLI: DetectedAgentCLI?,
+                                        context: UserFacingError.PresentationContext,
+                                        recordSettingsFailure: Bool)
+        -> (isReady: Bool, cli: DetectedAgentCLI?) {
+        guard provider.usesLocalCLI else { return (true, nil) }
+        let action = recordSettingsFailure ? "apply brain settings" : "start"
+        guard let cli = detectedCLI else {
+            jlog("Jarvis: can't \(action) — \(provider.displayName) CLI not found.")
+            if recordSettingsFailure { ActivityLog.shared.record(.settingsChangeNotApplied) }
+            errorReporter.report(.brainCLIMissing(provider: provider.displayName), context: context)
+            return (false, nil)
+        }
+        switch cli.authenticationStatus {
+        case .signedIn:
+            break
+        case .signedOut:
+            jlog("Jarvis: can't \(action) — \(provider.displayName) isn't signed in.")
+            if recordSettingsFailure { ActivityLog.shared.record(.settingsChangeNotApplied) }
+            errorReporter.report(.brainCLINotSignedIn(provider: provider.displayName), context: context)
+            return (false, nil)
+        case .unknown:
+            errorReporter.report(.brainCLISignInUnconfirmed(provider: provider.displayName),
+                                 context: context)
+        }
+        return (true, cli)
+    }
+
+    /// Construct the coach + compaction clients for one preferences snapshot. Both keep writing to
+    /// the current session's traffic recorder, so a hot switch remains one auditable conversation.
+    private func makeBrainRuntime(apiKey key: String, provider: BrainProvider,
+                                  cli: DetectedAgentCLI?) -> BrainRuntime {
+        let coachBase: BrainClient
+        let summarizer: BrainClient
+        if let cli {
+            let sessionDir = currentSessionDir ?? logDirectory()
+            coachBase = CLIBrainClient(provider: provider, executable: cli.executableURL,
+                                       model: brainPreferences.model(for: provider).id,
+                                       reasoningEffort: brainPreferences.effort.rawValue,
+                                       workDirectory: sessionDir,
+                                       codexSupportedFeatures: cli.supportedFeatures,
+                                       traffic: sessionTraffic, trafficTag: "coach")
+            summarizer = CLIBrainClient(provider: provider, executable: cli.executableURL,
+                                        model: BrainModelCatalog.summarizerModelID(for: provider),
+                                        reasoningEffort: ReasoningEffort.low.rawValue,
+                                        workDirectory: sessionDir,
+                                        codexSupportedFeatures: cli.supportedFeatures,
+                                        traffic: sessionTraffic, trafficTag: "summarizer")
+        } else {
+            coachBase = OpenAIBrainClient(apiKey: key, model: brainPreferences.model.id,
+                                          reasoningEffort: brainPreferences.effort.rawValue,
+                                          maxOutputTokens: brainPreferences.effort.maxOutputTokens,
+                                          traffic: sessionTraffic, trafficTag: "coach")
+            summarizer = OpenAIBrainClient(
+                apiKey: key, model: BrainModelCatalog.summarizerModelID(for: .openAI),
+                reasoningEffort: ReasoningEffort.low.rawValue, maxOutputTokens: 2_048,
+                traffic: sessionTraffic, trafficTag: "summarizer")
+        }
+
+        let onFailure: (@Sendable (String) -> Void)?
+        if provider.usesLocalCLI {
+            let signInCommand = provider == .claudeCode ? "claude auth login" : "codex login"
+            onFailure = { [errorReporter] reason in
+                ActivityLog.shared.record(.coachingStopped(provider: provider))
+                errorReporter.report(.brainCLIStopped(provider: provider.displayName,
+                                                       signInCommand: signInCommand,
+                                                       reason: reason),
+                                     context: .runtime)
+            }
+        } else {
+            onFailure = nil
+        }
+        return BrainRuntime(coach: RetryingBrainClient(base: coachBase),
+                            summarizer: summarizer, onFailure: onFailure)
+    }
+
+    /// Apply provider/model/effort changes without touching capture, transcription, history, or the
+    /// session directory. An in-flight turn finishes on its old snapshot; the next turn uses this.
+    private func applyBrainPreferencesToRunningSession(detectedCLI: DetectedAgentCLI?) {
+        guard let coachDriver, transcriber != nil else { return }
+        guard let key = secrets.apiKey(), !key.isEmpty else {
+            jlog("Jarvis: can't apply brain settings — no API key.")
+            ActivityLog.shared.record(.settingsChangeNotApplied)
+            errorReporter.report(.noAPIKey, context: .runtime)
+            return
+        }
+        let provider = brainPreferences.provider
+        let preflight = preflightBrainProvider(provider, detectedCLI: detectedCLI, context: .runtime,
+                                               recordSettingsFailure: true)
+        guard preflight.isReady else { return }
+        let runtime = makeBrainRuntime(apiKey: key, provider: provider, cli: preflight.cli)
+        coachDriver.updateBrain(
+            runtime.coach, provider: provider, summarizer: runtime.summarizer,
+            onBrainFailure: runtime.onFailure,
+            onBrainFallback: { failed, restored in
+                guard let failed, let restored else { return }
+                ActivityLog.shared.record(.brainFallback(failed: failed, restored: restored))
+            })
+        let model = brainPreferences.model(for: provider)
+        jlog("Jarvis: brain settings will apply on the next turn — \(provider.displayName), "
+             + "\(model.displayName), \(brainPreferences.effort.displayName) effort.")
+    }
+
     /// Build the brain + driver and start the transcription pipeline. Returns `false` (and stays
     /// stopped) if no API key is available yet (transcription always needs it), or if the selected
     /// brain provider's CLI is missing.
@@ -190,37 +311,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             errorReporter.report(.noAPIKey, context: reportContext)
             return false
         }
-        // A CLI brain provider's binary must exist before anything is torn down — a failed Start
-        // must leave the app exactly as it was.
         let brainProvider = brainPreferences.provider
-        var brainCLI: DetectedAgentCLI?
-        if brainProvider.usesLocalCLI {
-            guard let cli = AgentCLIDetector().detect(brainProvider) else {
-                jlog("Jarvis: can't start — \(brainProvider.displayName) CLI not found.")
-                if wasRunning {
-                    ActivityLog.shared.record(.settingsChangeNotApplied)
-                }
-                errorReporter.report(.brainCLIMissing(provider: brainProvider.displayName),
-                                     context: reportContext)
-                return false
-            }
-            switch cli.authenticationStatus {
-            case .signedIn:
-                break
-            case .signedOut:
-                jlog("Jarvis: can't start — \(brainProvider.displayName) isn't signed in.")
-                if wasRunning {
-                    ActivityLog.shared.record(.settingsChangeNotApplied)
-                }
-                errorReporter.report(.brainCLINotSignedIn(provider: brainProvider.displayName),
-                                     context: reportContext)
-                return false
-            case .unknown:
-                errorReporter.report(.brainCLISignInUnconfirmed(provider: brainProvider.displayName),
-                                     context: reportContext)
-            }
-            brainCLI = cli
-        }
+        // A CLI brain provider's binary/auth must pass before anything is torn down — a failed Start
+        // or in-place key reapply leaves the existing pipeline exactly as it was.
+        let detectedCLI = brainProvider.usesLocalCLI
+            ? AgentCLIDetector().detect(brainProvider)
+            : nil
+        let preflight = preflightBrainProvider(brainProvider, detectedCLI: detectedCLI,
+                                               context: reportContext,
+                                               recordSettingsFailure: wasRunning)
+        guard preflight.isReady else { return false }
         stop() // tear down any existing pipeline so we start cleanly
         // A fresh transcript for the fresh pipeline (even on an in-place restart, which rebuilds the
         // driver and transcribers too). Reusing the old one would re-send a dead run's lines as "new
@@ -237,60 +337,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // recording sits INSIDE the retry wrapper, so each retry attempt is its own audit-visible entry.
         // History-compaction summaries don't need the coaching model — each provider's cheap tier
         // (see `BrainModelCatalog.summarizerModelID`) writes a 250-word briefing a few times an hour.
-        let coachBase: BrainClient
-        let summarizer: BrainClient
-        if let cli = brainCLI {
-            // Brain on the local CLI: turns are billed to the user's Claude/ChatGPT subscription.
-            // Screenshots for the CLI are materialized inside the session dir (owner-only posture).
-            let sessionDir = currentSessionDir ?? logDirectory()
-            coachBase = CLIBrainClient(provider: brainProvider, executable: cli.executableURL,
-                                       model: brainPreferences.model(for: brainProvider).id,
-                                       reasoningEffort: brainPreferences.effort.rawValue,
-                                       workDirectory: sessionDir,
-                                       codexSupportedFeatures: cli.supportedFeatures,
-                                       traffic: sessionTraffic, trafficTag: "coach")
-            summarizer = CLIBrainClient(provider: brainProvider, executable: cli.executableURL,
-                                        model: BrainModelCatalog.summarizerModelID(for: brainProvider),
-                                        reasoningEffort: ReasoningEffort.low.rawValue,
-                                        workDirectory: sessionDir,
-                                        codexSupportedFeatures: cli.supportedFeatures,
-                                        traffic: sessionTraffic, trafficTag: "summarizer")
-        } else {
-            coachBase = OpenAIBrainClient(apiKey: key, model: brainPreferences.model.id,
-                                          reasoningEffort: brainPreferences.effort.rawValue,
-                                          maxOutputTokens: brainPreferences.effort.maxOutputTokens,
-                                          traffic: sessionTraffic, trafficTag: "coach")
-            summarizer = OpenAIBrainClient(apiKey: key, model: BrainModelCatalog.summarizerModelID(for: .openAI),
-                                           reasoningEffort: ReasoningEffort.low.rawValue,
-                                           maxOutputTokens: 2_048,
-                                           traffic: sessionTraffic, trafficTag: "summarizer")
-        }
-        let brain = RetryingBrainClient(base: coachBase)
-        // A token can expire after the bounded Start preflight, and other runtime failures remain
-        // possible. If the actual CLI request fails, surface the reason and stop the green-but-
-        // unusable session instead of silently ignoring every later utterance.
-        let onBrainFailure: (@Sendable (String) -> Void)?
-        if brainProvider.usesLocalCLI {
-            let signInCommand = brainProvider == .claudeCode ? "claude auth login" : "codex login"
-            onBrainFailure = { [errorReporter] reason in
-                // Preserve ghost mode: the fixed Activity notice is enough for the human-facing
-                // record; the provider's detailed failure stays in jarvis-debug.log below.
-                ActivityLog.shared.record(.coachingStopped(provider: brainProvider))
-                errorReporter.report(.brainCLIStopped(provider: brainProvider.displayName,
-                                                       signInCommand: signInCommand,
-                                                       reason: reason),
-                                     context: .runtime)
-            }
-        } else {
-            onBrainFailure = nil
-        }
+        let brainRuntime = makeBrainRuntime(apiKey: key, provider: brainProvider,
+                                            cli: preflight.cli)
         // Fan each spoken tip out to both the Overlay Caption and the persistent Overlay Box.
         let overlaySink = BroadcastOverlay([overlayCaption, overlayBox])
         let driver = CoachDriver(config: config, transcript: transcript,
-                                 brain: brain, summarizer: summarizer,
+                                 brain: brainRuntime.coach, brainProvider: brainProvider,
+                                 summarizer: brainRuntime.summarizer,
                                  screen: WindowScopedScreenCapture(preferences: screenPreferences),
                                  overlay: overlaySink, clock: clock,
-                                 onBrainFailure: onBrainFailure)
+                                 onBrainFailure: brainRuntime.onFailure)
 
         // CoachDriver is @unchecked Sendable; capture it (not @MainActor self) in the callbacks.
         // Route turns through TurnTaskBox so Stop can cancel an in-flight one. Concurrent triggers are
@@ -389,6 +445,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.themTranscriber = themTranscriber
         self.aggregateCapture = capture
         self.turns = turns
+        self.coachDriver = driver
         micConnectionState = .connecting
         systemConnectionState = .connecting
         reportedCoachingReady = false
@@ -437,6 +494,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let wasRunning = transcriber != nil || themTranscriber != nil
         requestManualHint = nil              // hotkey beeps again once there's no live session
         let cancelled = turns?.cancelAll() ?? []; turns = nil   // cancel any in-flight coaching turn
+        coachDriver = nil
         // Mark both delivery endpoints stopped before draining the IOProc. Aggregate capture hands
         // chunks off asynchronously, so callbacks already queued during teardown must see the
         // transcribers' stopped guards and become no-ops.

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -181,7 +181,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private struct BrainRuntime {
         let coach: BrainClient
         let summarizer: BrainClient
-        let onFailure: (@Sendable (String) -> Void)?
+        let onFailure: (@MainActor @Sendable (String) -> Void)?
     }
 
     /// Check the selected local provider before disturbing a live session. OpenAI needs no provider
@@ -246,15 +246,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 traffic: sessionTraffic, trafficTag: "summarizer")
         }
 
-        let onFailure: (@Sendable (String) -> Void)?
+        let onFailure: (@MainActor @Sendable (String) -> Void)?
         if provider.usesLocalCLI {
             let signInCommand = provider == .claudeCode ? "claude auth login" : "codex login"
             onFailure = { [errorReporter] reason in
                 ActivityLog.shared.record(.coachingStopped(provider: provider))
-                errorReporter.report(.brainCLIStopped(provider: provider.displayName,
-                                                       signInCommand: signInCommand,
-                                                       reason: reason),
-                                     context: .runtime)
+                errorReporter.reportImmediately(
+                    .brainCLIStopped(provider: provider.displayName,
+                                     signInCommand: signInCommand,
+                                     reason: reason),
+                    context: .runtime)
             }
         } else {
             onFailure = nil

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -280,6 +280,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         coachDriver.updateBrain(
             runtime.coach, provider: provider, summarizer: runtime.summarizer,
             onBrainFailure: runtime.onFailure,
+            onBrainChangeApplied: { previous, current in
+                guard let previous, let current else { return }
+                ActivityLog.shared.record(.brainChangeApplied(previous: previous, current: current))
+            },
             onBrainFallback: { failed, restored in
                 guard let failed, let restored else { return }
                 ActivityLog.shared.record(.brainFallback(failed: failed, restored: restored))

--- a/Sources/JarvisApp/App/ErrorReporter.swift
+++ b/Sources/JarvisApp/App/ErrorReporter.swift
@@ -18,7 +18,15 @@ final class ErrorReporter {
 
     nonisolated func report(_ error: UserFacingError,
                             context: UserFacingError.PresentationContext) {
-        Task { @MainActor in self.present(error, context: context) }
+        Task { @MainActor in self.reportImmediately(error, context: context) }
+    }
+
+    /// Deliver synchronously when the caller is already on the main actor. This keeps a guarded
+    /// runtime failure atomic with its lifecycle consequence instead of introducing another queued
+    /// task in which a newer provider configuration could be stopped.
+    func reportImmediately(_ error: UserFacingError,
+                           context: UserFacingError.PresentationContext) {
+        present(error, context: context)
     }
 
     private func present(_ error: UserFacingError,

--- a/Sources/JarvisApp/Settings/BrainSection.swift
+++ b/Sources/JarvisApp/Settings/BrainSection.swift
@@ -7,16 +7,17 @@ import JarvisCore
 /// list is per provider (each remembers its own); the effort is one global setting applied to all
 /// three, mapped onto each CLI's scale by `CLIBrainClient`. Installed CLIs are auto-detected
 /// whenever the tab is shown; Claude's bounded status command distinguishes signed in, signed out,
-/// and an unavailable probe. Selections persist immediately through `BrainPreferences`; changes
-/// take effect on the next Start, since the brain client is built once per coaching run. The
-/// transcription model is deliberately NOT here; it's a separate concern — which is also why the
-/// key stays required: transcription always runs on it.
+/// and an unavailable probe. Selections persist immediately through `BrainPreferences`; while
+/// coaching, the driver swaps its model clients for the next turn without resetting transcript or
+/// history. The transcription model is deliberately NOT here; it's a separate concern — which is
+/// also why the key stays required: transcription always runs on it.
 @MainActor
 final class BrainSection: NSObject, SettingsSection {
     let title = "Brain"
 
     private let preferences: BrainPreferences
     private let detector: AgentCLIDetector
+    private let onPreferencesChanged: (DetectedAgentCLI?) -> Void
     private let apiKey: APIKeyControls
 
     private var radios: [BrainProvider: NSButton] = [:]
@@ -26,9 +27,11 @@ final class BrainSection: NSObject, SettingsSection {
     private var listedModels: [BrainModel] = []
 
     init(preferences: BrainPreferences, detector: AgentCLIDetector,
+         onPreferencesChanged: @escaping (DetectedAgentCLI?) -> Void,
          keyStore: FileSecretStore, onKeySaved: @escaping (String) -> Void) {
         self.preferences = preferences
         self.detector = detector
+        self.onPreferencesChanged = onPreferencesChanged
         self.apiKey = APIKeyControls(store: keyStore, onKeySaved: onKeySaved)
     }
 
@@ -81,7 +84,8 @@ final class BrainSection: NSObject, SettingsSection {
         }
         view.addSubview(effortPopup)
 
-        let applyNote = NSTextField(labelWithString: "Changes apply on the next Start (Stop and Start to apply now).")
+        let applyNote = NSTextField(
+            labelWithString: "Changes apply on the next coaching turn (or the next Start while stopped).")
         applyNote.frame = NSRect(x: 24, y: 192, width: 512, height: 20)
         applyNote.textColor = .secondaryLabelColor
         view.addSubview(applyNote)
@@ -110,7 +114,8 @@ final class BrainSection: NSObject, SettingsSection {
 
     /// Update radio titles/enablement from detection and re-aim the model/effort controls at the
     /// selected provider.
-    private func refreshDetection() {
+    @discardableResult
+    private func refreshDetection() -> [BrainProvider: DetectedAgentCLI] {
         let selected = preferences.provider
         let detected = Dictionary(uniqueKeysWithValues: detector.detectAll().map { ($0.provider, $0) })
         for (provider, radio) in radios {
@@ -147,6 +152,7 @@ final class BrainSection: NSObject, SettingsSection {
         }
         providerNote?.stringValue = note
         reloadModels(for: selected)
+        return detected
     }
 
     private static func note(for provider: BrainProvider) -> String {
@@ -170,18 +176,26 @@ final class BrainSection: NSObject, SettingsSection {
     @objc private func providerChanged(_ sender: NSButton) {
         guard let provider = radios.first(where: { $0.value === sender })?.key else { return }
         preferences.provider = provider
-        refreshDetection()
+        let detected = refreshDetection()
+        onPreferencesChanged(detected[provider])
     }
 
     @objc private func modelChanged(_ sender: NSPopUpButton) {
         let row = sender.indexOfSelectedItem
         guard listedModels.indices.contains(row) else { return }
         preferences.setModel(listedModels[row], for: preferences.provider)
+        onPreferencesChanged(detectSelectedCLI())
     }
 
     @objc private func effortChanged(_ sender: NSPopUpButton) {
         let row = sender.indexOfSelectedItem
         guard ReasoningEffort.allCases.indices.contains(row) else { return }
         preferences.effort = ReasoningEffort.allCases[row]
+        onPreferencesChanged(detectSelectedCLI())
+    }
+
+    private func detectSelectedCLI() -> DetectedAgentCLI? {
+        let provider = preferences.provider
+        return provider.usesLocalCLI ? detector.detect(provider) : nil
     }
 }

--- a/Sources/JarvisCore/Brain/Brain.swift
+++ b/Sources/JarvisCore/Brain/Brain.swift
@@ -90,8 +90,9 @@ public struct BrainResponse: Sendable {
     /// session memory.
     public let outputItemsJSON: [String]
     /// Non-nil when the model run did NOT finish cleanly (Responses `status:"incomplete"`), carrying
-    /// the reason (e.g. `"max_output_tokens"`). An empty `toolCalls` with a non-nil reason is
-    /// *truncation*, not a deliberate decision to stay silent — the coach loop distinguishes them.
+    /// the reason (e.g. `"max_output_tokens"`). Such a response cannot confirm a provider cutover,
+    /// even if it includes a usable tool call. With no tool call it is *truncation*, not a deliberate
+    /// decision to stay silent — the coach loop distinguishes them.
     public let incompleteReason: String?
     /// The response's plain text output, if any. Coaching turns never use it (tool_choice is
     /// required there); it exists for tool-less calls like the history summarizer.

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -21,16 +21,9 @@ import Foundation
 public final class CoachDriver: @unchecked Sendable {
     private let config: Config
     private let transcript: RollingTranscript
-    private let brain: BrainClient
-    /// Writes the compaction summaries — typically a cheaper model than the coach (see AppDelegate).
-    /// Nil falls back to `brain`, so tests and minimal callers need not wire one.
-    private let summarizer: BrainClient?
     private let screen: ScreenCapturing
     private let overlay: OverlayRendering
     private let clock: Clock
-    /// The app edge uses this to surface a provider failure and end a session that can no longer
-    /// coach. Nil keeps Core-only callers/tests free of UI policy.
-    private let onBrainFailure: (@Sendable (String) -> Void)?
     private let sessionStart: TimeInterval
     private let history = CoachHistory()
 
@@ -38,6 +31,21 @@ public final class CoachDriver: @unchecked Sendable {
     private let maxToolIterations = 4
 
     private let stateLock = NSLock()
+    /// The coach, its cheaper compaction model, and its provider-specific failure policies move
+    /// together. A turn snapshots this once before its first model call, so a Settings change cannot
+    /// split one capture/tool loop across providers; the replacement starts on the next turn.
+    private struct BrainConfiguration {
+        let revision: UInt
+        let brain: BrainClient
+        let provider: BrainProvider?
+        let summarizer: BrainClient?
+        let onFailure: (@Sendable (String) -> Void)?
+        let onFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
+    }
+    private var brainConfiguration: BrainConfiguration
+    /// The previous active configuration. A replacement keeps it until the replacement itself
+    /// completes one turn, making a Settings change a transactional cutover.
+    private var fallbackBrainConfiguration: BrainConfiguration?
     private var isHandling = false
     /// Number of transcript lines already sent to the brain. Each turn sends `lines[sentCount...]`
     /// and advances this ONLY after the input reached the server, so a failed turn re-sends its speech.
@@ -52,17 +60,18 @@ public final class CoachDriver: @unchecked Sendable {
     private var terminalBrainFailure = false
 
     public init(config: Config, transcript: RollingTranscript,
-                brain: BrainClient, summarizer: BrainClient? = nil,
+                brain: BrainClient, brainProvider: BrainProvider? = nil,
+                summarizer: BrainClient? = nil,
                 screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock,
                 onBrainFailure: (@Sendable (String) -> Void)? = nil) {
         self.config = config
         self.transcript = transcript
-        self.brain = brain
-        self.summarizer = summarizer
         self.screen = screen
         self.overlay = overlay
         self.clock = clock
-        self.onBrainFailure = onBrainFailure
+        self.brainConfiguration = BrainConfiguration(
+            revision: 0, brain: brain, provider: brainProvider, summarizer: summarizer,
+            onFailure: onBrainFailure, onFallback: nil)
         self.sessionStart = clock.now()
     }
 
@@ -74,6 +83,66 @@ public final class CoachDriver: @unchecked Sendable {
     /// Advance the read position (forward only) once the input has reached the brain.
     private func advanceSentCount(to upTo: Int) {
         stateLock.lock(); if upTo > sentCount { sentCount = upTo }; stateLock.unlock()
+    }
+
+    /// Replace only the model layer of a running coach. The transcript, sent position, history,
+    /// trigger queue, overlays, and audio pipeline stay intact. If a turn is already in flight it
+    /// finishes with its snapshotted configuration; the replacement owns the next turn. The last
+    /// working configuration remains a fallback until the replacement completes one whole turn.
+    public func updateBrain(
+        _ brain: BrainClient,
+        provider: BrainProvider? = nil,
+        summarizer: BrainClient? = nil,
+        onBrainFailure: (@Sendable (String) -> Void)? = nil,
+        onBrainFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)? = nil
+    ) {
+        stateLock.lock()
+        // Several Settings edits can land before another coaching turn. Keep the original active
+        // configuration as the fallback rather than replacing it with an untried intermediate one.
+        if fallbackBrainConfiguration == nil {
+            fallbackBrainConfiguration = brainConfiguration
+        }
+        brainConfiguration = BrainConfiguration(
+            revision: brainConfiguration.revision &+ 1,
+            brain: brain, provider: provider, summarizer: summarizer,
+            onFailure: onBrainFailure, onFallback: onBrainFallback)
+        // A provider change is a recovery path if the former provider failed just as Settings was
+        // changed. Any failure from the superseded revision is ignored below instead of re-latching.
+        terminalBrainFailure = false
+        stateLock.unlock()
+    }
+
+    private func currentBrainConfiguration() -> BrainConfiguration {
+        stateLock.lock(); defer { stateLock.unlock() }; return brainConfiguration
+    }
+
+    /// Commit a successful cutover only if this is still the active revision. A turn on a provider
+    /// superseded while it was in flight must not discard the newer replacement's fallback.
+    private func confirmBrainConfiguration(_ revision: UInt) {
+        stateLock.lock()
+        if brainConfiguration.revision == revision {
+            fallbackBrainConfiguration = nil
+        }
+        stateLock.unlock()
+    }
+
+    /// Restore the previous active configuration when an unconfirmed replacement fails. The restored
+    /// clients get a fresh revision so stale failures cannot match them through an ABA-style race.
+    private func restoreFallback(
+        for failing: BrainConfiguration
+    ) -> (configuration: BrainConfiguration,
+          callback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?)? {
+        stateLock.lock(); defer { stateLock.unlock() }
+        guard brainConfiguration.revision == failing.revision,
+              let fallback = fallbackBrainConfiguration else { return nil }
+        let restored = BrainConfiguration(
+            revision: brainConfiguration.revision &+ 1,
+            brain: fallback.brain, provider: fallback.provider, summarizer: fallback.summarizer,
+            onFailure: fallback.onFailure, onFallback: fallback.onFallback)
+        brainConfiguration = restored
+        fallbackBrainConfiguration = nil
+        terminalBrainFailure = false
+        return (restored, failing.onFallback)
     }
 
     /// Atomically claim the single in-flight slot, OR (if busy) record the trigger as pending. One
@@ -98,11 +167,14 @@ public final class CoachDriver: @unchecked Sendable {
         return .claimed
     }
 
-    private func latchTerminalBrainFailure() {
-        stateLock.lock()
+    /// Latch/report only if the failing turn still belongs to the active provider. A user can switch
+    /// providers while an old request is in flight; that stale failure must not stop the replacement.
+    private func latchTerminalBrainFailure(for revision: UInt) -> Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        guard brainConfiguration.revision == revision else { return false }
         terminalBrainFailure = true
         pendingTrigger = nil
-        stateLock.unlock()
+        return true
     }
 
     /// Atomically take the next pending trigger (keeping the slot) OR release the slot. One critical
@@ -216,21 +288,40 @@ public final class CoachDriver: @unchecked Sendable {
 
         jlog("💭 thinking…")
 
+        // Keep one provider/model for the whole tool loop. Settings updates atomically replace the
+        // shared configuration, but this turn continues on its snapshot and the next turn sees it.
+        // If an unconfirmed replacement fails, discard its provider-specific tool state and restart
+        // this same turn from the original provider-neutral messages on the last working brain.
+        let initialTurnMessages = turnMessages
+        var brains = currentBrainConfiguration()
         var committed = false
         var iterations = 0
         while iterations < maxToolIterations {
             iterations += 1
             let response: BrainResponse
             do {
-                response = try await brain.respond(messages: historyBase + turnMessages,
-                                                   tools: coachTools, toolChoice: turnToolChoice)
+                response = try await brains.brain.respond(messages: historyBase + turnMessages,
+                                                          tools: coachTools, toolChoice: turnToolChoice)
             } catch {
                 // A cancellation (barge-in / Stop) is expected — report it quietly, not as a failure.
                 if Task.isCancelled { jlog("… turn cancelled (interrupted)"); return .cancelled }
                 let detail = error.localizedDescription
                 jlog("Jarvis coach: brain request failed on \(reason): \(detail)")
-                if onBrainFailure != nil { latchTerminalBrainFailure() }
-                onBrainFailure?(detail)
+                if let fallback = restoreFallback(for: brains) {
+                    jlog("Jarvis coach: replacement brain failed — retrying this turn on the previous configuration")
+                    fallback.callback?(brains.provider, fallback.configuration.provider)
+                    brains = fallback.configuration
+                    turnMessages = initialTurnMessages
+                    iterations = 0
+                    continue
+                }
+                if let onFailure = brains.onFailure {
+                    if latchTerminalBrainFailure(for: brains.revision) {
+                        onFailure(detail)
+                    } else {
+                        jlog("… ignoring failure from superseded brain configuration")
+                    }
+                }
                 // Speech already marked sent (a later-iteration failure) must not vanish from memory —
                 // commit what this turn accumulated. A first-request failure commits nothing; the
                 // un-advanced sentCount re-sends the delta next turn instead.
@@ -253,10 +344,12 @@ public final class CoachDriver: @unchecked Sendable {
                 commitIfWorthKeeping(turnMessages, deltaText: delta.text)
                 if let reasonText = response.incompleteReason {
                     jlog("⚠️ response truncated (\(reasonText)) — not deliberate silence")
+                    confirmBrainConfiguration(brains.revision)
                     return .truncated
                 }
                 jlog("… nothing useful to add, staying silent")
-                await compactIfNeeded()
+                confirmBrainConfiguration(brains.revision)
+                await compactIfNeeded(using: brains)
                 return .silentByModel
             }
 
@@ -320,7 +413,8 @@ public final class CoachDriver: @unchecked Sendable {
                 turnMessages.append(.assistantToolCalls(response.rawToolCalls))
                 turnMessages.append(.init(role: .tool, text: "shown to the user", toolCallId: callId))
                 history.commit(turnMessages)
-                await compactIfNeeded()
+                confirmBrainConfiguration(brains.revision)
+                await compactIfNeeded(using: brains)
                 return .spoke
 
             case .staySilent:
@@ -328,13 +422,15 @@ public final class CoachDriver: @unchecked Sendable {
                 // its non-answer would only bloat every later request — silence needs no memory.
                 jlog("… nothing useful to add, staying silent")
                 commitIfWorthKeeping(turnMessages, deltaText: delta.text)
-                await compactIfNeeded()
+                confirmBrainConfiguration(brains.revision)
+                await compactIfNeeded(using: brains)
                 return .silentByModel
             }
         }
         jlog("… tool loop exhausted without speaking")
         history.commit(turnMessages)   // captures + speech stay in memory even on the backstop path
-        await compactIfNeeded()
+        confirmBrainConfiguration(brains.revision)
+        await compactIfNeeded(using: brains)
         return .exhausted
     }
 
@@ -368,11 +464,11 @@ public final class CoachDriver: @unchecked Sendable {
     /// (via `summarizer`, falling back to the coach brain). Runs while still holding the turn slot —
     /// a concurrent trigger just coalesces, so there's no compaction/turn race — and fails soft: on
     /// any error the full history simply rides along until the next attempt.
-    private func compactIfNeeded() async {
+    private func compactIfNeeded(using brains: BrainConfiguration) async {
         guard history.estimatedTokens > config.historyCompactionTokenThreshold else { return }
         guard let (oldest, count) = history.compactionPrefix() else { return }
         do {
-            let response = try await (summarizer ?? brain).respond(
+            let response = try await (brains.summarizer ?? brains.brain).respond(
                 messages: [.system(Self.summaryInstructions), .user(Self.renderForSummary(oldest))],
                 tools: [], toolChoice: .auto)
             guard let summary = response.outputText, !summary.isEmpty else {

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -32,8 +32,8 @@ public final class CoachDriver: @unchecked Sendable {
 
     private let stateLock = NSLock()
     /// The coach, its cheaper compaction model, and its provider-specific failure policies move
-    /// together. A turn snapshots this once before its first model call, so a Settings change cannot
-    /// split one capture/tool loop across providers; the replacement starts on the next turn.
+    /// together. A turn snapshots this before any awaited work, so a Settings change cannot split
+    /// its manual capture or model tool loop across providers; the replacement starts next turn.
     private struct BrainConfiguration {
         let revision: UInt
         let brain: BrainClient
@@ -44,7 +44,7 @@ public final class CoachDriver: @unchecked Sendable {
     }
     private var brainConfiguration: BrainConfiguration
     /// The previous active configuration. A replacement keeps it until the replacement itself
-    /// completes one turn, making a Settings change a transactional cutover.
+    /// completes one non-truncated terminal turn, making a Settings change a transactional cutover.
     private var fallbackBrainConfiguration: BrainConfiguration?
     private var isHandling = false
     /// Number of transcript lines already sent to the brain. Each turn sends `lines[sentCount...]`
@@ -88,7 +88,8 @@ public final class CoachDriver: @unchecked Sendable {
     /// Replace only the model layer of a running coach. The transcript, sent position, history,
     /// trigger queue, overlays, and audio pipeline stay intact. If a turn is already in flight it
     /// finishes with its snapshotted configuration; the replacement owns the next turn. The last
-    /// working configuration remains a fallback until the replacement completes one whole turn.
+    /// working configuration remains a fallback until the replacement completes one non-truncated
+    /// terminal turn.
     public func updateBrain(
         _ brain: BrainClient,
         provider: BrainProvider? = nil,
@@ -259,6 +260,11 @@ public final class CoachDriver: @unchecked Sendable {
                         ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
         var turnMessages: [ChatMessage] = [.user(userText)]
 
+        // Keep one provider/model for the whole turn, including the manual-hint capture below. This
+        // snapshot must precede that await: a Settings update while capture is in flight belongs to
+        // the next turn, not the already-started hint.
+        var brains = currentBrainConfiguration()
+
         // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and
         // inject it into THIS first request — no waiting for the model to call capture_screen.
         // Forcing `speak` (below) then guarantees a visible hint in a single round trip. Same
@@ -288,12 +294,11 @@ public final class CoachDriver: @unchecked Sendable {
 
         jlog("💭 thinking…")
 
-        // Keep one provider/model for the whole tool loop. Settings updates atomically replace the
-        // shared configuration, but this turn continues on its snapshot and the next turn sees it.
-        // If an unconfirmed replacement fails, discard its provider-specific tool state and restart
-        // this same turn from the original provider-neutral messages on the last working brain.
+        // Settings updates atomically replace the shared configuration, but this turn continues on
+        // its snapshot and the next turn sees it. If an unconfirmed replacement fails, discard its
+        // provider-specific tool state and restart this same turn from the original provider-neutral
+        // messages on the last working brain.
         let initialTurnMessages = turnMessages
-        var brains = currentBrainConfiguration()
         var committed = false
         var iterations = 0
         while iterations < maxToolIterations {
@@ -344,7 +349,8 @@ public final class CoachDriver: @unchecked Sendable {
                 commitIfWorthKeeping(turnMessages, deltaText: delta.text)
                 if let reasonText = response.incompleteReason {
                     jlog("⚠️ response truncated (\(reasonText)) — not deliberate silence")
-                    confirmBrainConfiguration(brains.revision)
+                    // An incomplete response does not prove the replacement can finish a turn. Keep
+                    // the previous provider available for a later request failure.
                     return .truncated
                 }
                 jlog("… nothing useful to add, staying silent")

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -39,7 +39,7 @@ public final class CoachDriver: @unchecked Sendable {
         let brain: BrainClient
         let provider: BrainProvider?
         let summarizer: BrainClient?
-        let onFailure: (@Sendable (String) -> Void)?
+        let onFailure: (@MainActor @Sendable (String) -> Void)?
         let onChangeApplied: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
         let onFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
     }
@@ -64,7 +64,7 @@ public final class CoachDriver: @unchecked Sendable {
                 brain: BrainClient, brainProvider: BrainProvider? = nil,
                 summarizer: BrainClient? = nil,
                 screen: ScreenCapturing, overlay: OverlayRendering, clock: Clock,
-                onBrainFailure: (@Sendable (String) -> Void)? = nil) {
+                onBrainFailure: (@MainActor @Sendable (String) -> Void)? = nil) {
         self.config = config
         self.transcript = transcript
         self.screen = screen
@@ -95,7 +95,7 @@ public final class CoachDriver: @unchecked Sendable {
         _ brain: BrainClient,
         provider: BrainProvider? = nil,
         summarizer: BrainClient? = nil,
-        onBrainFailure: (@Sendable (String) -> Void)? = nil,
+        onBrainFailure: (@MainActor @Sendable (String) -> Void)? = nil,
         onBrainChangeApplied: (@Sendable (BrainProvider?, BrainProvider?) -> Void)? = nil,
         onBrainFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)? = nil
     ) {
@@ -188,6 +188,14 @@ public final class CoachDriver: @unchecked Sendable {
         terminalBrainFailure = true
         pendingTrigger = nil
         return true
+    }
+
+    /// Recheck at main-actor delivery, not only when the request unwinds. A Settings update can run
+    /// after a terminal failure is latched but before its callback reaches the app; that stale
+    /// callback must not stop the replacement provider.
+    private func isCurrentBrainConfiguration(_ revision: UInt) -> Bool {
+        stateLock.lock(); defer { stateLock.unlock() }
+        return brainConfiguration.revision == revision
     }
 
     /// Atomically take the next pending trigger (keeping the slot) OR release the slot. One critical
@@ -316,6 +324,7 @@ public final class CoachDriver: @unchecked Sendable {
         let initialTurnMessages = turnMessages
         var committed = false
         var iterations = 0
+        var lastResponseCompleted = false
         while iterations < maxToolIterations {
             iterations += 1
             let response: BrainResponse
@@ -333,11 +342,18 @@ public final class CoachDriver: @unchecked Sendable {
                     brains = fallback.configuration
                     turnMessages = initialTurnMessages
                     iterations = 0
+                    lastResponseCompleted = false
                     continue
                 }
                 if let onFailure = brains.onFailure {
                     if latchTerminalBrainFailure(for: brains.revision) {
-                        onFailure(detail)
+                        await MainActor.run {
+                            guard isCurrentBrainConfiguration(brains.revision) else {
+                                jlog("… ignoring queued failure from superseded brain configuration")
+                                return
+                            }
+                            onFailure(detail)
+                        }
                     } else {
                         jlog("… ignoring failure from superseded brain configuration")
                     }
@@ -348,6 +364,7 @@ public final class CoachDriver: @unchecked Sendable {
                 if committed { commitIfWorthKeeping(turnMessages, deltaText: delta.text) }
                 return .brainError
             }
+            lastResponseCompleted = response.incompleteReason == nil
             // The input provably reached the server — NOW mark the delta as sent.
             if !committed { advanceSentCount(to: delta.upTo); committed = true }
 
@@ -372,6 +389,10 @@ public final class CoachDriver: @unchecked Sendable {
                 confirmBrainConfiguration(brains.revision)
                 await compactIfNeeded(using: brains)
                 return .silentByModel
+            }
+
+            if let reasonText = response.incompleteReason {
+                jlog("⚠️ response incomplete (\(reasonText)) — not confirming a brain change")
             }
 
             switch call {
@@ -437,7 +458,9 @@ public final class CoachDriver: @unchecked Sendable {
                 turnMessages.append(.assistantToolCalls(response.rawToolCalls))
                 turnMessages.append(.init(role: .tool, text: "shown to the user", toolCallId: callId))
                 history.commit(turnMessages)
-                confirmBrainConfiguration(brains.revision)
+                if lastResponseCompleted {
+                    confirmBrainConfiguration(brains.revision)
+                }
                 await compactIfNeeded(using: brains)
                 return .spoke
 
@@ -448,14 +471,18 @@ public final class CoachDriver: @unchecked Sendable {
                 jlog("… nothing useful to add, staying silent")
                 ActivityLog.shared.record(.stayedSilent)
                 commitIfWorthKeeping(turnMessages, deltaText: delta.text)
-                confirmBrainConfiguration(brains.revision)
+                if lastResponseCompleted {
+                    confirmBrainConfiguration(brains.revision)
+                }
                 await compactIfNeeded(using: brains)
                 return .silentByModel
             }
         }
         jlog("… tool loop exhausted without speaking")
         history.commit(turnMessages)   // captures + speech stay in memory even on the backstop path
-        confirmBrainConfiguration(brains.revision)
+        if lastResponseCompleted {
+            confirmBrainConfiguration(brains.revision)
+        }
         await compactIfNeeded(using: brains)
         return .exhausted
     }

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -40,6 +40,7 @@ public final class CoachDriver: @unchecked Sendable {
         let provider: BrainProvider?
         let summarizer: BrainClient?
         let onFailure: (@Sendable (String) -> Void)?
+        let onChangeApplied: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
         let onFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
     }
     private var brainConfiguration: BrainConfiguration
@@ -71,7 +72,7 @@ public final class CoachDriver: @unchecked Sendable {
         self.clock = clock
         self.brainConfiguration = BrainConfiguration(
             revision: 0, brain: brain, provider: brainProvider, summarizer: summarizer,
-            onFailure: onBrainFailure, onFallback: nil)
+            onFailure: onBrainFailure, onChangeApplied: nil, onFallback: nil)
         self.sessionStart = clock.now()
     }
 
@@ -95,6 +96,7 @@ public final class CoachDriver: @unchecked Sendable {
         provider: BrainProvider? = nil,
         summarizer: BrainClient? = nil,
         onBrainFailure: (@Sendable (String) -> Void)? = nil,
+        onBrainChangeApplied: (@Sendable (BrainProvider?, BrainProvider?) -> Void)? = nil,
         onBrainFallback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)? = nil
     ) {
         stateLock.lock()
@@ -106,7 +108,8 @@ public final class CoachDriver: @unchecked Sendable {
         brainConfiguration = BrainConfiguration(
             revision: brainConfiguration.revision &+ 1,
             brain: brain, provider: provider, summarizer: summarizer,
-            onFailure: onBrainFailure, onFallback: onBrainFallback)
+            onFailure: onBrainFailure, onChangeApplied: onBrainChangeApplied,
+            onFallback: onBrainFallback)
         // A provider change is a recovery path if the former provider failed just as Settings was
         // changed. Any failure from the superseded revision is ignored below instead of re-latching.
         terminalBrainFailure = false
@@ -120,11 +123,19 @@ public final class CoachDriver: @unchecked Sendable {
     /// Commit a successful cutover only if this is still the active revision. A turn on a provider
     /// superseded while it was in flight must not discard the newer replacement's fallback.
     private func confirmBrainConfiguration(_ revision: UInt) {
+        var callback: (@Sendable (BrainProvider?, BrainProvider?) -> Void)?
+        var previousProvider: BrainProvider?
+        var activeProvider: BrainProvider?
         stateLock.lock()
-        if brainConfiguration.revision == revision {
+        if brainConfiguration.revision == revision,
+           let fallback = fallbackBrainConfiguration {
+            callback = brainConfiguration.onChangeApplied
+            previousProvider = fallback.provider
+            activeProvider = brainConfiguration.provider
             fallbackBrainConfiguration = nil
         }
         stateLock.unlock()
+        callback?(previousProvider, activeProvider)
     }
 
     /// Restore the previous active configuration when an unconfirmed replacement fails. The restored
@@ -139,7 +150,8 @@ public final class CoachDriver: @unchecked Sendable {
         let restored = BrainConfiguration(
             revision: brainConfiguration.revision &+ 1,
             brain: fallback.brain, provider: fallback.provider, summarizer: fallback.summarizer,
-            onFailure: fallback.onFailure, onFallback: fallback.onFallback)
+            onFailure: fallback.onFailure, onChangeApplied: fallback.onChangeApplied,
+            onFallback: fallback.onFallback)
         brainConfiguration = restored
         fallbackBrainConfiguration = nil
         terminalBrainFailure = false

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -2,8 +2,8 @@ import Foundation
 
 /// The model behind the human-facing activity viewer. It records the coaching exchange — heard
 /// speech, manual hint requests, screens Jarvis viewed, and tips Jarvis gave — plus a fixed,
-/// non-sensitive notice when coaching falls back, degrades, or must stop without interrupting the
-/// user. It pushes those entries into an in-app `WKWebView` window (see `ActivityViewer` in
+/// non-sensitive notice when a brain change succeeds, falls back, degrades, or must stop without
+/// interrupting the user. It pushes those entries into an in-app `WKWebView` window (see `ActivityViewer` in
 /// JarvisApp) and persists them so past sessions can be browsed later. Detailed diagnostics belong
 /// exclusively in `JarvisLog`.
 ///
@@ -38,6 +38,10 @@ public final class ActivityLog: @unchecked Sendable {
         case systemAudioStopped
         /// An explicit Settings reapply failed its preflight while the existing session continued.
         case settingsChangeNotApplied
+        /// A live brain replacement completed its first non-truncated terminal turn. Provider
+        /// identities are enough for a fixed human-facing success notice; model transport details
+        /// remain in jlog.
+        case brainChangeApplied(previous: BrainProvider, current: BrainProvider)
         /// A live brain replacement failed its first turn, so Jarvis restored the previous active
         /// provider. Carries provider identities only; raw failure detail stays in jlog.
         case brainFallback(failed: BrainProvider, restored: BrainProvider)
@@ -149,11 +153,18 @@ public final class ActivityLog: @unchecked Sendable {
         case .settingsChangeNotApplied:
             message = "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain"
             imageBase64 = nil
+        case .brainChangeApplied(let previous, let current):
+            if previous == current {
+                message = "🧠 brain change applied — \(current.displayName) setup is active"
+            } else {
+                message = "🧠 brain switch applied — \(previous.displayName) → \(current.displayName)"
+            }
+            imageBase64 = nil
         case .brainFallback(let failed, let restored):
             if failed == restored {
-                message = "⚠️ brain change failed — retrying this turn with the previous \(restored.displayName) setup"
+                message = "⚠️ brain change failed — previous \(restored.displayName) setup restored"
             } else {
-                message = "⚠️ brain switch failed — \(failed.displayName) couldn't respond; retrying this turn with \(restored.displayName)"
+                message = "⚠️ brain switch failed — \(failed.displayName) couldn't respond; \(restored.displayName) restored"
             }
             imageBase64 = nil
         }
@@ -247,6 +258,7 @@ public final class ActivityLog: @unchecked Sendable {
         if m.hasPrefix("👁") { return "see" }
         if m.hasPrefix("🗣") || m.hasPrefix("🤫") { return "hear" }
         if m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
+        if m.hasPrefix("🧠") { return "think" }
         if m.hasPrefix("⏹ coaching stopped") { return "think" }
         if m.hasPrefix("⚠️") { return "think" }
         let low = m.lowercased()
@@ -264,6 +276,8 @@ public final class ActivityLog: @unchecked Sendable {
             || m.hasPrefix("⏹ coaching stopped")
             || m.hasPrefix("⚠️ system audio stopped")
             || m.hasPrefix("⚠️ settings change wasn't applied")
+            || m.hasPrefix("🧠 brain switch applied")
+            || m.hasPrefix("🧠 brain change applied")
             || m.hasPrefix("⚠️ brain switch failed")
             || m.hasPrefix("⚠️ brain change failed")
     }

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -2,9 +2,10 @@ import Foundation
 
 /// The model behind the human-facing activity viewer. It records the coaching exchange — heard
 /// speech, manual hint requests, screens Jarvis viewed, and tips Jarvis gave — plus a fixed,
-/// non-sensitive notice when coaching must stop without interrupting the user. It pushes those
-/// entries into an in-app `WKWebView` window (see `ActivityViewer` in JarvisApp) and persists them so
-/// past sessions can be browsed later. Detailed diagnostics belong exclusively in `JarvisLog`.
+/// non-sensitive notice when coaching falls back, degrades, or must stop without interrupting the
+/// user. It pushes those entries into an in-app `WKWebView` window (see `ActivityViewer` in
+/// JarvisApp) and persists them so past sessions can be browsed later. Detailed diagnostics belong
+/// exclusively in `JarvisLog`.
 ///
 /// This type is UI-free (Foundation only): it generates the page HTML and the per-row JS as plain
 /// strings; the WebView lives in JarvisApp. See wiki/build-and-run.md.
@@ -37,6 +38,9 @@ public final class ActivityLog: @unchecked Sendable {
         case systemAudioStopped
         /// An explicit Settings reapply failed its preflight while the existing session continued.
         case settingsChangeNotApplied
+        /// A live brain replacement failed its first turn, so Jarvis restored the previous active
+        /// provider. Carries provider identities only; raw failure detail stays in jlog.
+        case brainFallback(failed: BrainProvider, restored: BrainProvider)
     }
 
     /// One recorded line. `imageFile` is the relative `shot-N.jpg` name on disk (the bytes the DOM
@@ -144,6 +148,13 @@ public final class ActivityLog: @unchecked Sendable {
             imageBase64 = nil
         case .settingsChangeNotApplied:
             message = "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain"
+            imageBase64 = nil
+        case .brainFallback(let failed, let restored):
+            if failed == restored {
+                message = "⚠️ brain change failed — retrying this turn with the previous \(restored.displayName) setup"
+            } else {
+                message = "⚠️ brain switch failed — \(failed.displayName) couldn't respond; retrying this turn with \(restored.displayName)"
+            }
             imageBase64 = nil
         }
         queue.async { [self] in
@@ -253,6 +264,8 @@ public final class ActivityLog: @unchecked Sendable {
             || m.hasPrefix("⏹ coaching stopped")
             || m.hasPrefix("⚠️ system audio stopped")
             || m.hasPrefix("⚠️ settings change wasn't applied")
+            || m.hasPrefix("⚠️ brain switch failed")
+            || m.hasPrefix("⚠️ brain change failed")
     }
 
     /// The empty page shell: dark theme, a header with a live count, the row container, the lightbox

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -620,20 +620,28 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             nil,
         ])
         let failureRecorder = BrainFailureRecorder()
+        let changeRecorder = BrainChangeRecorder()
         let fallbackRecorder = BrainFallbackRecorder()
         let (driver, transcript) = makeDriver(
             brain: previousBrain, brainProvider: .openAI, clock: clock)
         driver.updateBrain(
             replacementBrain, provider: .claudeCode,
             onBrainFailure: { failureRecorder.record($0) },
+            onBrainChangeApplied: {
+                changeRecorder.record(previous: $0, current: $1)
+            },
             onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
 
         transcript.append(.init(speaker: .me, text: "first replacement turn", at: 0))
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(changeRecorder.events == [
+            .init(previous: .openAI, current: .claudeCode),
+        ])
         transcript.append(.init(speaker: .me, text: "later provider failure", at: 1))
         #expect(await driver.handleTrigger(.turnEnd) == .brainError)
 
         #expect(previousBrain.calls.isEmpty)
+        #expect(changeRecorder.events.count == 1)
         #expect(fallbackRecorder.events.isEmpty)
         #expect(failureRecorder.messages.count == 1)
     }
@@ -652,14 +660,19 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             nil,
         ])
         let fallbackRecorder = BrainFallbackRecorder()
+        let changeRecorder = BrainChangeRecorder()
         let (driver, transcript) = makeDriver(
             brain: previousBrain, brainProvider: .openAI, clock: clock)
         driver.updateBrain(
             replacementBrain, provider: .claudeCode,
+            onBrainChangeApplied: {
+                changeRecorder.record(previous: $0, current: $1)
+            },
             onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
 
         transcript.append(.init(speaker: .me, text: "first replacement turn", at: 0))
         #expect(await driver.handleTrigger(.turnEnd) == .truncated)
+        #expect(changeRecorder.events.isEmpty)
         transcript.append(.init(speaker: .me, text: "retry this later turn safely", at: 1))
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
 
@@ -671,6 +684,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(fallbackRecorder.events == [
             .init(failed: .claudeCode, restored: .openAI),
         ])
+        #expect(changeRecorder.events.isEmpty)
     }
 
     /// The delta is sent once: a line already carried by an earlier turn appears in the next request
@@ -982,6 +996,21 @@ final class BrainFailureRecorder: @unchecked Sendable {
     private var recorded: [String] = []
     var messages: [String] { lock.lock(); defer { lock.unlock() }; return recorded }
     func record(_ message: String) { lock.lock(); recorded.append(message); lock.unlock() }
+}
+
+/// Lock-guarded record of provider identities reported when a transactional cutover commits.
+final class BrainChangeRecorder: @unchecked Sendable {
+    struct Event: Equatable {
+        let previous: BrainProvider?
+        let current: BrainProvider?
+    }
+
+    private let lock = NSLock()
+    private var recorded: [Event] = []
+    var events: [Event] { lock.lock(); defer { lock.unlock() }; return recorded }
+    func record(previous: BrainProvider?, current: BrainProvider?) {
+        lock.lock(); recorded.append(.init(previous: previous, current: current)); lock.unlock()
+    }
 }
 
 /// Lock-guarded record of provider identities reported by a transactional fallback.

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -84,7 +84,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
                             clock: Clock, config: Config = .default,
-                            onBrainFailure: (@Sendable (String) -> Void)? = nil)
+                            onBrainFailure: (@MainActor @Sendable (String) -> Void)? = nil)
         -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
         let driver = CoachDriver(
@@ -743,6 +743,48 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(changeRecorder.events.isEmpty)
     }
 
+    /// A response can carry a valid tool call even when the provider marks the run incomplete. The
+    /// tip is still useful, but it does not prove the replacement can finish reliably, so a later
+    /// failure must still restore the previous provider.
+    @Test func incompleteSpeakRetainsFallbackUntilTerminalTurn() async {
+        let clock = ManualClock(now: 0)
+        let previousBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["fallback after incomplete tip"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["fallback after incomplete tip"]}"#)]),
+        ])
+        let replacementBrain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["partial but useful"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["partial but useful"]}"#)],
+                  incompleteReason: "max_output_tokens"),
+            nil,
+        ])
+        let fallbackRecorder = BrainFallbackRecorder()
+        let changeRecorder = BrainChangeRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: previousBrain, brainProvider: .openAI, clock: clock)
+        driver.updateBrain(
+            replacementBrain, provider: .claudeCode,
+            onBrainChangeApplied: {
+                changeRecorder.record(previous: $0, current: $1)
+            },
+            onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
+
+        transcript.append(.init(speaker: .me, text: "first replacement turn", at: 0))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(changeRecorder.events.isEmpty)
+        transcript.append(.init(speaker: .me, text: "retry after incomplete response", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+
+        #expect(replacementBrain.calls.count == 2)
+        #expect(previousBrain.calls.count == 1)
+        #expect(fallbackRecorder.events == [
+            .init(failed: .claudeCode, restored: .openAI),
+        ])
+        #expect(changeRecorder.events.isEmpty)
+    }
+
     /// The delta is sent once: a line already carried by an earlier turn appears in the next request
     /// only via history (exactly once), never re-sent as new speech.
     @Test func indexDeltaSendsEachLineExactlyOnce() async {
@@ -1008,6 +1050,58 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(nextBrain.calls.count == 1)
     }
 
+    /// The old request can latch its terminal failure before the main actor delivers the callback.
+    /// A provider switch in that queueing window invalidates the callback so it cannot stop the new
+    /// configuration.
+    @Test func queuedTerminalFailureDoesNotStopReplacementBrain() async {
+        let mainEntered = DispatchSemaphore(value: 0)
+        let mainRelease = DispatchSemaphore(value: 0)
+        let mainBlocker = Task { @MainActor in
+            blockMainActor(entered: mainEntered, release: mainRelease)
+        }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async {
+                mainEntered.wait()
+                continuation.resume()
+            }
+        }
+        defer { mainRelease.signal() }
+
+        let gate = AsyncGate()
+        let oldBrain = GatedThrowingBrain(gate: gate)
+        let nextBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["still running"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["still running"]}"#)]),
+        ])
+        let recorder = BrainFailureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: oldBrain, clock: ManualClock(now: 0),
+            onBrainFailure: { recorder.record($0) }
+        )
+        transcript.append(.init(speaker: .me, text: "first question", at: 0))
+        async let oldTurn = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+        await gate.release()
+
+        var probe = await driver.handleTrigger(.turnEnd)
+        while probe == .busy {
+            await Task.yield()
+            probe = await driver.handleTrigger(.turnEnd)
+        }
+        #expect(probe == .brainError)
+
+        driver.updateBrain(nextBrain)
+        mainRelease.signal()
+        _ = await mainBlocker.value
+        #expect(await oldTurn == .brainError)
+        #expect(recorder.messages.isEmpty)
+
+        transcript.append(.init(speaker: .me, text: "second question", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(nextBrain.calls.count == 1)
+    }
+
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
     /// prompt — reply, look at the screen, or stay_silent — but must answer with one of them.
     @Test func everyAudioTurnRequiresAToolCall() async {
@@ -1036,6 +1130,14 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         _ = await first
         #expect(brain.callCount >= 2)                      // the original AND the coalesced turn ran
     }
+}
+
+/// Synchronous on purpose: it holds main-actor delivery at a deterministic point while the test
+/// advances the provider revision from another executor.
+@MainActor
+private func blockMainActor(entered: DispatchSemaphore, release: DispatchSemaphore) {
+    entered.signal()
+    release.wait()
 }
 
 /// A brain that always throws, to exercise the `.brainError` outcome.

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -512,6 +512,40 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(nextBrain.calls.count == 1)
     }
 
+    /// A manual hint starts before its detached screenshot finishes. Settings changes during that
+    /// capture belong to the next turn; the captured hint must finish on its original provider.
+    @Test func brainUpdateDuringManualHintCaptureAppliesToNextTurn() async {
+        let clock = ManualClock(now: 0)
+        let screen = GatedScreen()
+        let oldBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["old provider hint"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["old provider hint"]}"#)]),
+        ])
+        let nextBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["new provider turn"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["new provider turn"]}"#)]),
+        ])
+        let (driver, transcript) = makeDriver(
+            brain: oldBrain, screen: screen, clock: clock)
+        transcript.append(.init(speaker: .me, text: "help with what is on screen", at: 0))
+        async let hintTurn = driver.handleTrigger(.manualHint)
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            DispatchQueue.global().async { screen.entered.wait(); cont.resume() }
+        }
+
+        driver.updateBrain(nextBrain)
+        screen.release.signal()
+        #expect(await hintTurn == .spoke)
+        #expect(oldBrain.calls.count == 1)
+        #expect(nextBrain.calls.isEmpty)
+
+        transcript.append(.init(speaker: .me, text: "continue with the new provider", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(nextBrain.calls.count == 1)
+    }
+
     /// The old brain remains a transaction fallback until the replacement proves it can finish a
     /// turn. A first-request failure retries the same transcript delta immediately on the old brain.
     @Test func failedReplacementRetriesSameTurnOnPreviousBrain() async {
@@ -602,6 +636,41 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(previousBrain.calls.isEmpty)
         #expect(fallbackRecorder.events.isEmpty)
         #expect(failureRecorder.messages.count == 1)
+    }
+
+    /// A truncated response is not a successful cutover. If the replacement fails on a later turn,
+    /// the previous provider must still be available to retry that turn and keep coaching alive.
+    @Test func truncatedReplacementRetainsFallbackUntilTerminalTurn() async {
+        let clock = ManualClock(now: 0)
+        let previousBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["fallback after truncation"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["fallback after truncation"]}"#)]),
+        ])
+        let replacementBrain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [], rawToolCalls: [], incompleteReason: "max_output_tokens"),
+            nil,
+        ])
+        let fallbackRecorder = BrainFallbackRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: previousBrain, brainProvider: .openAI, clock: clock)
+        driver.updateBrain(
+            replacementBrain, provider: .claudeCode,
+            onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
+
+        transcript.append(.init(speaker: .me, text: "first replacement turn", at: 0))
+        #expect(await driver.handleTrigger(.turnEnd) == .truncated)
+        transcript.append(.init(speaker: .me, text: "retry this later turn safely", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+
+        #expect(replacementBrain.calls.count == 2)
+        #expect(previousBrain.calls.count == 1)
+        #expect(previousBrain.calls[0].contains {
+            ($0.text ?? "").contains("retry this later turn safely")
+        })
+        #expect(fallbackRecorder.events == [
+            .init(failed: .claudeCode, restored: .openAI),
+        ])
     }
 
     /// The delta is sent once: a line already carried by an earlier turn appears in the next request

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -75,7 +75,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 // Serializing the suite keeps their enable()/disable() calls from racing each other — they are the
 // only code that enables the shared log, so no other suite can collide.
 @Suite(.serialized) struct CoachDriverPipelineTests {
-    private func makeDriver(brain: BrainClient, summarizer: BrainClient? = nil,
+    private func makeDriver(brain: BrainClient, brainProvider: BrainProvider? = nil,
+                            summarizer: BrainClient? = nil,
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
                             clock: Clock, config: Config = .default,
@@ -84,7 +85,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         let transcript = RollingTranscript()
         let driver = CoachDriver(
             config: config, transcript: transcript,
-            brain: brain, summarizer: summarizer, screen: screen, overlay: overlay, clock: clock,
+            brain: brain, brainProvider: brainProvider, summarizer: summarizer,
+            screen: screen, overlay: overlay, clock: clock,
             onBrainFailure: onBrainFailure
         )
         return (driver, transcript)
@@ -445,6 +447,163 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(second.contains { $0.role == .tool && $0.toolCallId == "spk1" })
     }
 
+    /// Changing provider/model is a model-layer swap, not a new coaching session: the replacement
+    /// receives the existing client-managed history plus only the transcript delta it has not seen.
+    @Test func brainUpdateAppliesToNextTurnWithoutLosingHistory() async {
+        let clock = ManualClock(now: 0)
+        let firstBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["first tip"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["first tip"]}"#)]),
+        ])
+        let nextBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["second tip"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["second tip"]}"#)]),
+        ])
+        let (driver, transcript) = makeDriver(brain: firstBrain, clock: clock)
+        transcript.append(.init(speaker: .me, text: "the original problem", at: 0))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+
+        driver.updateBrain(nextBrain)
+        transcript.append(.init(speaker: .me, text: "my next idea", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+
+        #expect(firstBrain.calls.count == 1)
+        #expect(nextBrain.calls.count == 1)
+        let replacementContext = nextBrain.calls[0]
+        #expect(replacementContext.contains { ($0.text ?? "").contains("the original problem") })
+        #expect(replacementContext.contains { ($0.text ?? "").contains("my next idea") })
+        #expect(replacementContext.contains { $0.role == .assistant && $0.toolCalls?.first?.id == "old" })
+        #expect(replacementContext.contains { $0.role == .tool && $0.toolCallId == "old" })
+    }
+
+    /// One capture/tool loop is one provider transaction. A switch during its first request waits
+    /// for the next turn instead of sending the captured result to a different provider/model.
+    @Test func brainUpdateDoesNotSplitAnInFlightToolLoop() async {
+        let clock = ManualClock(now: 0)
+        let gate = AsyncGate()
+        let oldBrain = GatedBrain(gate: gate, script: [
+            .init(toolCalls: [.captureScreen(callId: "capture")],
+                  rawToolCalls: [RawToolCall(id: "capture", name: "capture_screen",
+                                             argumentsJSON: "{}")]),
+            .init(toolCalls: [.speak(callId: "old", lines: ["old provider finished"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["old provider finished"]}"#)]),
+        ])
+        let nextBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["new provider turn"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["new provider turn"]}"#)]),
+        ])
+        let (driver, transcript) = makeDriver(brain: oldBrain, clock: clock)
+        transcript.append(.init(speaker: .me, text: "inspect this code", at: 0))
+        async let oldTurn = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+
+        driver.updateBrain(nextBrain)
+        await gate.release()
+        #expect(await oldTurn == .spoke)
+        #expect(oldBrain.callCount == 2)
+        #expect(nextBrain.calls.isEmpty)
+
+        transcript.append(.init(speaker: .me, text: "now continue", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(nextBrain.calls.count == 1)
+    }
+
+    /// The old brain remains a transaction fallback until the replacement proves it can finish a
+    /// turn. A first-request failure retries the same transcript delta immediately on the old brain.
+    @Test func failedReplacementRetriesSameTurnOnPreviousBrain() async {
+        let clock = ManualClock(now: 0)
+        let previousBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["fallback tip"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["fallback tip"]}"#)]),
+        ])
+        let replacementBrain = ScriptedThrowBrain(script: [nil])
+        let fallbackRecorder = BrainFallbackRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: previousBrain, brainProvider: .openAI, clock: clock)
+        driver.updateBrain(
+            replacementBrain, provider: .claudeCode,
+            onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
+        transcript.append(.init(speaker: .me, text: "keep this conversation going", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(replacementBrain.calls.count == 1)
+        #expect(previousBrain.calls.count == 1)
+        #expect(previousBrain.calls[0].contains {
+            ($0.text ?? "").contains("keep this conversation going")
+        })
+        #expect(fallbackRecorder.events == [
+            .init(failed: .claudeCode, restored: .openAI),
+        ])
+    }
+
+    /// If the replacement fails after asking for a screenshot, rollback restarts from the original
+    /// provider-neutral turn. Provider-specific calls/results from the failed tool loop never cross
+    /// into the fallback provider.
+    @Test func failedReplacementToolLoopRestartsCleanlyOnPreviousBrain() async {
+        let clock = ManualClock(now: 0)
+        let previousBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["clean fallback"])],
+                  rawToolCalls: [RawToolCall(id: "old", name: "speak",
+                                             argumentsJSON: #"{"lines":["clean fallback"]}"#)]),
+        ])
+        let replacementBrain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.captureScreen(callId: "new-capture")],
+                  rawToolCalls: [RawToolCall(id: "new-capture", name: "capture_screen",
+                                             argumentsJSON: "{}")]),
+            nil,
+        ])
+        let (driver, transcript) = makeDriver(
+            brain: previousBrain, brainProvider: .openAI, clock: clock)
+        driver.updateBrain(replacementBrain, provider: .codexCLI)
+        transcript.append(.init(speaker: .me, text: "review the visible code", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(replacementBrain.calls.count == 2)
+        #expect(previousBrain.calls.count == 1)
+        let fallbackRequest = previousBrain.calls[0]
+        #expect(fallbackRequest.contains { ($0.text ?? "").contains("review the visible code") })
+        #expect(!fallbackRequest.contains { $0.role == .tool })
+        #expect(!fallbackRequest.contains { $0.role == .assistant && $0.toolCalls != nil })
+        #expect(!fallbackRequest.contains { $0.rawItemsJSON != nil })
+    }
+
+    /// Once a replacement completes a turn it is the established provider. Later failures follow its
+    /// normal policy instead of unexpectedly rolling back to a stale provider.
+    @Test func successfulReplacementClearsItsFallback() async {
+        let clock = ManualClock(now: 0)
+        let previousBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "old", lines: ["should not run"])])
+        ])
+        let replacementBrain = ScriptedThrowBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["replacement works"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["replacement works"]}"#)]),
+            nil,
+        ])
+        let failureRecorder = BrainFailureRecorder()
+        let fallbackRecorder = BrainFallbackRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: previousBrain, brainProvider: .openAI, clock: clock)
+        driver.updateBrain(
+            replacementBrain, provider: .claudeCode,
+            onBrainFailure: { failureRecorder.record($0) },
+            onBrainFallback: { fallbackRecorder.record(failed: $0, restored: $1) })
+
+        transcript.append(.init(speaker: .me, text: "first replacement turn", at: 0))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        transcript.append(.init(speaker: .me, text: "later provider failure", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .brainError)
+
+        #expect(previousBrain.calls.isEmpty)
+        #expect(fallbackRecorder.events.isEmpty)
+        #expect(failureRecorder.messages.count == 1)
+    }
+
     /// The delta is sent once: a line already carried by an earlier turn appears in the next request
     /// only via history (exactly once), never re-sent as new speech.
     @Test func indexDeltaSendsEachLineExactlyOnce() async {
@@ -680,6 +839,36 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(recorder.messages == ["gated brain failed"])
     }
 
+    /// A Settings switch can race an already-running request. Its superseded provider may still
+    /// unwind with an error, but that stale failure must neither stop nor poison the replacement.
+    @Test func supersededInFlightFailureDoesNotStopReplacementBrain() async {
+        let clock = ManualClock(now: 0)
+        let gate = AsyncGate()
+        let oldBrain = GatedThrowingBrain(gate: gate)
+        let nextBrain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "new", lines: ["recovered"])],
+                  rawToolCalls: [RawToolCall(id: "new", name: "speak",
+                                             argumentsJSON: #"{"lines":["recovered"]}"#)]),
+        ])
+        let recorder = BrainFailureRecorder()
+        let (driver, transcript) = makeDriver(
+            brain: oldBrain, clock: clock,
+            onBrainFailure: { recorder.record($0) }
+        )
+        transcript.append(.init(speaker: .me, text: "first question", at: 0))
+        async let oldTurn = driver.handleTrigger(.turnEnd)
+        await gate.waitUntilEntered()
+
+        driver.updateBrain(nextBrain)
+        await gate.release()
+        #expect(await oldTurn == .brainError)
+        #expect(recorder.messages.isEmpty)
+
+        transcript.append(.init(speaker: .me, text: "second question", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .spoke)
+        #expect(nextBrain.calls.count == 1)
+    }
+
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
     /// prompt — reply, look at the screen, or stay_silent — but must answer with one of them.
     @Test func everyAudioTurnRequiresAToolCall() async {
@@ -726,20 +915,41 @@ final class BrainFailureRecorder: @unchecked Sendable {
     func record(_ message: String) { lock.lock(); recorded.append(message); lock.unlock() }
 }
 
+/// Lock-guarded record of provider identities reported by a transactional fallback.
+final class BrainFallbackRecorder: @unchecked Sendable {
+    struct Event: Equatable {
+        let failed: BrainProvider?
+        let restored: BrainProvider?
+    }
+
+    private let lock = NSLock()
+    private var recorded: [Event] = []
+    var events: [Event] { lock.lock(); defer { lock.unlock() }; return recorded }
+    func record(failed: BrainProvider?, restored: BrainProvider?) {
+        lock.lock(); recorded.append(.init(failed: failed, restored: restored)); lock.unlock()
+    }
+}
+
 /// A brain that parks inside `respond` until released, so a second concurrent trigger can be
 /// observed hitting the single-in-flight guard.
 final class GatedBrain: BrainClient, @unchecked Sendable {
     private let gate: AsyncGate
-    private let response: BrainResponse
+    private let script: [BrainResponse]
     private let lock = NSLock()
     private var _callCount = 0
     var callCount: Int { lock.lock(); defer { lock.unlock() }; return _callCount }
-    private func record() { lock.lock(); _callCount += 1; lock.unlock() }
-    init(gate: AsyncGate, response: BrainResponse) { self.gate = gate; self.response = response }
+    private func record() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        let index = _callCount
+        _callCount += 1
+        return index
+    }
+    init(gate: AsyncGate, response: BrainResponse) { self.gate = gate; self.script = [response] }
+    init(gate: AsyncGate, script: [BrainResponse]) { self.gate = gate; self.script = script }
     func respond(messages: [ChatMessage], tools: [ToolDef], toolChoice: ToolChoice) async throws -> BrainResponse {
-        record()
+        let index = record()
         await gate.enter()
-        return response
+        return script[min(index, script.count - 1)]
     }
 }
 

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -10,6 +10,7 @@ import Foundation
         #expect(ActivityLog.cssClass(for: "🤫 quiet for 8s") == "hear")
         #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
         #expect(ActivityLog.cssClass(for: "… nothing useful to add, staying silent") == "think")
+        #expect(ActivityLog.cssClass(for: "🧠 brain switch applied — OpenAI API → Claude Code") == "think")
         #expect(ActivityLog.cssClass(for: "⏹ coaching stopped — Claude Code couldn't respond") == "think")
         #expect(ActivityLog.cssClass(for: "Jarvis realtime error event: oops") == "err")
         #expect(ActivityLog.cssClass(for: "Jarvis: coaching started.") == "")
@@ -121,6 +122,24 @@ import Foundation
         ))
     }
 
+    @Test func brainChangeAppliedNamesProvidersWithoutDiagnosticDetail() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        log.record(.brainChangeApplied(previous: .openAI, current: .claudeCode))
+        let snapshot = log.attach { _ in }
+
+        let row = try #require(snapshot.rows.first)
+        #expect(row.contains("brain switch applied"))
+        #expect(row.contains("OpenAI API"))
+        #expect(row.contains("Claude Code"))
+        #expect(!row.contains("OAuth"))
+        #expect(!row.contains("token"))
+        #expect(ActivityLog.isHumanFacing(
+            message: "🧠 brain switch applied — OpenAI API → Claude Code",
+            imageFile: nil
+        ))
+    }
+
     @Test func brainFallbackNamesProvidersWithoutDiagnosticDetail() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
@@ -131,11 +150,13 @@ import Foundation
         #expect(row.contains("brain switch failed"))
         #expect(row.contains("Claude Code"))
         #expect(row.contains("OpenAI API"))
-        #expect(row.contains("retrying this turn"))
+        #expect(row.contains("OpenAI API restored"))
+        #expect(!row.contains("retry"))
+        #expect(!row.contains("turn"))
         #expect(!row.contains("OAuth"))
         #expect(!row.contains("token"))
         #expect(ActivityLog.isHumanFacing(
-            message: "⚠️ brain switch failed — Claude Code couldn't respond; retrying this turn with OpenAI API",
+            message: "⚠️ brain switch failed — Claude Code couldn't respond; OpenAI API restored",
             imageFile: nil
         ))
     }

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -121,6 +121,25 @@ import Foundation
         ))
     }
 
+    @Test func brainFallbackNamesProvidersWithoutDiagnosticDetail() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        log.record(.brainFallback(failed: .claudeCode, restored: .openAI))
+        let snapshot = log.attach { _ in }
+
+        let row = try #require(snapshot.rows.first)
+        #expect(row.contains("brain switch failed"))
+        #expect(row.contains("Claude Code"))
+        #expect(row.contains("OpenAI API"))
+        #expect(row.contains("retrying this turn"))
+        #expect(!row.contains("OAuth"))
+        #expect(!row.contains("token"))
+        #expect(ActivityLog.isHumanFacing(
+            message: "⚠️ brain switch failed — Claude Code couldn't respond; retrying this turn with OpenAI API",
+            imageFile: nil
+        ))
+    }
+
     @Test func runtimeFailureNoticesStayFixedAndDiagnosticFree() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -85,7 +85,10 @@ then just run the script) for packaging without CI. Distributed builds run on Ap
 
 Settings → **Activity** opens an **in-app `WKWebView`** into which `ActivityLog` pushes the typed,
 human-facing coaching exchange: finalized interviewer/user speech, manual hint requests, screens
-Jarvis viewed, and tips Jarvis displayed. Screen-view events carry their thumbnails as in-memory
+Jarvis viewed, and tips Jarvis displayed. Fixed runtime notices also record a settings preflight that
+was not applied, a failed live brain switch falling back to the previous provider, or a subsystem
+stopping/degrading; provider names are allowed, while raw errors, authentication details, retries,
+and timing remain in `jarvis-debug.log`. Screen-view events carry their thumbnails as in-memory
 `data:` URIs. Chosen over a local HTTP server + SSE: for an app that already holds the entries in
 memory, pushing into an embedded WebView is less code, has zero network surface, and is the most
 testable (the production runtime *is* the test runtime). It also sidesteps the `file://` `fetch()`

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -533,18 +533,8 @@
 
 ### 2026-07-22 — Brain settings hot-switch between coaching turns
 
-- **Chose:** Apply provider, model, and reasoning-effort changes to a running `CoachDriver` without
-  restarting the coaching pipeline. The driver atomically replaces the coach client, summarizer, and
-  provider-specific failure policy, then snapshots that configuration once per turn: an in-flight
-  tool loop finishes on its original provider and the next turn uses the replacement. Transcript,
-  sent position, client-managed history, overlays, audio capture/transcription, session directory,
-  and traffic recorder remain one continuous session. Cutover is transactional: the previous active
-  provider remains available until the replacement completes one non-truncated terminal turn. If the
-  replacement fails, discard its provider-specific tool-loop state, restore the prior provider, and
-  retry that same turn from the original provider-neutral messages; record only the failed/restored
-  providers in Activity while raw error detail stays in `jarvis-debug.log`. A superseded in-flight
-  provider failure cannot stop the replacement; a missing or signed-out newly selected CLI fails
-  preflight and leaves the current brain running.
+- **Chose:** Apply provider, model, and reasoning-effort changes between coaching turns without
+  stopping the session, using a snapshotted, transactional brain configuration in `CoachDriver`.
 - **Why:** A live interview is exactly when changing provider or model is useful. The old Settings
   behavior persisted the click but silently kept the start-time client for the entire run, while the
   obvious reuse of the existing restart path would discard the transcript and coaching history.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -191,7 +191,7 @@
 
 - **Chose:** A Brain settings tab picks the model from a code-owned `BrainModelCatalog` (default `gpt-5.5`) and one global reasoning effort (default `low`), persisted via `BrainPreferences` and applied on next Start; moved out of `Config`.
 - **Why:** The catalog/enum becomes the single source of truth, and the user can trade quality versus cost/latency.
-- **Superseded in part by:** 2026-07-22 — Brain settings hot-switch between coaching turns. Persistence and catalog ownership stand; next-Start-only application does not.
+- **Superseded by:** 2026-07-22 — Brain settings hot-switch between coaching turns. Persistence and catalog ownership stand; next-Start-only application does not.
 - **Detail:** [settings-window.md](./settings-window.md).
 
 ### 2026-06-20 — Persistent response box beside the overlay

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -539,7 +539,7 @@
   tool loop finishes on its original provider and the next turn uses the replacement. Transcript,
   sent position, client-managed history, overlays, audio capture/transcription, session directory,
   and traffic recorder remain one continuous session. Cutover is transactional: the previous active
-  provider remains available until the replacement completes one whole turn. If the
+  provider remains available until the replacement completes one non-truncated terminal turn. If the
   replacement fails, discard its provider-specific tool-loop state, restore the prior provider, and
   retry that same turn from the original provider-neutral messages; record only the failed/restored
   providers in Activity while raw error detail stays in `jarvis-debug.log`. A superseded in-flight

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -191,6 +191,7 @@
 
 - **Chose:** A Brain settings tab picks the model from a code-owned `BrainModelCatalog` (default `gpt-5.5`) and one global reasoning effort (default `low`), persisted via `BrainPreferences` and applied on next Start; moved out of `Config`.
 - **Why:** The catalog/enum becomes the single source of truth, and the user can trade quality versus cost/latency.
+- **Superseded in part by:** 2026-07-22 — Brain settings hot-switch between coaching turns. Persistence and catalog ownership stand; next-Start-only application does not.
 - **Detail:** [settings-window.md](./settings-window.md).
 
 ### 2026-06-20 — Persistent response box beside the overlay
@@ -529,3 +530,34 @@
 - **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
 - **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers),
   `Sources/JarvisCore/Brain/CLIBrainClient+Invocation.swift`, `AgentCLIProcessRunner.swift`.
+
+### 2026-07-22 — Brain settings hot-switch between coaching turns
+
+- **Chose:** Apply provider, model, and reasoning-effort changes to a running `CoachDriver` without
+  restarting the coaching pipeline. The driver atomically replaces the coach client, summarizer, and
+  provider-specific failure policy, then snapshots that configuration once per turn: an in-flight
+  tool loop finishes on its original provider and the next turn uses the replacement. Transcript,
+  sent position, client-managed history, overlays, audio capture/transcription, session directory,
+  and traffic recorder remain one continuous session. Cutover is transactional: the previous active
+  provider remains available until the replacement completes one whole turn. If the
+  replacement fails, discard its provider-specific tool-loop state, restore the prior provider, and
+  retry that same turn from the original provider-neutral messages; record only the failed/restored
+  providers in Activity while raw error detail stays in `jarvis-debug.log`. A superseded in-flight
+  provider failure cannot stop the replacement; a missing or signed-out newly selected CLI fails
+  preflight and leaves the current brain running.
+- **Why:** A live interview is exactly when changing provider or model is useful. The old Settings
+  behavior persisted the click but silently kept the start-time client for the entire run, while the
+  obvious reuse of the existing restart path would discard the transcript and coaching history.
+  Client-managed, provider-neutral committed history makes a between-turn switch safe; provider raw
+  reasoning items exist only inside a turn's tool loop, which is why the snapshot boundary matters.
+- **Rejected:** (a) Stop and Start automatically — rotates or resets live context and interrupts
+  transcription. (b) Looking up preferences on every `BrainClient.respond` call — can split one
+  capture/tool loop across providers and invalidate provider-specific reasoning/call linkage. (c)
+  Cancelling the in-flight turn on every Settings click — drops a valid response and can churn CLI
+  subprocesses while the user adjusts model and effort controls. (d) Stopping after an unconfirmed
+  replacement fails — sacrifices a known-working provider and interrupts the live conversation. (e)
+  Feeding the failed replacement's partial tool loop into the fallback — provider-specific reasoning
+  and call identifiers cannot safely cross transports, so the clean turn input is replayed instead.
+- **Supersedes in part:** 2026-06-20 — Brain model + reasoning effort are user-selectable.
+- **Detail:** [settings-window.md → Brain](./settings-window.md#brain),
+  `Sources/JarvisCore/Coach/CoachDriver.swift`, `Sources/JarvisApp/App/AppDelegate.swift`.

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -143,13 +143,15 @@ audio pipeline, and session logs continue unchanged. The previous active provide
 until the replacement completes one non-truncated terminal turn; an incomplete response does not
 commit the cutover. If the replacement fails, the driver
 discards its provider-specific tool-loop state, restores the prior provider, and retries that same
-turn from its provider-neutral starting messages; Activity names the failed and restored providers
-without including the raw error. Several Settings edits before a turn still fall back to the original
-active provider, not an untried intermediate selection. A local-CLI choice is preflighted first; if
-its binary is missing or it is signed out, the existing brain keeps running and Activity records the
-fixed settings-not-applied notice. Runtime fallback changes the live brain only; the attempted choice
-remains persisted so the user can retry it or select something else deliberately. While stopped,
-persisted changes apply on the **next Start**.
+turn from its provider-neutral starting messages. Once the replacement completes its first
+non-truncated terminal turn, Activity records fixed provider-only switch-applied copy; a fallback
+instead records the failed and restored providers without retry lifecycle or raw error detail.
+Several Settings edits before a turn still fall back to the original active provider, not an untried
+intermediate selection. A local-CLI choice is preflighted first; if its binary is missing or it is
+signed out, the existing brain keeps running and Activity records the fixed settings-not-applied
+notice. Runtime fallback changes the live brain only; the attempted choice remains persisted so the
+user can retry it or select something else deliberately. While stopped, persisted changes apply on
+the **next Start**.
 
 All four selections persist via `BrainPreferences` —
 `Sources/JarvisCore/Config/BrainPreferences.swift` is the single source for the UserDefaults keys,

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -49,7 +49,7 @@ so an unwrapped fixed-frame view would ride the bottom edge in a taller window).
 
 | Section class | Tab title | Always present | Description |
 |---|---|---|---|
-| `BrainSection` | "Brain" | yes | Everything that decides who answers a coaching turn, in one tab: the provider radios (OpenAI API / Claude Code / Codex CLI — see [Brain](#brain)), a per-provider model dropdown, the reasoning-effort dropdown (one global setting, mapped onto each provider's scale), and the OpenAI API-key controls (`APIKeyControls`: an `NSSecureTextField` that saves to an owner-only file and restarts the pipeline if already running). Takes effect on the next Start. |
+| `BrainSection` | "Brain" | yes | Everything that decides who answers a coaching turn, in one tab: the provider radios (OpenAI API / Claude Code / Codex CLI — see [Brain](#brain)), a per-provider model dropdown, the reasoning-effort dropdown (one global setting, mapped onto each provider's scale), and the OpenAI API-key controls (`APIKeyControls`: an `NSSecureTextField` that saves to an owner-only file and restarts the pipeline if already running). Brain choices take effect on the next coaching turn while running, or the next Start while stopped. |
 | `OverlaySection` | "Overlay" | yes | Two groups, one per overlay surface — **Overlay Caption** (the transient on-screen tip) and **Overlay Box** (the persistent response history). Each has a header with an On/Off toggle (an `NSSwitch` + "On"/"Off" label) and a one-line description. When a surface is **on** it also shows its Text Size + Opacity sliders (with live readouts) and a live sample, **only while the Overlay tab is selected** (`didBecomeActive`/`didResignActive`); when **off**, its sliders and sample are hidden and the layout collapses. Persists via `OverlayAppearance`. |
 | `DisplaySection` | "Screen" | yes | One dropdown — the capture scope: **Active window** (default) or one **Entire display** entry per connected display; persists via `ScreenCapturePreferences`. Applies to the next screenshot. |
 | `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `fillsTab == true` so the log stretches with the window. Its header shows the selected session's exact directory ID in a selectable field with **Copy ID**, and carries **Evaluate** — one click sends the selected session's recorded LLM wire traffic (`brain-traffic.jsonl`) to the brain model at high effort for a context-engineering audit (`SessionEvaluator`), saved as `eval-report.md` in the session dir and opened in the browser as a rendered `eval-report.html` page (`EvalReportPage`) whose **Copy as Markdown** button hands the raw report to an agent chat; once a session has a saved report the button flips to **Open report**. Only *finished* conversations qualify: the button is disabled while the selected session is the live, still-running one (a mid-session audit would judge half a story) and re-enables once Stop has drained any in-flight turn — the cancelled request's final traffic line must land before the audit reads the file. |
@@ -114,9 +114,10 @@ known install dirs, while Claude sign-in uses its non-billing `auth status --jso
 short timeout because account metadata can outlive an expired OAuth session. Codex keeps using its
 auth-file marker. The radios show **signed in**, **signed out**, or **sign-in unknown**; a confirmed
 logout refuses Start, while an unavailable probe warns but does not falsely claim logout. An actual
-CLI request can still fail after preflight; Jarvis then stops the unusable coaching session without
-activating the app, adds a discreet provider-only notice to Activity, and keeps the detailed error
-and sign-in command in `jarvis-debug.log`.
+CLI request can still fail after preflight. A provider that was selected at Start or has already
+completed a turn then stops the unusable coaching session without activating the app; a newly
+switched provider uses the transactional fallback described below. Both paths keep detailed error
+and sign-in information in `jarvis-debug.log` and put only fixed provider-level copy in Activity.
 
 **Model + effort.** A **Model** dropdown drawn from `BrainModelCatalog` per provider (OpenAI ids for
 the API; CLI aliases like `sonnet` for the CLIs, plus a "CLI default" entry meaning "no model flag" —
@@ -134,9 +135,20 @@ the key.
 
 Reads are validated: a persisted model id no longer in that provider's catalog (or an unrecognized
 provider/effort) falls back to the default rather than reaching the API. The transcription model is
-deliberately **not** here — it's a separate field and code path (`Config.transcriptionModel`). The
-values are read in `AppDelegate.start()` when the brain client is built, so a change takes effect on
-the **next Start**, not mid-session — hence the caption on the tab.
+deliberately **not** here — it's a separate field and code path (`Config.transcriptionModel`). A
+running `CoachDriver` atomically replaces its coach, summarizer, and provider-failure policy when a
+brain value changes. An in-flight turn keeps one snapshotted provider through its whole tool loop;
+the replacement starts on the **next coaching turn** while the transcript, client-managed history,
+audio pipeline, and session logs continue unchanged. The previous active provider remains available
+until the replacement completes one whole turn. If the replacement fails, the driver
+discards its provider-specific tool-loop state, restores the prior provider, and retries that same
+turn from its provider-neutral starting messages; Activity names the failed and restored providers
+without including the raw error. Several Settings edits before a turn still fall back to the original
+active provider, not an untried intermediate selection. A local-CLI choice is preflighted first; if
+its binary is missing or it is signed out, the existing brain keeps running and Activity records the
+fixed settings-not-applied notice. Runtime fallback changes the live brain only; the attempted choice
+remains persisted so the user can retry it or select something else deliberately. While stopped,
+persisted changes apply on the **next Start**.
 
 All four selections persist via `BrainPreferences` —
 `Sources/JarvisCore/Config/BrainPreferences.swift` is the single source for the UserDefaults keys,

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -140,7 +140,8 @@ running `CoachDriver` atomically replaces its coach, summarizer, and provider-fa
 brain value changes. An in-flight turn keeps one snapshotted provider through its whole tool loop;
 the replacement starts on the **next coaching turn** while the transcript, client-managed history,
 audio pipeline, and session logs continue unchanged. The previous active provider remains available
-until the replacement completes one whole turn. If the replacement fails, the driver
+until the replacement completes one non-truncated terminal turn; an incomplete response does not
+commit the cutover. If the replacement fails, the driver
 discards its provider-specific tool-loop state, restores the prior provider, and retries that same
 turn from its provider-neutral starting messages; Activity names the failed and restored providers
 without including the raw error. Several Settings edits before a turn still fall back to the original

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -25,12 +25,15 @@ replacement socket replays the rest after a half-open failure. A live Wi-Fi reco
 that speech captured during the outage returns after recovery. The brain can also run through a
 locally installed Claude Code or Codex CLI on the user's subscription; Settings → Brain auto-detects
 those providers, reports Claude's current sign-in state from its bounded status command, and keeps
-the OpenAI API-key path available. Codex coaching calls suppress project instructions and its
-feature-gated agent tools, run as direct-response decisions, and stop under a provider-specific
-stall bound instead of leaving later speech batched indefinitely. A failed CLI coaching request
-stops the unusable session without activating the app, leaves a discreet provider-only Activity
-notice, and keeps the detailed reason in `jarvis-debug.log` instead of leaving the listening state
-green. The same runtime ghost-mode rule
+the OpenAI API-key path available. Provider, model, and effort changes apply transactionally between
+turns without restarting the session: the previous brain remains available until the replacement
+finishes a non-truncated terminal turn, and Activity records a fixed provider-only success or
+fallback notice. Codex coaching calls suppress project instructions and its feature-gated agent
+tools, run as direct-response decisions, and stop under a provider-specific stall bound instead of
+leaving later speech batched indefinitely. A failed established CLI coaching request stops the
+unusable session without activating the app, leaves a discreet provider-only Activity notice, and
+keeps the detailed reason in `jarvis-debug.log` instead of leaving the listening state green. The
+same runtime ghost-mode rule
 now covers microphone transcription, audio-route loss, in-place CLI preflight, and Activity-audit
 completion: no runtime error autonomously activates Jarvis, opens a browser, or presents a modal;
 fixed notices remain available in Activity. The gate statically rejects unreviewed presentation APIs.
@@ -42,8 +45,11 @@ details, ask “Jarvis, how can I solve this in one pass?”, and confirm the fi
 exactly one `capture_screen` followed by a screen-specific reply. Then ask a fully stated behavioral
 question and confirm it can answer without an unnecessary capture. Finish the in-app Claude Code
 provider smoke: confirm Settings shows it signed in, then confirm a coaching turn and screen request.
-Finish the in-app Codex smoke through audio and the overlay, then confirm a missing or signed-out CLI
-fails loudly. The standard release checklist remains in [build-and-run.md](./build-and-run.md).
+While that session runs, switch providers and confirm the next completed turn preserves context and
+adds the provider-only success notice to Activity; then exercise a failed replacement and confirm
+the previous provider continues the conversation with a provider-only fallback notice. Finish the
+in-app Codex smoke through audio and the overlay, then confirm a missing or signed-out CLI fails
+loudly. The standard release checklist remains in [build-and-run.md](./build-and-run.md).
 
 ## Built
 
@@ -53,12 +59,12 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisCore/Audio/` — transactional PCM + utterance buffering, adaptive content-free activity detection, non-destructive AEC reference alignment, and system-audio timeline preservation (`PCMBuffer`, `UtteranceBuffer`, `PCM16Framer`, `AudioDownmix`, `AdaptiveAudioActivityDetector`, `EchoReferenceAlignment`, `SystemAudioTimeline`).
 - `Sources/JarvisCore/Transcription/` — realtime session wire contract, per-item event ledger, and rolling transcript (`RealtimeSession`, `RealtimeTranscriptionLedger`, `Transcript`, `NoiseReduction`).
 - `Sources/JarvisCore/Brain/` — the LLM integration: the `BrainClient` contract (`Brain`), `OpenAIBrainClient`, `CLIBrainClient` + `AgentCLIProcessRunner` + `AgentCLIDetector`/`AgentCLIAuthenticationStatus` (the local Claude Code / Codex brain providers and sign-in state), `RetryingBrainClient`, `BrainProvider`, `BrainModelCatalog` (default `gpt-5.5`), `ReasoningEffort`.
-- `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver`, `CoachHistory` (client-managed session memory), `ToolDefs` (coach tools + system prompt).
+- `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver` (including transactional between-turn brain replacement), `CoachHistory` (client-managed session memory), `ToolDefs` (coach tools + system prompt).
 - `Sources/JarvisCore/Triggers/` — turn/silence trigger detection, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
 - `Sources/JarvisCore/Screen/` — the model-triggered screen-capture tool contract + window-scoped capture logic (`ScreenCapture`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`).
 - `Sources/JarvisCore/Overlay/` — overlay text model + length-proportional timing + fan-out (`OverlayRendering`, `OverlayTiming`, `OverlayAppearance`, `BroadcastOverlay`).
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + brain/screen preferences (`Config`, `Secrets`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
-- `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation (single-call in-app **and** the agentic dev-side audit's prompt/transcript prep), user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `AgenticEvaluation`, `UserFacingError`).
+- `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log with fixed typed brain-change success/fallback notices, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + one-click session evaluation (single-call in-app **and** the agentic dev-side audit's prompt/transcript prep), user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `SessionEvaluator`, `AgenticEvaluation`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
 - `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (startup alerts plus an unconditional no-presentation runtime policy).
 - `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).


### PR DESCRIPTION
## Summary

- apply provider, model, and reasoning-effort changes to a running coaching session on the next turn while preserving transcript, history, audio, and session logs
- snapshot the provider before any awaited turn work, including manual-hint screen capture, so an already-started turn cannot switch providers mid-flight
- make the cutover transactional: retain the previous brain until the replacement completes a non-truncated terminal turn, and restore it automatically if the replacement fails
- treat every incomplete response as non-confirming, including usable `speak`, `stay_silent`, and capture-loop responses, so the previous working provider remains available
- suppress a terminal failure callback if its provider revision is superseded before main-actor delivery, preventing a queued old-provider failure from stopping the replacement session
- retry a failed replacement turn from a clean provider-neutral message set so partial tool-loop state is never sent across providers
- record fixed provider-only Activity notices when a brain change is confirmed or falls back, while keeping retry lifecycle and raw diagnostics in `jarvis-debug.log`
- keep the decision log, Settings design, current status, and Activity policy aligned with the live-switch behavior
- merge current `main` and preserve its complete brain-action and terminal-transcription Activity behavior

## Validation

- `swift build`
- `./scripts/run-tests.sh --filter queuedTerminalFailureDoesNotStopReplacementBrain` — passed
- `./scripts/run-tests.sh --filter incompleteSpeakRetainsFallbackUntilTerminalTurn` — passed
- `./scripts/run-tests.sh --filter OverlayInvisibilityTests` — 18 tests passed
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — 456 tests passed across 54 suites
- ghost-mode guard passed

The default parallel all-suite invocation encountered the repository's known cross-suite AppKit timing contention in `OverlayInvisibilityTests`; the overlay suite passed cleanly in isolation and the complete 456-test suite passed serially.