### PR TITLE
fix(settings): open window without blocking

### DIFF
--- a/Sources/JarvisApp/Settings/BrainSection.swift
+++ b/Sources/JarvisApp/Settings/BrainSection.swift
@@ -25,6 +25,13 @@ final class BrainSection: NSObject, SettingsSection {
     private var modelPopup: NSPopUpButton?
     /// The models backing the current popup rows, so selection maps back without re-deriving.
     private var listedModels: [BrainModel] = []
+    /// The latest completed probe remains usable while the next refresh runs in the background.
+    private var detectedCLIs: [BrainProvider: DetectedAgentCLI]?
+    /// Deliberately survives a Settings close so a local-provider edit made during the probe still
+    /// reaches the running coaching session when detection finishes.
+    private var detectionTask: Task<Void, Never>?
+    /// Several edits during one probe collapse into one application of the latest persisted values.
+    private var applyPreferencesAfterDetection = false
 
     init(preferences: BrainPreferences, detector: AgentCLIDetector,
          onPreferencesChanged: @escaping (DetectedAgentCLI?) -> Void,
@@ -102,27 +109,43 @@ final class BrainSection: NSObject, SettingsSection {
 
         apiKey.addControls(to: view, top: 112)
 
+        renderDetection()
         return view
     }
 
-    /// Populate on initial activation and re-probe on every later show so an install or sign-in
-    /// completed while the app was open appears. `makeView()` deliberately does not probe: the
-    /// Settings host activates the initial tab immediately after building all section views.
+    /// Re-probe whenever the tab becomes visible so an install or sign-in completed while the app
+    /// was open appears. The subprocesses stay off the main actor; cached or base labels render
+    /// immediately and the status suffixes update when detection finishes.
     func didBecomeActive() {
         refreshDetection()
     }
 
-    /// Update radio titles/enablement from detection and re-aim the model/effort controls at the
-    /// selected provider.
-    @discardableResult
-    private func refreshDetection() -> [BrainProvider: DetectedAgentCLI] {
+    private func refreshDetection() {
+        guard detectionTask == nil else { return }
+        let detector = detector
+        detectionTask = Task { [weak self] in
+            let values = await detector.detectAllAsync()
+            guard !Task.isCancelled, let self else { return }
+            detectionTask = nil
+            detectedCLIs = Dictionary(uniqueKeysWithValues: values.map { ($0.provider, $0) })
+            renderDetection()
+            if applyPreferencesAfterDetection {
+                applyPreferencesAfterDetection = false
+                onPreferencesChanged(detectedCLIs?[preferences.provider])
+            }
+        }
+    }
+
+    /// Update radio titles/enablement from the most recent detection and re-aim the model controls at
+    /// the selected provider. Before the first probe completes, local providers stay selectable and
+    /// use their base labels rather than being misreported as missing.
+    private func renderDetection() {
         let selected = preferences.provider
-        let detected = Dictionary(uniqueKeysWithValues: detector.detectAll().map { ($0.provider, $0) })
         for (provider, radio) in radios {
             var title = provider.displayName
             var enabled = true
-            if provider.usesLocalCLI {
-                if let cli = detected[provider] {
+            if provider.usesLocalCLI, let detectedCLIs {
+                if let cli = detectedCLIs[provider] {
                     switch cli.authenticationStatus {
                     case .signedIn: title += " — detected, signed in"
                     case .signedOut: title += " — detected, signed out"
@@ -140,7 +163,7 @@ final class BrainSection: NSObject, SettingsSection {
             radio.state = provider == selected ? .on : .off
         }
         var note = Self.note(for: selected)
-        if selected.usesLocalCLI, let cli = detected[selected] {
+        if selected.usesLocalCLI, let cli = detectedCLIs?[selected] {
             switch cli.authenticationStatus {
             case .signedIn:
                 break
@@ -152,7 +175,6 @@ final class BrainSection: NSObject, SettingsSection {
         }
         providerNote?.stringValue = note
         reloadModels(for: selected)
-        return detected
     }
 
     private static func note(for provider: BrainProvider) -> String {
@@ -176,26 +198,36 @@ final class BrainSection: NSObject, SettingsSection {
     @objc private func providerChanged(_ sender: NSButton) {
         guard let provider = radios.first(where: { $0.value === sender })?.key else { return }
         preferences.provider = provider
-        let detected = refreshDetection()
-        onPreferencesChanged(detected[provider])
+        renderDetection()
+        preferencesDidChange()
     }
 
     @objc private func modelChanged(_ sender: NSPopUpButton) {
         let row = sender.indexOfSelectedItem
         guard listedModels.indices.contains(row) else { return }
         preferences.setModel(listedModels[row], for: preferences.provider)
-        onPreferencesChanged(detectSelectedCLI())
+        preferencesDidChange()
     }
 
     @objc private func effortChanged(_ sender: NSPopUpButton) {
         let row = sender.indexOfSelectedItem
         guard ReasoningEffort.allCases.indices.contains(row) else { return }
         preferences.effort = ReasoningEffort.allCases[row]
-        onPreferencesChanged(detectSelectedCLI())
+        preferencesDidChange()
     }
 
-    private func detectSelectedCLI() -> DetectedAgentCLI? {
+    private func preferencesDidChange() {
         let provider = preferences.provider
-        return provider.usesLocalCLI ? detector.detect(provider) : nil
+        guard provider.usesLocalCLI else {
+            applyPreferencesAfterDetection = false
+            onPreferencesChanged(nil)
+            return
+        }
+        if detectionTask == nil, let detectedCLIs {
+            onPreferencesChanged(detectedCLIs[provider])
+        } else {
+            applyPreferencesAfterDetection = true
+            refreshDetection()
+        }
     }
 }

--- a/Sources/JarvisApp/Settings/BrainSection.swift
+++ b/Sources/JarvisApp/Settings/BrainSection.swift
@@ -223,7 +223,13 @@ final class BrainSection: NSObject, SettingsSection {
             onPreferencesChanged(nil)
             return
         }
-        if detectionTask == nil, let detectedCLIs {
+        // Never apply a cached preflight while a fresher probe is running. The completion collapses
+        // any edits made during that probe into one application of the latest persisted preferences.
+        if detectionTask != nil {
+            applyPreferencesAfterDetection = true
+            return
+        }
+        if let detectedCLIs {
             onPreferencesChanged(detectedCLIs[provider])
         } else {
             applyPreferencesAfterDetection = true

--- a/Sources/JarvisApp/Settings/SettingsWindow.swift
+++ b/Sources/JarvisApp/Settings/SettingsWindow.swift
@@ -10,13 +10,14 @@ private final class EscapableWindow: NSWindow {
 /// One window hosting all settings sections as tabs. Non-modal: it promotes the accessory app to
 /// `.regular` while open (so secure/text fields can become first responder and accept paste) and
 /// drops back to `.accessory` on close — the lesson the old API-key dialog and activity viewer
-/// both learned. The window is rebuilt on each open so sections start fresh (mirrors the viewer's
-/// rebuild-on-show pattern).
+/// both learned. The lightweight window/tab shell is retained between opens, while section views are
+/// rebuilt lazily so controls start fresh without constructing hidden tabs before presentation.
 @MainActor
 final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
     private let sections: [SettingsSection]
     private var window: NSWindow?
     private var tabView: NSTabView?
+    private var loadedSectionIndexes: Set<Int> = []
     /// The section whose tab is currently selected, so we can pair `didBecomeActive`/`didResignActive`.
     private var activeSection: SettingsSection?
 
@@ -31,13 +32,9 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
     }
 
     func show() {
-        if let window {
-            NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit Settings action
-            window.makeKeyAndOrderFront(nil) // ghost-mode-allowed: explicit Settings action
-            return
-        }
-        build()
         NSApp.setActivationPolicy(.regular) // ghost-mode-allowed: explicit Settings action
+        if window == nil { build() }
+        activate(tabView?.selectedTabViewItem)
         NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit Settings action
         window?.makeKeyAndOrderFront(nil) // ghost-mode-allowed: explicit Settings action
     }
@@ -57,15 +54,12 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
         for section in sections {
             let item = NSTabViewItem(identifier: section.title)
             item.label = section.title
-            item.view = section.fillsTab ? section.makeView() : Self.topPinned(section.makeView())
+            item.view = NSView()
             tabView.addTabViewItem(item)
         }
         win.contentView!.addSubview(tabView)
         self.window = win
         self.tabView = tabView
-        // Activate the initially-selected tab (delegate callbacks during addTabViewItem above are
-        // no-ops because window/tabView weren't wired yet).
-        activate(tabView.selectedTabViewItem)
     }
 
     /// Wrap a fixed-layout section view so it hugs the top of the tab (and centers horizontally)
@@ -91,6 +85,10 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
         let newly = sections[idx]
         guard newly !== activeSection else { return }
         activeSection?.didResignActive()
+        if loadedSectionIndexes.insert(idx).inserted {
+            let view = newly.makeView()
+            item.view = newly.fillsTab ? view : Self.topPinned(view)
+        }
         activeSection = newly
         newly.didBecomeActive()
     }
@@ -99,8 +97,13 @@ final class SettingsWindow: NSObject, NSWindowDelegate, NSTabViewDelegate {
         activeSection?.didResignActive()        // e.g. turn the overlay preview off if Overlay was open
         activeSection = nil
         for section in sections { section.windowWillClose() }
+        // Preserve the cheap NSWindow/NSTabView shell, but release every section view so controls and
+        // Activity's WebView still get their established fresh-on-open lifecycle.
+        tabView?.delegate = nil
+        for item in tabView?.tabViewItems ?? [] { item.view = NSView() }
+        loadedSectionIndexes.removeAll()
+        tabView?.selectTabViewItem(at: 0)
+        tabView?.delegate = self
         NSApp.setActivationPolicy(.accessory) // ghost-mode-allowed: close explicit Settings action
-        window = nil
-        tabView = nil
     }
 }

--- a/Sources/JarvisCore/Brain/AgentCLIDetector.swift
+++ b/Sources/JarvisCore/Brain/AgentCLIDetector.swift
@@ -27,6 +27,16 @@ public struct AgentCLIDetector: Sendable {
         BrainProvider.allCases.compactMap(detect)
     }
 
+    /// Run the blocking subprocess probes away from the caller's executor. Settings uses this path
+    /// so a slow CLI cannot hold the main actor and delay or freeze its window.
+    public func detectAllAsync() async -> [DetectedAgentCLI] {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(returning: detectAll())
+            }
+        }
+    }
+
     /// The given provider's CLI, or nil when its binary isn't installed (or the provider is the
     /// direct API, which has nothing to detect).
     public func detect(_ provider: BrainProvider) -> DetectedAgentCLI? {

--- a/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
+++ b/Tests/JarvisCoreTests/Brain/AgentCLIDetectorTests.swift
@@ -203,4 +203,17 @@ import Glibc
         #expect(d.detect(.openAI) == nil)
         #expect(d.detectAll().map(\.provider) == [.claudeCode, .codexCLI])
     }
+
+    @Test func asyncDetectionReturnsProbeResults() async throws {
+        let home = try makeHome()
+        let bin = home.appendingPathComponent("fakebin")
+        try installBinary("claude", in: bin, script: """
+            #!/bin/sh
+            printf '%s\\n' '{"loggedIn":true,"authMethod":"claude.ai"}'
+            """)
+        try installBinary("codex", in: bin)
+        let d = AgentCLIDetector(home: home, pathVariable: bin.path, authStatusTimeout: 10)
+        let result = await d.detectAllAsync()
+        #expect(result.first(where: { $0.provider == .claudeCode })?.authenticationStatus == .signedIn)
+    }
 }

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -551,3 +551,19 @@
 - **Supersedes in part:** 2026-06-20 — Brain model + reasoning effort are user-selectable.
 - **Detail:** [settings-window.md → Brain](./settings-window.md#brain),
   `Sources/JarvisCore/Coach/CoachDriver.swift`, `Sources/JarvisApp/App/AppDelegate.swift`.
+
+### 2026-07-23 — Settings retains its shell and lazily builds sections
+
+- **Chose:** Retain the lightweight `NSWindow`/`NSTabView` shell between opens, build a section view
+  only when its tab is selected, and release all section views when the window closes.
+- **Why:** The pre-presentation path rebuilt every section, including Activity's `WKWebView`, then
+  ran bounded CLI subprocess probes on the main actor, making a warm open take about 0.95 seconds.
+  Moving probes off the main actor and deferring hidden sections reduced warm opens to about
+  0.12–0.13 seconds.
+  Releasing section views preserves Activity's established fresh-WebView lifecycle while retaining
+  only the cheap window shell.
+- **Rejected:** Rebuilding the whole window on every open — it repeats unrelated hidden-tab work on
+  the latency-sensitive presentation path.
+- **Detail:** [settings-window.md](./settings-window.md),
+  `Sources/JarvisApp/Settings/SettingsWindow.swift`,
+  `Sources/JarvisCore/Brain/AgentCLIDetector.swift`.

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -6,9 +6,9 @@
 
 ## Entry Point
 
-One menu item — **"Settings…"** — calls `SettingsWindow.show()`. The window is rebuilt on each
-open so every section starts fresh; re-opening while already visible brings it to the front without
-rebuilding.
+One menu item — **"Settings…"** — calls `SettingsWindow.show()`. The lightweight window and tab shell
+are retained between opens. Section views are built only when selected and released on close, so
+controls still start fresh without constructing hidden tabs before the window can appear.
 
 ## Architecture
 
@@ -54,8 +54,8 @@ so an unwrapped fixed-frame view would ride the bottom edge in a taller window).
 | `DisplaySection` | "Screen" | yes | One dropdown — the capture scope: **Active window** (default) or one **Entire display** entry per connected display; persists via `ScreenCapturePreferences`. Applies to the next screenshot. |
 | `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content view (`makeContentView()` / `teardown()`); `fillsTab == true` so the log stretches with the window. Its header shows the selected session's exact directory ID in a selectable field with **Copy ID**, and carries **Evaluate** — one click sends the selected session's recorded LLM wire traffic (`brain-traffic.jsonl`) to the brain model at high effort for a context-engineering audit (`SessionEvaluator`), saved as `eval-report.md` in the session dir and opened in the browser as a rendered `eval-report.html` page (`EvalReportPage`) whose **Copy as Markdown** button hands the raw report to an agent chat; once a session has a saved report the button flips to **Open report**. Only *finished* conversations qualify: the button is disabled while the selected session is the live, still-running one (a mid-session audit would judge half a story) and re-enables once Stop has drained any in-flight turn — the cancelled request's final traffic line must land before the audit reads the file. |
 
-`AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. All four sections
-are always present.
+`AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. All four tabs are
+always present, but each tab's content is created lazily on first selection during that open.
 
 ## Activation-Policy Switch
 
@@ -63,7 +63,9 @@ are always present.
 `show()` promotes the activation policy to `.regular` so the window can become key and accept
 paste/keyboard input. `windowWillClose(_:)` drops it back to `.accessory`. This is the same pattern
 the old API-key dialog and activity viewer each learned independently — now consolidated in one
-place.
+place. Initial Brain controls render from preferences and the latest cached CLI status immediately;
+CLI status and capability subprocesses run away from the main actor and update those controls when
+they finish, so their bounded timeouts cannot delay presentation.
 
 ## Overlay Appearance
 
@@ -112,10 +114,12 @@ subprocesses and billed to the user's existing Claude / ChatGPT *subscription* i
 CLIs are auto-detected by `AgentCLIDetector`: binary discovery is a pure file probe over $PATH + the
 known install dirs, while Claude sign-in uses its non-billing `auth status --json` command under a
 short timeout because account metadata can outlive an expired OAuth session. Codex keeps using its
-auth-file marker. The radios show **signed in**, **signed out**, or **sign-in unknown**; a confirmed
-logout refuses Start, while an unavailable probe warns but does not falsely claim logout. An actual
-CLI request can still fail after preflight. A provider that was selected at Start or has already
-completed a turn then stops the unusable coaching session without activating the app; a newly
+auth-file marker. Settings runs these probes asynchronously and keeps local-provider controls
+selectable while the first result is pending. The radios then show **signed in**, **signed out**, or
+**sign-in unknown**; a confirmed logout refuses Start, while an unavailable probe warns but does not
+falsely claim logout. An actual CLI request can still fail after preflight. A provider that was
+selected at Start or has already completed a turn then stops the unusable coaching session without
+activating the app; a newly
 switched provider uses the transactional fallback described below. Both paths keep detailed error
 and sign-in information in `jarvis-debug.log` and put only fixed provider-level copy in Activity.
 


### PR DESCRIPTION
## Summary

- retain the lightweight Settings window/tab shell between opens and lazily build only the selected section
- move Claude/Codex CLI status probes off the main actor while keeping provider controls immediately usable
- release section views on close so Activity and other sections preserve their fresh lifecycle
- document the responsive Settings lifecycle and add coverage for asynchronous CLI detection

## Root cause

Opening Settings synchronously constructed all four tab contents, including Activity's `WKWebView`, and waited for local CLI detection subprocesses before the window was presented. Those subprocess probes accounted for most of the repeated-open delay.

## User impact

The Settings window appears before optional provider status work completes. In a live accessibility benchmark, warm repeated opens improved from about 0.95 seconds to 0.12–0.13 seconds (roughly 86% faster); the first post-build open measured about 0.60 seconds. All four tabs were exercised, including lazy Activity initialization and asynchronous Claude/Codex status updates.

## Validation

- `swift build`
- `./scripts/run-tests.sh --filter AgentCLIDetectorTests`
- `./scripts/run-tests.sh --filter OverlayInvisibilityTests`
- `swift build && SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — 458 tests across 54 suites passed; one opt-in live capture test skipped
- `./scripts/build-app.sh --run` and live Settings open/close/tab cycling

The initial parallel full-suite run hit the repository's known AppKit overlay timing contention; the isolated overlay suite and documented serial full gate both passed.