### PR TITLE
fix(coach): stay silent on garbled fragments

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -182,9 +182,12 @@ public final class CoachDriver: @unchecked Sendable {
         let historyBase: [ChatMessage] = [.system(coachSystemPrompt)] + history.snapshot()
         // New speech (when there is any) followed by the trigger note (when there is one — a
         // turn-end has none, the stamped delta already carries that signal). Never both empty:
-        // an empty turn-end delta is gated above, and silence/manual-hint always have a note.
-        let userText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
-                        ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
+        // an empty turn-end delta is gated above, and silence/manual-hint always have a note. The
+        // explicit boundary lets the prompt select the final turn instead of mistaking a retained
+        // historical fragment for newly delivered speech.
+        let currentTurnText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
+                               ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
+        let userText = "Current turn:\n\(currentTurnText)"
         var turnMessages: [ChatMessage] = [.user(userText)]
 
         // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -182,12 +182,9 @@ public final class CoachDriver: @unchecked Sendable {
         let historyBase: [ChatMessage] = [.system(coachSystemPrompt)] + history.snapshot()
         // New speech (when there is any) followed by the trigger note (when there is one — a
         // turn-end has none, the stamped delta already carries that signal). Never both empty:
-        // an empty turn-end delta is gated above, and silence/manual-hint always have a note. The
-        // explicit boundary lets the prompt select the final turn instead of mistaking a retained
-        // historical fragment for newly delivered speech.
-        let currentTurnText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
-                               ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
-        let userText = "Current turn:\n\(currentTurnText)"
+        // an empty turn-end delta is gated above, and silence/manual-hint always have a note.
+        let userText = [delta.text.isEmpty ? nil : "New since last turn:\n\(delta.text)",
+                        ctx.promptLine].compactMap { $0 }.joined(separator: "\n\n")
         var turnMessages: [ChatMessage] = [.user(userText)]
 
         // Manual hint (hotkey): the user explicitly asked for help, so capture the screen HERE and

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -35,10 +35,10 @@ interviews. Help without interrupting productive thinking.
   answer "them" directly.
 - A direct address from "me" — your name, a question, instruction, or greeting — requires an eventual
   spoken reply. "them:" is context; offer "me" a tip only when useful.
-- The final "Current turn:" block is the request you are answering; every earlier "Current turn:"
-  block is history. New speech inside the final block appears under "New since last turn" with
-  [mm:ss] timestamps. A "(no speech for ...)" marker means quiet, not a request. Longer quiet makes
-  being stuck more likely, but does not prove it.
+- The final user text block is the request you are answering; every earlier user block is history.
+  New speech inside the final block appears under "New since last turn" with [mm:ss] timestamps. A
+  "(no speech for ...)" marker means quiet, not a request. Longer quiet makes being stuck more likely,
+  but does not prove it.
 - You can see the screen only through capture_screen. A fresh screenshot or OCR in the current input
   counts as current screen context.
 - OCR text is a reading aid that garbles the odd token; the screenshot image is ground truth. Before
@@ -50,12 +50,12 @@ Choose exactly one action on each model response, in this priority order:
 
 1. Direct address from "me": if a specific, correct reply depends on missing current visible
    information, continue to the screen gate below. Otherwise call speak without capturing.
-2. Fragment gate: inspect only the final "Current turn:" block and ignore every earlier one in
+2. Fragment gate: inspect only the final user text block and ignore every earlier user block in
    history. Apply this gate only when that final block includes "New since last turn". Judge only the
    newest speech inside that block: if it is a short, question-free fragment or likely ASR garble,
    call stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
-   A direct reply required by rule 1 bypasses this gate. A final "Current turn:" block with no "New
-   since last turn" speech also bypasses it, even if the newest historical speech was fragmentary.
+   A direct reply required by rule 1 bypasses this gate. A final user block with no "New since last
+   turn" speech also bypasses it, even if the newest historical speech was fragmentary.
    A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
    Wait for more speech. If a direct reply is required, hedge your interpretation instead.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -35,8 +35,7 @@ interviews. Help without interrupting productive thinking.
   answer "them" directly.
 - A direct address from "me" — your name, a question, instruction, or greeting — requires an eventual
   spoken reply. "them:" is context; offer "me" a tip only when useful.
-- The final user text block is the request you are answering; every earlier user block is history.
-  New speech inside the final block appears under "New since last turn" with [mm:ss] timestamps. A
+- New speech appears under "New since last turn" with [mm:ss] timestamps. A
   "(no speech for ...)" marker means quiet, not a request. Longer quiet makes being stuck more likely,
   but does not prove it.
 - You can see the screen only through capture_screen. A fresh screenshot or OCR in the current input
@@ -48,20 +47,13 @@ interviews. Help without interrupting productive thinking.
 # Action policy
 Choose exactly one action on each model response, in this priority order:
 
-1. Direct address from "me": if a specific, correct reply depends on missing current visible
-   information, continue to the screen gate below. Otherwise call speak without capturing.
-2. Fragment gate: inspect only the final user text block and ignore every earlier user block in
-   history. If the final block includes a "(no speech for ...)" marker, bypass this gate even when
-   unsent speech rides along under "New since last turn". Otherwise, apply this gate only when that
-   final block includes "New since last turn". Evaluate all newly delivered speech in that block,
-   not only its last line. Call stay_silent only when the entire fresh delta consists of short,
-   question-free fragments or likely ASR garble. If any fresh line conveys a coherent substantive
-   statement — including an explicit help request or stuck signal, correction, requirement, or
-   technical fact — bypass this gate and continue through the remaining policy.
-   A direct reply required by rule 1 bypasses this gate. A final user block with no "New since last
-   turn" speech bypasses it too, even if the newest historical speech was fragmentary.
-   A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
-   Wait for more speech. If a direct reply is required, hedge your interpretation instead.
+1. Direct address from "me": bypass the fragment gate. If a specific, correct reply depends on
+   missing current visible information, continue to the screen gate below. Otherwise call speak.
+2. Fragment gate: when the latest user message contains "New since last turn" and no "(no speech for
+   ...)" marker, inspect all speech in that section. If all of it consists of short, question-free
+   fragments or likely ASR garble, call stay_silent; otherwise continue. Help/stuck signals,
+   corrections, requirements, and technical facts are meaningful, not fragments. Do not correct
+   likely transcription mistakes; hedge your interpretation when a reply is required.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible
    information that is absent from the conversation and no fresh capture result is available for this
    request. This includes an explicit request to look or an unresolved reference to the current

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -56,10 +56,14 @@ Choose exactly one action on each model response, in this priority order:
    result. If only "them" spoke and no tip is warranted, call stay_silent without capturing.
 2. Direct address from "me": call speak. If the conversation already contains everything needed,
    answer without capturing.
-3. "me" is making steady progress: call stay_silent.
-4. Progress is unclear, especially after silence: call capture_screen unless a fresh result is already
+3. Fragment gate: if the newest speech is a short, question-free fragment or likely ASR garble, call
+   stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
+   A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
+   Wait for more speech. If a direct reply is required, hedge your interpretation instead.
+4. "me" is making steady progress: call stay_silent.
+5. Progress is unclear, especially after silence: call capture_screen unless a fresh result is already
    available. Then speak only if the user seems stuck; otherwise call stay_silent.
-5. "me" is stuck: call speak with the next concrete step. Build on earlier tips instead of repeating
+6. "me" is stuck: call speak with the next concrete step. Build on earlier tips instead of repeating
    them.
 
 A fresh capture result satisfies the screen gate for that request. Use it; do not capture again for

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -47,19 +47,20 @@ interviews. Help without interrupting productive thinking.
 # Action policy
 Choose exactly one action on each model response, in this priority order:
 
-1. Screen gate: before speaking, capture when a specific, correct response depends on current visible
+1. Direct address from "me": if a specific, correct reply depends on missing current visible
+   information, continue to the screen gate below. Otherwise call speak without capturing.
+2. Fragment gate: if the newest speech is a short, question-free fragment or likely ASR garble, call
+   stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
+   A direct reply required by rule 1 bypasses this gate.
+   A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
+   Wait for more speech. If a direct reply is required, hedge your interpretation instead.
+3. Screen gate: before speaking, capture when a specific, correct response depends on current visible
    information that is absent from the conversation and no fresh capture result is available for this
    request. This includes an explicit request to look or an unresolved reference to the current
    question, code, error, diagram, document, or notes (for example, "this problem", "here", "my code",
-   or "one pass" without the problem). Never guess missing content. This gate applies to either speaker
-   and overrides the direct-reply rule. If "me" asked, call capture_screen now, then speak after the
-   result. If only "them" spoke and no tip is warranted, call stay_silent without capturing.
-2. Direct address from "me": call speak. If the conversation already contains everything needed,
-   answer without capturing.
-3. Fragment gate: if the newest speech is a short, question-free fragment or likely ASR garble, call
-   stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
-   A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
-   Wait for more speech. If a direct reply is required, hedge your interpretation instead.
+   or "one pass" without the problem). Never guess missing content. This gate applies to either speaker.
+   If "me" asked, call capture_screen now, then speak after the result. If only "them" spoke and no tip
+   is warranted, call stay_silent without capturing.
 4. "me" is making steady progress: call stay_silent.
 5. Progress is unclear, especially after silence: call capture_screen unless a fresh result is already
    available. Then speak only if the user seems stuck; otherwise call stay_silent.

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -49,11 +49,9 @@ Choose exactly one action on each model response, in this priority order:
 
 1. Direct address from "me": bypass the fragment gate. If a specific, correct reply depends on
    missing current visible information, continue to the screen gate below. Otherwise call speak.
-2. Fragment gate: when the latest user message contains "New since last turn" and no "(no speech for
-   ...)" marker, inspect all speech in that section. If all of it consists of short, question-free
-   fragments or likely ASR garble, call stay_silent; otherwise continue. Help/stuck signals,
-   corrections, requirements, and technical facts are meaningful, not fragments. Do not correct
-   likely transcription mistakes; hedge your interpretation when a reply is required.
+2. Fragment gate: when a non-silence request contains new speech, call stay_silent only if all of
+   it is incomplete or likely mistranscribed. Help/stuck signals and other meaningful speech bypass
+   this gate. If a reply is required despite uncertain transcription, hedge rather than correct it.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible
    information that is absent from the conversation and no fresh capture result is available for this
    request. This includes an explicit request to look or an unresolved reference to the current

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -49,9 +49,11 @@ Choose exactly one action on each model response, in this priority order:
 
 1. Direct address from "me": if a specific, correct reply depends on missing current visible
    information, continue to the screen gate below. Otherwise call speak without capturing.
-2. Fragment gate: if the newest speech is a short, question-free fragment or likely ASR garble, call
-   stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
-   A direct reply required by rule 1 bypasses this gate.
+2. Fragment gate: apply only when this turn's user text includes a "New since last turn" block.
+   Judge only the newest speech inside that block: if it is a short, question-free fragment or likely
+   ASR garble, call stay_silent unless it clearly conveys a correction, requirement, or new technical
+   fact. A direct reply required by rule 1 bypasses this gate. A silence-only turn with no "New since
+   last turn" block also bypasses it, even if the newest historical speech was fragmentary.
    A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
    Wait for more speech. If a direct reply is required, hedge your interpretation instead.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -35,9 +35,10 @@ interviews. Help without interrupting productive thinking.
   answer "them" directly.
 - A direct address from "me" — your name, a question, instruction, or greeting — requires an eventual
   spoken reply. "them:" is context; offer "me" a tip only when useful.
-- New speech appears under "New since last turn" with [mm:ss] timestamps. A
-  "(no speech for ...)" marker means quiet, not a request. Longer quiet makes being stuck more likely,
-  but does not prove it.
+- The final "Current turn:" block is the request you are answering; every earlier "Current turn:"
+  block is history. New speech inside the final block appears under "New since last turn" with
+  [mm:ss] timestamps. A "(no speech for ...)" marker means quiet, not a request. Longer quiet makes
+  being stuck more likely, but does not prove it.
 - You can see the screen only through capture_screen. A fresh screenshot or OCR in the current input
   counts as current screen context.
 - OCR text is a reading aid that garbles the odd token; the screenshot image is ground truth. Before
@@ -49,11 +50,12 @@ Choose exactly one action on each model response, in this priority order:
 
 1. Direct address from "me": if a specific, correct reply depends on missing current visible
    information, continue to the screen gate below. Otherwise call speak without capturing.
-2. Fragment gate: apply only when this turn's user text includes a "New since last turn" block.
-   Judge only the newest speech inside that block: if it is a short, question-free fragment or likely
-   ASR garble, call stay_silent unless it clearly conveys a correction, requirement, or new technical
-   fact. A direct reply required by rule 1 bypasses this gate. A silence-only turn with no "New since
-   last turn" block also bypasses it, even if the newest historical speech was fragmentary.
+2. Fragment gate: inspect only the final "Current turn:" block and ignore every earlier one in
+   history. Apply this gate only when that final block includes "New since last turn". Judge only the
+   newest speech inside that block: if it is a short, question-free fragment or likely ASR garble,
+   call stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
+   A direct reply required by rule 1 bypasses this gate. A final "Current turn:" block with no "New
+   since last turn" speech also bypasses it, even if the newest historical speech was fragmentary.
    A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
    Wait for more speech. If a direct reply is required, hedge your interpretation instead.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -51,11 +51,15 @@ Choose exactly one action on each model response, in this priority order:
 1. Direct address from "me": if a specific, correct reply depends on missing current visible
    information, continue to the screen gate below. Otherwise call speak without capturing.
 2. Fragment gate: inspect only the final user text block and ignore every earlier user block in
-   history. Apply this gate only when that final block includes "New since last turn". Judge only the
-   newest speech inside that block: if it is a short, question-free fragment or likely ASR garble,
-   call stay_silent unless it clearly conveys a correction, requirement, or new technical fact.
+   history. If the final block includes a "(no speech for ...)" marker, bypass this gate even when
+   unsent speech rides along under "New since last turn". Otherwise, apply this gate only when that
+   final block includes "New since last turn". Evaluate all newly delivered speech in that block,
+   not only its last line. Call stay_silent only when the entire fresh delta consists of short,
+   question-free fragments or likely ASR garble. If any fresh line conveys a coherent substantive
+   statement — including an explicit help request or stuck signal, correction, requirement, or
+   technical fact — bypass this gate and continue through the remaining policy.
    A direct reply required by rule 1 bypasses this gate. A final user block with no "New since last
-   turn" speech also bypasses it, even if the newest historical speech was fragmentary.
+   turn" speech bypasses it too, even if the newest historical speech was fragmentary.
    A likely transcription mistake is not itself a coaching opportunity: do not correct its wording.
    Wait for more speech. If a direct reply is required, hedge your interpretation instead.
 3. Screen gate: before speaking, capture when a specific, correct response depends on current visible

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -59,21 +59,6 @@ import Testing
                 "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
     }
 
-    /// A filler-only turn-end does not advance the sent index, so the first silence wake-up carries
-    /// both the retained filler and its fresh silence marker. The prompt uses the marker to bypass
-    /// fragment silence and reach the proactive screen policy without waiting for another backoff.
-    @Test func silenceAfterSkippedFillerCarriesBlockThenNote() async {
-        let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "quiet")])])
-        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
-        transcript.append(.init(speaker: .me, text: "hmm", at: 0))
-
-        #expect(await driver.handleTrigger(.turnEnd) == .skippedFillerOnly)
-        #expect(brain.calls.isEmpty)
-        #expect(await driver.handleTrigger(.silence(secondsQuiet: 30)) == .silentByModel)
-        #expect(lastUserMessage(brain) ==
-                "New since last turn:\n[00:00] me: hmm\n\n[00:00] (no speech for 30s)")
-    }
-
     /// A fragment committed after `stay_silent` remains useful history, but it must not masquerade as
     /// fresh speech on a later proactive silence check. The current turn is the final bare note.
     @Test func silenceAfterFragmentCarriesNoFreshSpeechBlock() async {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -58,4 +58,24 @@ import Testing
         #expect(lastUserMessage(brain) ==
                 "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
     }
+
+    /// A fragment committed after `stay_silent` remains useful history, but it must not masquerade as
+    /// fresh speech on a later proactive silence check. The current turn is the final bare note.
+    @Test func silenceAfterFragmentCarriesNoFreshSpeechBlock() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "quiet1")]),
+            .init(toolCalls: [.staySilent(callId: "quiet2")]),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "one pass", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 30)) == .silentByModel)
+
+        let userMessages = brain.calls[1].filter { $0.role == .user }.compactMap(\.text)
+        #expect(userMessages == [
+            "New since last turn:\n[00:00] me: one pass",
+            "[00:00] (no speech for 30s)",
+        ])
+    }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -2,10 +2,11 @@ import Foundation
 import Testing
 @testable import JarvisCore
 
-/// How the per-turn user message is assembled (CoachDriver.runTurn): new speech is wrapped in a
-/// "New since last turn:" block ONLY when there is any, followed by the trigger note ONLY when the
-/// trigger has one — a turn-end has none (the stamped delta already says the user just spoke), so
-/// its message is the bare block; a silence wake-up with nothing said is the bare note.
+/// How the per-turn user message is assembled (CoachDriver.runTurn): every request gets an explicit
+/// "Current turn:" boundary. New speech is wrapped in a "New since last turn:" block ONLY when there
+/// is any, followed by the trigger note ONLY when the trigger has one — a turn-end has none (the
+/// stamped delta already says the user just spoke), so its payload is the bare speech block; a
+/// silence wake-up with nothing said carries only the bare note after the boundary.
 @Suite struct CoachDriverContextMessageTests {
     private func makeDriver(brain: BrainClient, clock: Clock) -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
@@ -30,7 +31,8 @@ import Testing
 
         await driver.handleTrigger(.turnEnd)
 
-        #expect(lastUserMessage(brain) == "New since last turn:\n[00:00] me: brute force two-sum")
+        #expect(lastUserMessage(brain) ==
+                "Current turn:\nNew since last turn:\n[00:00] me: brute force two-sum")
     }
 
     /// No new speech (a silence wake-up with nothing said): the message is the bare trigger note —
@@ -42,7 +44,7 @@ import Testing
         await driver.handleTrigger(.silence(secondsQuiet: 30))
 
         let msg = lastUserMessage(brain)
-        #expect(msg == "[00:00] (no speech for 30s)")
+        #expect(msg == "Current turn:\n[00:00] (no speech for 30s)")
         #expect(msg?.contains("New since last turn") == false)
         #expect(msg?.contains("nothing new") == false)
     }
@@ -56,7 +58,8 @@ import Testing
         await driver.handleTrigger(.silence(secondsQuiet: 45))
 
         #expect(lastUserMessage(brain) ==
-                "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
+                "Current turn:\nNew since last turn:\n[00:00] me: hmm let me think\n\n"
+                + "[00:00] (no speech for 45s)")
     }
 
     /// A fragment committed after `stay_silent` remains useful history, but it must not masquerade as
@@ -74,8 +77,8 @@ import Testing
 
         let userMessages = brain.calls[1].filter { $0.role == .user }.compactMap(\.text)
         #expect(userMessages == [
-            "New since last turn:\n[00:00] me: one pass",
-            "[00:00] (no speech for 30s)",
+            "Current turn:\nNew since last turn:\n[00:00] me: one pass",
+            "Current turn:\n[00:00] (no speech for 30s)",
         ])
     }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -59,6 +59,21 @@ import Testing
                 "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
     }
 
+    /// A filler-only turn-end does not advance the sent index, so the first silence wake-up carries
+    /// both the retained filler and its fresh silence marker. The prompt uses the marker to bypass
+    /// fragment silence and reach the proactive screen policy without waiting for another backoff.
+    @Test func silenceAfterSkippedFillerCarriesBlockThenNote() async {
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.staySilent(callId: "quiet")])])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "hmm", at: 0))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .skippedFillerOnly)
+        #expect(brain.calls.isEmpty)
+        #expect(await driver.handleTrigger(.silence(secondsQuiet: 30)) == .silentByModel)
+        #expect(lastUserMessage(brain) ==
+                "New since last turn:\n[00:00] me: hmm\n\n[00:00] (no speech for 30s)")
+    }
+
     /// A fragment committed after `stay_silent` remains useful history, but it must not masquerade as
     /// fresh speech on a later proactive silence check. The current turn is the final bare note.
     @Test func silenceAfterFragmentCarriesNoFreshSpeechBlock() async {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -2,11 +2,10 @@ import Foundation
 import Testing
 @testable import JarvisCore
 
-/// How the per-turn user message is assembled (CoachDriver.runTurn): every request gets an explicit
-/// "Current turn:" boundary. New speech is wrapped in a "New since last turn:" block ONLY when there
-/// is any, followed by the trigger note ONLY when the trigger has one — a turn-end has none (the
-/// stamped delta already says the user just spoke), so its payload is the bare speech block; a
-/// silence wake-up with nothing said carries only the bare note after the boundary.
+/// How the per-turn user message is assembled (CoachDriver.runTurn): new speech is wrapped in a
+/// "New since last turn:" block ONLY when there is any, followed by the trigger note ONLY when the
+/// trigger has one — a turn-end has none (the stamped delta already says the user just spoke), so
+/// its message is the bare block; a silence wake-up with nothing said is the bare note.
 @Suite struct CoachDriverContextMessageTests {
     private func makeDriver(brain: BrainClient, clock: Clock) -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
@@ -31,8 +30,7 @@ import Testing
 
         await driver.handleTrigger(.turnEnd)
 
-        #expect(lastUserMessage(brain) ==
-                "Current turn:\nNew since last turn:\n[00:00] me: brute force two-sum")
+        #expect(lastUserMessage(brain) == "New since last turn:\n[00:00] me: brute force two-sum")
     }
 
     /// No new speech (a silence wake-up with nothing said): the message is the bare trigger note —
@@ -44,7 +42,7 @@ import Testing
         await driver.handleTrigger(.silence(secondsQuiet: 30))
 
         let msg = lastUserMessage(brain)
-        #expect(msg == "Current turn:\n[00:00] (no speech for 30s)")
+        #expect(msg == "[00:00] (no speech for 30s)")
         #expect(msg?.contains("New since last turn") == false)
         #expect(msg?.contains("nothing new") == false)
     }
@@ -58,8 +56,7 @@ import Testing
         await driver.handleTrigger(.silence(secondsQuiet: 45))
 
         #expect(lastUserMessage(brain) ==
-                "Current turn:\nNew since last turn:\n[00:00] me: hmm let me think\n\n"
-                + "[00:00] (no speech for 45s)")
+                "New since last turn:\n[00:00] me: hmm let me think\n\n[00:00] (no speech for 45s)")
     }
 
     /// A fragment committed after `stay_silent` remains useful history, but it must not masquerade as
@@ -77,8 +74,8 @@ import Testing
 
         let userMessages = brain.calls[1].filter { $0.role == .user }.compactMap(\.text)
         #expect(userMessages == [
-            "Current turn:\nNew since last turn:\n[00:00] me: one pass",
-            "Current turn:\n[00:00] (no speech for 30s)",
+            "New since last turn:\n[00:00] me: one pass",
+            "[00:00] (no speech for 30s)",
         ])
     }
 }

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -58,10 +58,11 @@ import Testing
     /// Short fragments and transcription noise should not create unsolicited overlay chatter, while
     /// terse corrections and requirements still carry enough interview signal to coach.
     @Test func coachPromptDefaultsFragmentsAndASRGarbleToSilence() {
-        #expect(coachSystemPrompt.contains(
+        let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(prompt.contains(
             "short, question-free fragment or likely ASR garble"
         ))
-        #expect(coachSystemPrompt.contains(
+        #expect(prompt.contains(
             "stay_silent unless it clearly conveys a correction, requirement, or new technical fact"
         ))
         #expect(coachSystemPrompt.contains(
@@ -69,6 +70,18 @@ import Testing
         ))
         #expect(coachSystemPrompt.contains("do not correct its wording"))
         #expect(coachSystemPrompt.contains("Wait for more speech"))
+    }
+
+    @Test func coachPromptLimitsFragmentGateToFreshSpeech() {
+        let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(prompt.contains(
+            "apply only when this turn's user text includes a \"New since last turn\" block"
+        ))
+        #expect(prompt.contains("Judge only the newest speech inside that block"))
+        #expect(prompt.contains(
+            "A silence-only turn with no \"New since last turn\" block also bypasses it"
+        ))
+        #expect(prompt.contains("the newest historical speech was fragmentary"))
     }
 
     @Test func coachPromptOrdersDirectRepliesThenFragmentsThenScreenGate() {

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -56,15 +56,16 @@ import Testing
     }
 
     /// Short fragments and transcription noise should not create unsolicited overlay chatter, while
-    /// terse corrections and requirements still carry enough interview signal to coach.
+    /// substantive speech and explicit stuck signals still carry enough interview signal to coach.
     @Test func coachPromptDefaultsFragmentsAndASRGarbleToSilence() {
         let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
         #expect(prompt.contains(
-            "short, question-free fragment or likely ASR garble"
+            "the entire fresh delta consists of short, question-free fragments or likely ASR garble"
         ))
         #expect(prompt.contains(
-            "stay_silent unless it clearly conveys a correction, requirement, or new technical fact"
+            "explicit help request or stuck signal, correction, requirement, or technical fact"
         ))
+        #expect(prompt.contains("bypass this gate and continue through the remaining policy"))
         #expect(coachSystemPrompt.contains(
             "A likely transcription mistake is not itself a coaching opportunity"
         ))
@@ -77,11 +78,20 @@ import Testing
         #expect(prompt.contains("inspect only the final user text block"))
         #expect(prompt.contains("ignore every earlier user block in history"))
         #expect(prompt.contains(
-            "Apply this gate only when that final block includes \"New since last turn\""
+            "apply this gate only when that final block includes \"New since last turn\""
         ))
-        #expect(prompt.contains("Judge only the newest speech inside that block"))
+        #expect(prompt.contains("Evaluate all newly delivered speech in that block"))
+        #expect(prompt.contains("not only its last line"))
         #expect(prompt.contains("A final user block with no \"New since last turn\""))
         #expect(prompt.contains("the newest historical speech was fragmentary"))
+    }
+
+    @Test func coachPromptLetsSilenceWakeUpsBypassUnsentFiller() {
+        let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(prompt.contains(
+            "If the final block includes a \"(no speech for ...)\" marker, bypass this gate"
+        ))
+        #expect(prompt.contains("even when unsent speech rides along under \"New since last turn\""))
     }
 
     @Test func coachPromptOrdersDirectRepliesThenFragmentsThenScreenGate() {

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -74,13 +74,13 @@ import Testing
 
     @Test func coachPromptLimitsFragmentGateToFreshSpeech() {
         let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        #expect(prompt.contains("inspect only the final \"Current turn:\" block"))
-        #expect(prompt.contains("ignore every earlier one in history"))
+        #expect(prompt.contains("inspect only the final user text block"))
+        #expect(prompt.contains("ignore every earlier user block in history"))
         #expect(prompt.contains(
             "Apply this gate only when that final block includes \"New since last turn\""
         ))
         #expect(prompt.contains("Judge only the newest speech inside that block"))
-        #expect(prompt.contains("A final \"Current turn:\" block with no \"New since last turn\""))
+        #expect(prompt.contains("A final user block with no \"New since last turn\""))
         #expect(prompt.contains("the newest historical speech was fragmentary"))
     }
 

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -59,14 +59,12 @@ import Testing
     /// meaningful signals that should continue through the coaching policy.
     @Test func coachPromptScopesFragmentSilence() {
         let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        #expect(prompt.contains("latest user message contains \"New since last turn\""))
-        #expect(prompt.contains("and no \"(no speech for ...)\" marker"))
-        #expect(prompt.contains("inspect all speech in that section"))
-        #expect(prompt.contains("If all of it consists of short, question-free fragments"))
-        #expect(prompt.contains("Help/stuck signals, corrections, requirements, and technical facts"))
-        #expect(prompt.contains("meaningful, not fragments"))
-        #expect(prompt.contains("Do not correct likely transcription mistakes"))
-        #expect(prompt.contains("hedge your interpretation when a reply is required"))
+        #expect(prompt.contains("when a non-silence request contains new speech"))
+        #expect(prompt.contains("call stay_silent only if all of it is incomplete or likely mistranscribed"))
+        #expect(prompt.contains("Help/stuck signals and other meaningful speech bypass this gate"))
+        #expect(prompt.contains(
+            "If a reply is required despite uncertain transcription, hedge rather than correct it"
+        ))
     }
 
     @Test func coachPromptOrdersDirectRepliesThenFragmentsThenScreenGate() {

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -71,14 +71,19 @@ import Testing
         #expect(coachSystemPrompt.contains("Wait for more speech"))
     }
 
-    @Test func coachPromptKeepsDirectRepliesAheadOfTheFragmentGate() {
-        let directReply = coachSystemPrompt.range(of: "2. Direct address from \"me\"")
-        let fragmentGate = coachSystemPrompt.range(of: "3. Fragment gate")
+    @Test func coachPromptOrdersDirectRepliesThenFragmentsThenScreenGate() {
+        let directReply = coachSystemPrompt.range(of: "1. Direct address from \"me\"")
+        let fragmentGate = coachSystemPrompt.range(of: "2. Fragment gate")
+        let screenGate = coachSystemPrompt.range(of: "3. Screen gate")
         #expect(directReply != nil)
         #expect(fragmentGate != nil)
-        if let directReply, let fragmentGate {
+        #expect(screenGate != nil)
+        if let directReply, let fragmentGate, let screenGate {
             #expect(directReply.lowerBound < fragmentGate.lowerBound)
+            #expect(fragmentGate.lowerBound < screenGate.lowerBound)
         }
+        #expect(coachSystemPrompt.contains("continue to the screen gate below"))
+        #expect(coachSystemPrompt.contains("A direct reply required by rule 1 bypasses this gate"))
         #expect(coachSystemPrompt.contains(
             "If a direct reply is required, hedge your interpretation instead"
         ))

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -55,43 +55,18 @@ import Testing
         #expect(!coachSystemPrompt.contains("one tool call each turn"))
     }
 
-    /// Short fragments and transcription noise should not create unsolicited overlay chatter, while
-    /// substantive speech and explicit stuck signals still carry enough interview signal to coach.
-    @Test func coachPromptDefaultsFragmentsAndASRGarbleToSilence() {
+    /// Fragment silence applies only to wholly fragmentary fresh speech, never silence probes or
+    /// meaningful signals that should continue through the coaching policy.
+    @Test func coachPromptScopesFragmentSilence() {
         let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        #expect(prompt.contains(
-            "the entire fresh delta consists of short, question-free fragments or likely ASR garble"
-        ))
-        #expect(prompt.contains(
-            "explicit help request or stuck signal, correction, requirement, or technical fact"
-        ))
-        #expect(prompt.contains("bypass this gate and continue through the remaining policy"))
-        #expect(coachSystemPrompt.contains(
-            "A likely transcription mistake is not itself a coaching opportunity"
-        ))
-        #expect(coachSystemPrompt.contains("do not correct its wording"))
-        #expect(coachSystemPrompt.contains("Wait for more speech"))
-    }
-
-    @Test func coachPromptLimitsFragmentGateToFreshSpeech() {
-        let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        #expect(prompt.contains("inspect only the final user text block"))
-        #expect(prompt.contains("ignore every earlier user block in history"))
-        #expect(prompt.contains(
-            "apply this gate only when that final block includes \"New since last turn\""
-        ))
-        #expect(prompt.contains("Evaluate all newly delivered speech in that block"))
-        #expect(prompt.contains("not only its last line"))
-        #expect(prompt.contains("A final user block with no \"New since last turn\""))
-        #expect(prompt.contains("the newest historical speech was fragmentary"))
-    }
-
-    @Test func coachPromptLetsSilenceWakeUpsBypassUnsentFiller() {
-        let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        #expect(prompt.contains(
-            "If the final block includes a \"(no speech for ...)\" marker, bypass this gate"
-        ))
-        #expect(prompt.contains("even when unsent speech rides along under \"New since last turn\""))
+        #expect(prompt.contains("latest user message contains \"New since last turn\""))
+        #expect(prompt.contains("and no \"(no speech for ...)\" marker"))
+        #expect(prompt.contains("inspect all speech in that section"))
+        #expect(prompt.contains("If all of it consists of short, question-free fragments"))
+        #expect(prompt.contains("Help/stuck signals, corrections, requirements, and technical facts"))
+        #expect(prompt.contains("meaningful, not fragments"))
+        #expect(prompt.contains("Do not correct likely transcription mistakes"))
+        #expect(prompt.contains("hedge your interpretation when a reply is required"))
     }
 
     @Test func coachPromptOrdersDirectRepliesThenFragmentsThenScreenGate() {
@@ -105,11 +80,8 @@ import Testing
             #expect(directReply.lowerBound < fragmentGate.lowerBound)
             #expect(fragmentGate.lowerBound < screenGate.lowerBound)
         }
+        #expect(coachSystemPrompt.contains("bypass the fragment gate"))
         #expect(coachSystemPrompt.contains("continue to the screen gate below"))
-        #expect(coachSystemPrompt.contains("A direct reply required by rule 1 bypasses this gate"))
-        #expect(coachSystemPrompt.contains(
-            "If a direct reply is required, hedge your interpretation instead"
-        ))
     }
 
     @Test func coachContextCoversTechnicalInterviewFormatsWithoutBrandNarrowing() {

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -55,6 +55,35 @@ import Testing
         #expect(!coachSystemPrompt.contains("one tool call each turn"))
     }
 
+    /// Short fragments and transcription noise should not create unsolicited overlay chatter, while
+    /// terse corrections and requirements still carry enough interview signal to coach.
+    @Test func coachPromptDefaultsFragmentsAndASRGarbleToSilence() {
+        #expect(coachSystemPrompt.contains(
+            "short, question-free fragment or likely ASR garble"
+        ))
+        #expect(coachSystemPrompt.contains(
+            "stay_silent unless it clearly conveys a correction, requirement, or new technical fact"
+        ))
+        #expect(coachSystemPrompt.contains(
+            "A likely transcription mistake is not itself a coaching opportunity"
+        ))
+        #expect(coachSystemPrompt.contains("do not correct its wording"))
+        #expect(coachSystemPrompt.contains("Wait for more speech"))
+    }
+
+    @Test func coachPromptKeepsDirectRepliesAheadOfTheFragmentGate() {
+        let directReply = coachSystemPrompt.range(of: "2. Direct address from \"me\"")
+        let fragmentGate = coachSystemPrompt.range(of: "3. Fragment gate")
+        #expect(directReply != nil)
+        #expect(fragmentGate != nil)
+        if let directReply, let fragmentGate {
+            #expect(directReply.lowerBound < fragmentGate.lowerBound)
+        }
+        #expect(coachSystemPrompt.contains(
+            "If a direct reply is required, hedge your interpretation instead"
+        ))
+    }
+
     @Test func coachContextCoversTechnicalInterviewFormatsWithoutBrandNarrowing() {
         let modelContext = captureScreenTool.description + coachSystemPrompt
         #expect(modelContext.contains("behavioral"))

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -74,13 +74,13 @@ import Testing
 
     @Test func coachPromptLimitsFragmentGateToFreshSpeech() {
         let prompt = coachSystemPrompt.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(prompt.contains("inspect only the final \"Current turn:\" block"))
+        #expect(prompt.contains("ignore every earlier one in history"))
         #expect(prompt.contains(
-            "apply only when this turn's user text includes a \"New since last turn\" block"
+            "Apply this gate only when that final block includes \"New since last turn\""
         ))
         #expect(prompt.contains("Judge only the newest speech inside that block"))
-        #expect(prompt.contains(
-            "A silence-only turn with no \"New since last turn\" block also bypasses it"
-        ))
+        #expect(prompt.contains("A final \"Current turn:\" block with no \"New since last turn\""))
         #expect(prompt.contains("the newest historical speech was fragmentary"))
     }
 


### PR DESCRIPTION
## Summary

- add a concise fragment gate that uses `stay_silent` only when all new speech in a non-silence request is incomplete or likely mistranscribed
- let direct address and meaningful speech, including help/stuck signals, continue through the existing coaching policy
- hedge required replies when transcription is uncertain instead of correcting the transcript
- preserve the direct-address → fragment → screen-gate order and cover it with compact prompt and request-shape regressions

## Why

Isolated fragments and likely transcription artifacts were producing unsolicited tips. Conversation ordering already distinguishes history from new speech, so the prompt relies on that existing request shape without explaining history mechanics or naming transport markers.

## Validation

- `./scripts/run-tests.sh --filter ToolDefsTests` — 14 tests passed
- `./scripts/run-tests.sh --filter CoachDriverContextMessageTests` — 4 tests passed
- `swift build && SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — build passed; 448 tests across 54 suites passed, 1 opt-in capture test skipped