### PR TITLE
ci: enable Claude conflict resolution

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && github.event.comment.body != '@claude /resolve-conflicts') ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
@@ -30,3 +30,19 @@ jobs:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
     with:
       runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes
+
+  resolve-conflicts:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '@claude /resolve-conflicts'
+    uses: JINGBANZ/workflows/.github/workflows/claude-resolve-conflicts.yml@main
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: write
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+    with:
+      runs-on: vps # VPS self-hosted runner (JINGBANZ/vps-setup), off GitHub's metered minutes
+      validation-command: "swift build && ./scripts/run-tests.sh"


### PR DESCRIPTION
## Summary

- route the exact top-level PR comment `@claude /resolve-conflicts` away from normal read-only `@claude` handling
- call the guarded resolver from `JINGBANZ/workflows`
- scope `contents: write` and `issues: write` to the resolver job
- require `swift build && ./scripts/run-tests.sh` before the workflow can push a merge commit
- keep all other `@claude` comments on the existing read-only path

## Why

The standard Anthropic action explicitly cannot merge or rebase branches, which is why repeated comments asking Claude to resolve PR conflicts did not work. This caller opts Jarvis into the separate guarded workflow that performs the merge around Claude's conflict-file edits.

## Dependency

Merge [JINGBANZ/workflows#10](https://github.com/JINGBANZ/workflows/pull/10) first. This caller references the new reusable workflow from `JINGBANZ/workflows@main`.

## Validation

- `actionlint` 1.7.12 on `.github/workflows/claude.yml`
- `swift build`
- focused known-flake check: `./scripts/run-tests.sh --filter OverlayInvisibilityTests` — 18/18 passed
- final serial gate: `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — 445/445 passed

The initial parallel gate hit the repository's known AppKit timing flake in `OverlayInvisibilityTests`; the isolated suite and final serial full gate both passed.