### PR TITLE
fix(brain): retry CLI subprocess timeouts in RetryingBrainClient

### DIFF
--- a/Sources/JarvisCore/Brain/RetryingBrainClient.swift
+++ b/Sources/JarvisCore/Brain/RetryingBrainClient.swift
@@ -39,6 +39,11 @@ public struct RetryingBrainClient: BrainClient, Sendable {
         if ns.domain == "OpenAIBrainClient" {
             return [408, 409, 500, 502, 503, 504].contains(ns.code)
         }
+        // The CLI runner labels its watchdog timeout with `NSURLErrorTimedOut` to signal the same
+        // transient intent as an OpenAI URLSession timeout, but keeps its own domain for diagnostics.
+        if ns.domain == "AgentCLIProcessRunner" {
+            return ns.code == NSURLErrorTimedOut
+        }
         return false
     }
 }

--- a/Tests/JarvisCoreTests/Brain/RetryingBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/RetryingBrainClientTests.swift
@@ -41,6 +41,30 @@ import Testing
         #expect(base.callCount == 2)
     }
 
+    @Test func retriesCLISubprocessTimeout() async throws {
+        let base = RetryScriptBrain(script: [
+            .failure(NSError(domain: "AgentCLIProcessRunner", code: NSURLErrorTimedOut)),
+            .success(.init(toolCalls: [.staySilent(callId: "ok")])),
+        ])
+        let client = RetryingBrainClient(base: base)
+
+        _ = try await client.respond(messages: [.user("hi")], tools: coachTools)
+
+        #expect(base.callCount == 2)
+    }
+
+    @Test func doesNotRetryNonTimeoutCLIError() async {
+        let base = RetryScriptBrain(script: [
+            .failure(NSError(domain: "AgentCLIProcessRunner", code: 1)),
+        ])
+        let client = RetryingBrainClient(base: base)
+
+        await #expect(throws: (any Error).self) {
+            _ = try await client.respond(messages: [.user("hi")], tools: coachTools)
+        }
+        #expect(base.callCount == 1)
+    }
+
     @Test func doesNotRetryPermanentFailure() async {
         let error = NSError(domain: "OpenAIBrainClient", code: 401)
         let base = RetryScriptBrain(script: [.failure(error)])


### PR DESCRIPTION
## Summary

`AgentCLIProcessRunner` throws its watchdog timeout as `NSError(domain: "AgentCLIProcessRunner", code: NSURLErrorTimedOut)` — deliberately reusing the URL-loading timeout code to signal transient intent. But `RetryingBrainClient.isTransient` only honored `NSURLErrorTimedOut` under `NSURLErrorDomain`, so the runner's own domain fell through to the non-transient default. The result: an OpenAI URLSession timeout was retried once, while an identical CLI (Claude Code / Codex) subprocess timeout failed immediately with no retry — the one automatic retry the wrapper exists to provide silently never fired.

## Change

- `RetryingBrainClient.isTransient` — add an `AgentCLIProcessRunner` domain branch that treats `NSURLErrorTimedOut` as transient, keeping the runner's distinct domain for diagnostics (option 1 from the issue). Any other code from that domain stays non-transient.
- `RetryingBrainClientTests` — add `retriesCLISubprocessTimeout` (CLI timeout → success, asserts `callCount == 2`, mirroring `retriesOneTransientFailure`) and `doesNotRetryNonTimeoutCLIError` (a non-timeout code from that domain is not retried).

## Testing

The full `swift build && ./scripts/run-tests.sh` gate can't run on this Linux CI runner — the package links `AppKit`/`WebKit` via the macOS-only overlay/viewer/app targets, and `swift test` compiles the whole tree. The affected code lives entirely in the Foundation-only `JarvisCore` library, which builds cleanly here (`swift build --target JarvisCore` ✅). The gate should be run on macOS to confirm the new tests pass.

Fixes #104