### PR TITLE
fix(activity): log every session end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,10 +182,10 @@ The squash-merge subject carries the PR number (`type: summary (#N)`).
 - **Keep human activity separate from agent diagnostics.** `ActivityLog` is the human-facing coaching
   record: finalized interviewer/user speech, manual hint requests, every brain action (`capture_screen`
   success or failure, `speak`, and `stay_silent`), fixed typed brain-change notices, and fixed typed
-  notices for every runtime failure that stops or degrades coaching belong there. Lifecycle,
-  transport, retry, raw error, timing, and diagnosis details go through `jlog` to
-  `jarvis-debug.log`. Never mirror `jlog` into `ActivityLog`; record the corresponding typed activity
-  event explicitly.
+  notices for every live-session end and every runtime failure that degrades coaching belong there.
+  Lifecycle sequencing, transport, retry, raw error, timing, and diagnosis details go through `jlog`
+  to `jarvis-debug.log`. Never mirror `jlog` into `ActivityLog`; record the corresponding typed
+  activity event explicitly.
 - **The only screen-/audio-derived data persisted to disk is the per-session log directory** (the
   activity log — spoken tips, deliberate-silence and fixed failure notices, transcribed "heard:"
   lines, and the screenshots the model looked at — plus the wire-level brain traffic record and its

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -31,6 +31,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var systemConnectionState: RealtimeConnectionState = .stopped
     private var reportedCoachingReady = false
     private var reportedTranscriptionFailure = false
+    /// Resource allocation begins before audio capture can prove startup succeeded. Keep that
+    /// provisional state separate so tearing it down cannot look like the end of a live session.
+    private var sessionIsLive = false
     /// One-clock capture: a single private aggregate device (built-in mic + system-output tap on one
     /// drift-compensated clock) feeds both transcription sockets, running AEC3 inside its IOProc so the
     /// other side's speaker bleed is cancelled from the mic. Replaces the separate AVAudioEngine mic +
@@ -695,6 +698,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 .captureFailed(reason: reason), context: reportContext)
             return false
         }
+        sessionIsLive = true
         jlog("Jarvis: coaching starting — verifying realtime transcription connections.")
         jlog("Jarvis network path at start: \(networkDiagnostics.currentSummary)")
         activityViewer.coachingStateDidChange()   // the live session is no longer evaluable
@@ -710,7 +714,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         pendingStartRevision &+= 1
         pendingStartTask?.cancel()
         pendingStartTask = nil
-        let wasRunning = transcriber != nil || themTranscriber != nil
+        let hadAllocatedPipeline = transcriber != nil || themTranscriber != nil
+        let endedLiveSession = sessionIsLive
+        sessionIsLive = false
         requestManualHint = nil              // hotkey beeps again once there's no live session
         let cancelled = turns?.cancelAll() ?? []; turns = nil   // cancel any in-flight coaching turn
         coachDriver = nil
@@ -729,8 +735,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         systemConnectionState = .stopped
         reportedCoachingReady = false
         menuBar?.setState(.stopped)
-        if wasRunning {
+        if hadAllocatedPipeline {
             jlog("Jarvis: stopped.")
+        }
+        if endedLiveSession {
             ActivityLog.shared.record(.sessionEnded(reason: reason))
         }
         // Activity writes are asynchronous during live capture. Persist every fixed failure outcome

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -153,11 +153,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // The menu drives the pipeline lifecycle. Jarvis does NOT auto-start; the user presses Start.
         menuBar.onStart = { [weak self] in self?.start() ?? false }
-        menuBar.onStop = { [weak self] in self?.stop() }
+        menuBar.onStop = { [weak self] in self?.stop(reason: .stoppedByUser) }
 
         // A fatal error tears the session down and corrects the menu — one place owns that.
-        errorReporter.onFatal = { [weak self] in
-            self?.stop()
+        errorReporter.onFatal = { [weak self] reason in
+            self?.stop(reason: reason)
         }
 
         // Global hint hotkey: while a session is running, screenshot + ask the brain for a hint in one
@@ -180,6 +180,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationWillTerminate(_ notification: Notification) {
         activityViewer?.cancelEvaluation()
+        stop(reason: .applicationQuit)
     }
 
     /// The two clients that move together with one provider/model route target.
@@ -334,11 +335,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     jlog("Jarvis: ignoring route exhaustion from a stopped or superseded session.")
                     return
                 }
-                ActivityLog.shared.record(
-                    .brainRouteExhausted(lastProvider: target.provider))
                 errorReporter.reportImmediately(
                     .brainRouteExhausted(
-                        lastProvider: target.provider.displayName,
+                        lastProvider: target.provider,
                         reason: failure.detail),
                     context: .runtime)
             })
@@ -521,7 +520,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let primaryCLI = preflight.cli {
             detectedCLIs[brainProvider] = primaryCLI
         }
-        stop() // tear down any existing pipeline so we start cleanly
+        stop(reason: .replacedByNewSession) // tear down any existing pipeline so we start cleanly
         reportedTranscriptionFailure = false
         // A fresh transcript for the fresh pipeline. Reusing the old one would re-send a dead run's
         // lines as "new since last turn" — their [mm:ss] stamps minted against the previous
@@ -654,7 +653,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             guard let capture else { return }
             Task { @MainActor [weak self] in
                 guard let self, self.aggregateCapture === capture else { return }
-                ActivityLog.shared.record(.audioCaptureStopped)
                 self.errorReporter.reportImmediately(
                     .captureStopped(reason: reason), context: .runtime)
             }
@@ -693,10 +691,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         transcriber.connect()
         themTranscriber.connect()
         if let reason = capture.start() {
-            stop()                      // tear down the sockets we just opened
-            if reportContext == .runtime {
-                ActivityLog.shared.record(.audioCaptureStopped)
-            }
             errorReporter.reportImmediately(
                 .captureFailed(reason: reason), context: reportContext)
             return false
@@ -712,7 +706,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// transcribers must go: otherwise a turn-end trigger from a still-live socket could drive a
     /// coaching turn on a torn-down driver — the exact "speak after Stop" failure the turns box exists
     /// to prevent — and a subsequent Start would leak the orphaned IOProc/sockets.
-    private func stop() {
+    private func stop(reason: SessionEndReason) {
         pendingStartRevision &+= 1
         pendingStartTask?.cancel()
         pendingStartTask = nil
@@ -735,7 +729,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         systemConnectionState = .stopped
         reportedCoachingReady = false
         menuBar?.setState(.stopped)
-        if wasRunning { jlog("Jarvis: stopped.") }
+        if wasRunning {
+            jlog("Jarvis: stopped.")
+            ActivityLog.shared.record(.sessionEnded(reason: reason))
+        }
         // Activity writes are asynchronous during live capture. Persist every fixed failure outcome
         // before this session can become evaluable, or an immediate Evaluate could miss why it ended.
         ActivityLog.shared.flush()
@@ -760,7 +757,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func reportTranscriptionFailure(_ reason: TranscriptionFailureReason) {
         guard !reportedTranscriptionFailure, transcriber != nil || themTranscriber != nil else { return }
         reportedTranscriptionFailure = true
-        ActivityLog.shared.record(.transcriptionStopped(reason: reason))
         // This method already runs on the main actor after checking the emitting transcriber's
         // identity. Deliver synchronously so Stop → Start cannot slip between that check and the
         // terminal lifecycle consequence and let a stale failure stop the replacement session.

--- a/Sources/JarvisApp/App/ErrorReporter.swift
+++ b/Sources/JarvisApp/App/ErrorReporter.swift
@@ -14,7 +14,7 @@ import JarvisCore
 final class ErrorReporter {
     /// Invoked for an error whose severity stops the session (on the main actor), correcting the
     /// menu without requiring a modal alert. Wired by `AppDelegate` once the menu bar exists.
-    var onFatal: (() -> Void)?
+    var onFatal: ((SessionEndReason) -> Void)?
 
     nonisolated func report(_ error: UserFacingError,
                             context: UserFacingError.PresentationContext) {
@@ -32,7 +32,9 @@ final class ErrorReporter {
     private func present(_ error: UserFacingError,
                          context: UserFacingError.PresentationContext) {
         jlog("Jarvis: \(error.severity) — \(error.title): \(error.message)")  // diagnostics still go to JarvisLog
-        if error.severity.stopsSession { onFatal?() }
+        if error.severity.stopsSession {
+            onFatal?(error.sessionEndReason ?? .unexpectedError)
+        }
         guard error.severity.showsAlert(in: context) else { return }
         NSApp.activate(ignoringOtherApps: true) // ghost-mode-allowed: explicit startup failure
         let alert = NSAlert() // ghost-mode-allowed: explicit startup failure

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -901,6 +901,10 @@ public final class CoachDriver: @unchecked Sendable {
                 return .completed(.spoke)
 
             case .staySilent:
+                if Task.isCancelled {
+                    jlog("… attempt cancelled (stopped) before recording silence")
+                    return .cancelled
+                }
                 jlog("… nothing useful to add, staying silent")
                 ActivityLog.shared.record(.stayedSilent)
                 commitIfWorthKeeping(turnMessages, deltaText: delta.text)

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -23,22 +23,12 @@ public final class ActivityLog: @unchecked Sendable {
         case tip
         case stayedSilent
         case sessionEnded
-        /// Retained so logs written before session teardown was unified remain decodable.
-        case coachingStopped
         case coachingTurnFailed
-        /// Retained so logs written before session teardown was unified remain decodable.
-        case transcriptionStopped
-        /// Retained so logs written before session teardown was unified remain decodable.
-        case audioCaptureStopped
         case systemAudioStopped
         case settingsChangeNotApplied
         case brainChangeApplied
-        /// Retained so logs written by the superseded transactional-switch build remain decodable.
-        case brainFallback
         case brainRouteAdvanced
         case brainRouteTargetSkipped
-        /// Retained so logs written before session teardown was unified remain decodable.
-        case brainRouteExhausted
     }
 
     /// A human-visible event in the coaching exchange. Keeping this closed set typed prevents
@@ -77,21 +67,66 @@ public final class ActivityLog: @unchecked Sendable {
         /// A route target was proven unavailable before a provider request could be constructed.
         case brainRouteTargetSkipped(provider: BrainProvider)
 
-        var kind: EventKind {
+        /// Keep persisted identity, human copy, and the optional screenshot payload in one exhaustive
+        /// mapping so adding or editing an event cannot make its `k` disagree with what Activity shows.
+        var rendered: (kind: EventKind, message: String, imageBase64: String?) {
             switch self {
-            case .heard: .heard
-            case .manualHint: .manualHint
-            case .screenViewed: .screenViewed
-            case .screenViewFailed: .screenViewFailed
-            case .tip: .tip
-            case .stayedSilent: .stayedSilent
-            case .sessionEnded: .sessionEnded
-            case .coachingTurnFailed: .coachingTurnFailed
-            case .systemAudioStopped: .systemAudioStopped
-            case .settingsChangeNotApplied: .settingsChangeNotApplied
-            case .brainChangeApplied: .brainChangeApplied
-            case .brainRouteAdvanced: .brainRouteAdvanced
-            case .brainRouteTargetSkipped: .brainRouteTargetSkipped
+            case .heard(let speaker, let text):
+                return (.heard, "🗣 heard (\(speaker.rawValue)): \"\(text)\"", nil)
+            case .manualHint(let prompt):
+                return (.manualHint, "⌨️ hint shortcut — \(prompt)", nil)
+            case .screenViewed(let imageBase64JPEG):
+                return (.screenViewed, "👁 looking at your screen", imageBase64JPEG)
+            case .screenViewFailed:
+                return (
+                    .screenViewFailed,
+                    "👁 couldn't view your screen — screen capture failed; check Screen Recording permission",
+                    nil
+                )
+            case .tip(let lines):
+                return (.tip, "💬 \(lines.joined(separator: " "))", nil)
+            case .stayedSilent:
+                return (.stayedSilent, "🤫 stayed silent — nothing useful to add", nil)
+            case .sessionEnded(let reason):
+                return (.sessionEnded, "⏹ \(reason.activityMessage)", nil)
+            case .coachingTurnFailed(let provider):
+                return (
+                    .coachingTurnFailed,
+                    "⚠️ \(provider.displayName) couldn't respond this turn — listening continues",
+                    nil
+                )
+            case .systemAudioStopped:
+                return (
+                    .systemAudioStopped,
+                    "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log",
+                    nil
+                )
+            case .settingsChangeNotApplied:
+                return (
+                    .settingsChangeNotApplied,
+                    "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain",
+                    nil
+                )
+            case .brainChangeApplied(let previous, let current):
+                let message = if previous == current {
+                    "🧠 brain change applied — \(current.displayName) setup is active"
+                } else {
+                    "🧠 brain switch applied — \(previous.displayName) → \(current.displayName)"
+                }
+                return (.brainChangeApplied, message, nil)
+            case .brainRouteAdvanced(let previous, let current):
+                let message = if previous == current {
+                    "⚠️ \(previous.displayName) target couldn't respond — continuing with the next \(current.displayName) model"
+                } else {
+                    "⚠️ \(previous.displayName) couldn't respond — continuing on \(current.displayName)"
+                }
+                return (.brainRouteAdvanced, message, nil)
+            case .brainRouteTargetSkipped(let provider):
+                return (
+                    .brainRouteTargetSkipped,
+                    "⚠️ \(provider.displayName) target is unavailable — skipping it",
+                    nil
+                )
             }
         }
     }
@@ -173,68 +208,19 @@ public final class ActivityLog: @unchecked Sendable {
     /// and then the `.jsonl` line referencing it — so a persisted reference always points at a file
     /// that exists.
     public func record(_ event: Event, at date: Date = Date()) {
-        let kind = event.kind
-        let message: String
-        let imageBase64: String?
-        switch event {
-        case .heard(let speaker, let text):
-            message = "🗣 heard (\(speaker.rawValue)): \"\(text)\""
-            imageBase64 = nil
-        case .manualHint(let prompt):
-            message = "⌨️ hint shortcut — \(prompt)"
-            imageBase64 = nil
-        case .screenViewed(let imageBase64JPEG):
-            message = "👁 looking at your screen"
-            imageBase64 = imageBase64JPEG
-        case .screenViewFailed:
-            message = "👁 couldn't view your screen — screen capture failed; check Screen Recording permission"
-            imageBase64 = nil
-        case .tip(let lines):
-            message = "💬 \(lines.joined(separator: " "))"
-            imageBase64 = nil
-        case .stayedSilent:
-            message = "🤫 stayed silent — nothing useful to add"
-            imageBase64 = nil
-        case .sessionEnded(let reason):
-            message = "⏹ \(reason.activityMessage)"
-            imageBase64 = nil
-        case .coachingTurnFailed(let provider):
-            message = "⚠️ \(provider.displayName) couldn't respond this turn — listening continues"
-            imageBase64 = nil
-        case .systemAudioStopped:
-            message = "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log"
-            imageBase64 = nil
-        case .settingsChangeNotApplied:
-            message = "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain"
-            imageBase64 = nil
-        case .brainChangeApplied(let previous, let current):
-            if previous == current {
-                message = "🧠 brain change applied — \(current.displayName) setup is active"
-            } else {
-                message = "🧠 brain switch applied — \(previous.displayName) → \(current.displayName)"
-            }
-            imageBase64 = nil
-        case .brainRouteAdvanced(let previous, let current):
-            if previous == current {
-                message = "⚠️ \(previous.displayName) target couldn't respond — continuing with the next \(current.displayName) model"
-            } else {
-                message = "⚠️ \(previous.displayName) couldn't respond — continuing on \(current.displayName)"
-            }
-            imageBase64 = nil
-        case .brainRouteTargetSkipped(let provider):
-            message = "⚠️ \(provider.displayName) target is unavailable — skipping it"
-            imageBase64 = nil
-        }
+        let rendered = event.rendered
         queue.async { [self] in
             guard let dir else { return }
-            let shotName = imageBase64.flatMap { saveShot($0, in: dir) }
-            let entry = Entry(time: df.string(from: date), message: message, imageFile: shotName)
-            appendJSONL(entry, kind: kind, in: dir)
+            let shotName = rendered.imageBase64.flatMap { saveShot($0, in: dir) }
+            let entry = Entry(time: df.string(from: date), message: rendered.message,
+                              imageFile: shotName)
+            appendJSONL(entry, kind: rendered.kind, in: dir)
             entries.append(entry)
             totalCount += 1
             if entries.count > maxLines { entries.removeFirst(entries.count - maxLines) }
             // Push with the live bytes in hand (no disk read on the hot path).
-            onAppend?(Self.rowScript(time: entry.time, message: entry.message, imageBase64: imageBase64))
+            onAppend?(Self.rowScript(time: entry.time, message: entry.message,
+                                     imageBase64: rendered.imageBase64))
         }
     }
 

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -169,6 +169,7 @@ public final class ActivityLog: @unchecked Sendable {
     private var entries: [Entry] = []
     private var totalCount = 0    // everything recorded this session (survives the maxLines cap)
     private var shotSeq = 0       // monotonic id for saved screenshot files this session
+    private var sessionHasEnded = false
     private let df: DateFormatter
     private var dir: URL?         // nil ⇒ disabled (no observer pushes, no disk writes)
     private var onAppend: ((String) -> Void)?
@@ -189,7 +190,7 @@ public final class ActivityLog: @unchecked Sendable {
     public func enable(directory: URL) {
         queue.sync {
             dir = directory
-            entries.removeAll(); totalCount = 0; shotSeq = 0; onAppend = nil
+            entries.removeAll(); totalCount = 0; shotSeq = 0; sessionHasEnded = false; onAppend = nil
             let url = directory.appendingPathComponent(Self.filename)
             FileManager.default.createFile(atPath: url.path, contents: Data(),
                                            attributes: [.posixPermissions: 0o600])
@@ -198,7 +199,14 @@ public final class ActivityLog: @unchecked Sendable {
 
     /// Turn the viewer back off (no further pushes or disk writes).
     public func disable() {
-        queue.sync { dir = nil; entries.removeAll(); totalCount = 0; shotSeq = 0; onAppend = nil }
+        queue.sync {
+            dir = nil
+            entries.removeAll()
+            totalCount = 0
+            shotSeq = 0
+            sessionHasEnded = false
+            onAppend = nil
+        }
     }
 
     /// Append one human-facing coaching event: persist it, then push it to the observer. No-op when
@@ -210,13 +218,18 @@ public final class ActivityLog: @unchecked Sendable {
     public func record(_ event: Event, at date: Date = Date()) {
         let rendered = event.rendered
         queue.async { [self] in
-            guard let dir else { return }
+            // Teardown can race a coaching task that is finishing cancellation. Once the typed end
+            // marker reaches this serial queue, it is the final event for this session by definition.
+            guard let dir, !sessionHasEnded else { return }
             let shotName = rendered.imageBase64.flatMap { saveShot($0, in: dir) }
             let entry = Entry(time: df.string(from: date), message: rendered.message,
                               imageFile: shotName)
             appendJSONL(entry, kind: rendered.kind, in: dir)
             entries.append(entry)
             totalCount += 1
+            if rendered.kind == .sessionEnded {
+                sessionHasEnded = true
+            }
             if entries.count > maxLines { entries.removeFirst(entries.count - maxLines) }
             // Push with the live bytes in hand (no disk read on the hot path).
             onAppend?(Self.rowScript(time: entry.time, message: entry.message,

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// The model behind the human-facing activity viewer. It records the coaching exchange — heard
 /// speech, manual hint requests, every brain action (screen view, tip, or deliberate silence), and
-/// fixed non-sensitive notices when a brain change succeeds, a route advances, degrades, or stops. It
-/// pushes those entries into an in-app `WKWebView` window (see `ActivityViewer` in JarvisApp) and
-/// persists them so past sessions can be browsed later. Detailed diagnostics belong exclusively in
-/// `JarvisLog`.
+/// fixed non-sensitive notices when a brain change succeeds, a route advances, degrades, or stops,
+/// and one typed reason whenever the live session ends. It pushes those entries into an in-app
+/// `WKWebView` window (see `ActivityViewer` in JarvisApp) and persists them so past sessions can be
+/// browsed later. Detailed diagnostics belong exclusively in `JarvisLog`.
 ///
 /// This type is UI-free (Foundation only): it generates the page HTML and the per-row JS as plain
 /// strings; the WebView lives in JarvisApp. See wiki/build-and-run.md.
@@ -22,9 +22,13 @@ public final class ActivityLog: @unchecked Sendable {
         case screenViewFailed
         case tip
         case stayedSilent
+        case sessionEnded
+        /// Retained so logs written before session teardown was unified remain decodable.
         case coachingStopped
         case coachingTurnFailed
+        /// Retained so logs written before session teardown was unified remain decodable.
         case transcriptionStopped
+        /// Retained so logs written before session teardown was unified remain decodable.
         case audioCaptureStopped
         case systemAudioStopped
         case settingsChangeNotApplied
@@ -33,6 +37,7 @@ public final class ActivityLog: @unchecked Sendable {
         case brainFallback
         case brainRouteAdvanced
         case brainRouteTargetSkipped
+        /// Retained so logs written before session teardown was unified remain decodable.
         case brainRouteExhausted
     }
 
@@ -53,19 +58,12 @@ public final class ActivityLog: @unchecked Sendable {
         case tip(lines: [String])
         /// The brain explicitly chose `stay_silent` for this turn.
         case stayedSilent
-        /// Coaching ended because the selected brain could not respond. Carries only the provider,
-        /// never the raw error, so the notice cannot expose provider diagnostics during screen
-        /// sharing.
-        case coachingStopped(provider: BrainProvider)
+        /// The single terminal lifecycle event for a live coaching session. The reason is a closed,
+        /// sanitized set so raw errors cannot leak into Activity.
+        case sessionEnded(reason: SessionEndReason)
         /// One coaching turn failed temporarily while capture and transcription remain live. The
         /// provider identity is enough for fixed recovery copy; raw error detail stays in debug.
         case coachingTurnFailed(provider: BrainProvider)
-        /// The session ended because transcription became unusable. Carries a fixed, typed reason;
-        /// raw provider and transport details remain exclusively in diagnostics.
-        case transcriptionStopped(reason: TranscriptionFailureReason)
-        /// Coaching ended because the running audio capture became unavailable. No device or route
-        /// detail is carried; the fixed copy points to diagnostics.
-        case audioCaptureStopped
         /// The secondary system-audio transcription stopped while microphone coaching continued.
         case systemAudioStopped
         /// An explicit Settings reapply failed its preflight while the existing session continued.
@@ -78,8 +76,6 @@ public final class ActivityLog: @unchecked Sendable {
         case brainRouteAdvanced(previous: BrainProvider, current: BrainProvider)
         /// A route target was proven unavailable before a provider request could be constructed.
         case brainRouteTargetSkipped(provider: BrainProvider)
-        /// Every user-authorized target was exhausted, so coaching stopped.
-        case brainRouteExhausted(lastProvider: BrainProvider)
 
         var kind: EventKind {
             switch self {
@@ -89,16 +85,13 @@ public final class ActivityLog: @unchecked Sendable {
             case .screenViewFailed: .screenViewFailed
             case .tip: .tip
             case .stayedSilent: .stayedSilent
-            case .coachingStopped: .coachingStopped
+            case .sessionEnded: .sessionEnded
             case .coachingTurnFailed: .coachingTurnFailed
-            case .transcriptionStopped: .transcriptionStopped
-            case .audioCaptureStopped: .audioCaptureStopped
             case .systemAudioStopped: .systemAudioStopped
             case .settingsChangeNotApplied: .settingsChangeNotApplied
             case .brainChangeApplied: .brainChangeApplied
             case .brainRouteAdvanced: .brainRouteAdvanced
             case .brainRouteTargetSkipped: .brainRouteTargetSkipped
-            case .brainRouteExhausted: .brainRouteExhausted
             }
         }
     }
@@ -202,17 +195,11 @@ public final class ActivityLog: @unchecked Sendable {
         case .stayedSilent:
             message = "🤫 stayed silent — nothing useful to add"
             imageBase64 = nil
-        case .coachingStopped(let provider):
-            message = "⏹ coaching stopped — \(provider.displayName) couldn't respond; check Settings → Brain"
+        case .sessionEnded(let reason):
+            message = "⏹ \(reason.activityMessage)"
             imageBase64 = nil
         case .coachingTurnFailed(let provider):
             message = "⚠️ \(provider.displayName) couldn't respond this turn — listening continues"
-            imageBase64 = nil
-        case .transcriptionStopped(let reason):
-            message = "⏹ session failed — \(reason.activityDescription)"
-            imageBase64 = nil
-        case .audioCaptureStopped:
-            message = "⏹ coaching stopped — audio capture became unavailable; check jarvis-debug.log"
             imageBase64 = nil
         case .systemAudioStopped:
             message = "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log"
@@ -236,9 +223,6 @@ public final class ActivityLog: @unchecked Sendable {
             imageBase64 = nil
         case .brainRouteTargetSkipped(let provider):
             message = "⚠️ \(provider.displayName) target is unavailable — skipping it"
-            imageBase64 = nil
-        case .brainRouteExhausted(let provider):
-            message = "⏹ coaching stopped — all configured provider targets were exhausted; last target: \(provider.displayName)"
             imageBase64 = nil
         }
         queue.async { [self] in
@@ -338,7 +322,8 @@ public final class ActivityLog: @unchecked Sendable {
         if m.hasPrefix("🗣") || m.hasPrefix("🤫 quiet") { return "hear" }
         if m.hasPrefix("🤫 stayed silent") || m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
         if m.hasPrefix("🧠") { return "think" }
-        if m.hasPrefix("⏹ coaching stopped") { return "think" }
+        if m.hasPrefix("⏹ session ended by error") { return "err" }
+        if m.hasPrefix("⏹ coaching stopped") || m.hasPrefix("⏹ session ended") { return "think" }
         if m.hasPrefix("⚠️") { return "think" }
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
@@ -362,6 +347,7 @@ public final class ActivityLog: @unchecked Sendable {
             || m.hasPrefix("💬") || m.hasPrefix("🤫 stayed silent")
             || m.hasPrefix("⏹ coaching stopped")
             || m.hasPrefix("⏹ session failed")
+            || m.hasPrefix("⏹ session ended")
             || (m.hasPrefix("⚠️") && m.contains("couldn't respond this turn")
                 && m.hasSuffix("listening continues"))
             || m.hasPrefix("⚠️ system audio stopped")

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -309,7 +309,7 @@ public final class ActivityLog: @unchecked Sendable {
         if m.hasPrefix("🤫 stayed silent") || m.hasPrefix("💭") || m.hasPrefix("…") { return "think" }
         if m.hasPrefix("🧠") { return "think" }
         if m.hasPrefix("⏹ session ended by error") { return "err" }
-        if m.hasPrefix("⏹ coaching stopped") || m.hasPrefix("⏹ session ended") { return "think" }
+        if m.hasPrefix("⏹ session ended") { return "think" }
         if m.hasPrefix("⚠️") { return "think" }
         let low = m.lowercased()
         if low.contains("error") || low.contains("failed") || low.contains("denied") { return "err" }
@@ -331,8 +331,6 @@ public final class ActivityLog: @unchecked Sendable {
         return m.hasPrefix("🗣 heard") || m.hasPrefix("⌨️ hint shortcut")
             || m.hasPrefix("👁 looking at your screen") || m.hasPrefix("👁 couldn't view your screen")
             || m.hasPrefix("💬") || m.hasPrefix("🤫 stayed silent")
-            || m.hasPrefix("⏹ coaching stopped")
-            || m.hasPrefix("⏹ session failed")
             || m.hasPrefix("⏹ session ended")
             || (m.hasPrefix("⚠️") && m.contains("couldn't respond this turn")
                 && m.hasSuffix("listening continues"))

--- a/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
+++ b/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
@@ -155,8 +155,9 @@ public enum AgenticEvaluation {
         speech, manual hints, every brain action, and every fixed stop/degrade notice, with stable \
         event kinds in `k`. Read the file itself in full; it is deliberately NOT filtered, summarized, \
         or copied into `\(transcriptFilename)`. Use it whenever you need the user-visible sequence or \
-        lifecycle consequence. Treat `coaching stopped` / `session failed` as a session-level UX \
-        failure and distinguish it from a recoverable `listening continues` notice. A single call \
+        lifecycle consequence. Treat `session ended by error` as a session-level UX failure, but not \
+        an end caused by the user, app quit, or a new session; distinguish all of them from a \
+        recoverable `listening continues` notice. A single call \
         timeout that stopped the whole session is catastrophic even if the wire-level failure itself \
         looks ordinary.
 

--- a/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
+++ b/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
@@ -155,10 +155,9 @@ public enum AgenticEvaluation {
         speech, manual hints, every brain action, and every fixed stop/degrade notice, with stable \
         event kinds in `k`. Read the file itself in full; it is deliberately NOT filtered, summarized, \
         or copied into `\(transcriptFilename)`. Use it whenever you need the user-visible sequence or \
-        lifecycle consequence. Treat `session ended by error` and the legacy `coaching stopped` or \
-        `session failed` phrases as session-level UX failures, but not an end caused by the user, app \
-        quit, or a new session; distinguish all of them from a recoverable `listening continues` \
-        notice. A single call \
+        lifecycle consequence. Treat `session ended by error` as a session-level UX failure, but not \
+        an end caused by the user, app quit, or a new session; distinguish all of them from a \
+        recoverable `listening continues` notice. A single call \
         timeout that stopped the whole session is catastrophic even if the wire-level failure itself \
         looks ordinary.
 

--- a/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
+++ b/Sources/JarvisCore/Diagnostics/AgenticEvaluation.swift
@@ -155,9 +155,10 @@ public enum AgenticEvaluation {
         speech, manual hints, every brain action, and every fixed stop/degrade notice, with stable \
         event kinds in `k`. Read the file itself in full; it is deliberately NOT filtered, summarized, \
         or copied into `\(transcriptFilename)`. Use it whenever you need the user-visible sequence or \
-        lifecycle consequence. Treat `session ended by error` as a session-level UX failure, but not \
-        an end caused by the user, app quit, or a new session; distinguish all of them from a \
-        recoverable `listening continues` notice. A single call \
+        lifecycle consequence. Treat `session ended by error` and the legacy `coaching stopped` or \
+        `session failed` phrases as session-level UX failures, but not an end caused by the user, app \
+        quit, or a new session; distinguish all of them from a recoverable `listening continues` \
+        notice. A single call \
         timeout that stopped the whole session is catastrophic even if the wire-level failure itself \
         looks ordinary.
 

--- a/Sources/JarvisCore/Diagnostics/SessionEndReason.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEndReason.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// The sanitized reason a live coaching session ended. This closed set keeps raw provider, transport,
+/// and device errors out of Activity while still making every terminal lifecycle transition explicit.
+public enum SessionEndReason: Sendable, Equatable {
+    case stoppedByUser
+    case applicationQuit
+    case replacedByNewSession
+    case openAIAPIKeyMissing
+    case brainProviderNotConfigured
+    case brainRouteExhausted(lastProvider: BrainProvider)
+    case transcriptionStopped(reason: TranscriptionFailureReason)
+    case audioCaptureUnavailable
+    case unexpectedError
+
+    var activityMessage: String {
+        switch self {
+        case .stoppedByUser:
+            "session ended by user"
+        case .applicationQuit:
+            "session ended because Jarvis quit"
+        case .replacedByNewSession:
+            "session ended because a new session started"
+        case .openAIAPIKeyMissing:
+            "session ended by error — the OpenAI API key is missing; check Settings → Brain"
+        case .brainProviderNotConfigured:
+            "session ended by error — no Primary brain provider is configured; check Settings → Brain"
+        case .brainRouteExhausted(let lastProvider):
+            "session ended by error — all configured provider targets were exhausted; last target: \(lastProvider.displayName)"
+        case .transcriptionStopped(let reason):
+            "session ended by error — \(reason.activityDescription)"
+        case .audioCaptureUnavailable:
+            "session ended by error — audio capture became unavailable; check jarvis-debug.log"
+        case .unexpectedError:
+            "session ended by error — check jarvis-debug.log"
+        }
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -35,8 +35,8 @@ public struct SessionStore: Sendable {
         let t: String
         let m: String
         let s: String?
-        /// A raw value keeps rows with legacy or future kinds readable; only current kinds bypass the
-        /// legacy human-copy classifier.
+        /// A raw value lets this build distinguish current typed events from unknown kinds; only
+        /// current kinds bypass the human-copy classifier.
         let k: String?
     }
 

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -61,8 +61,8 @@ public struct SessionStore: Sendable {
             .sorted { $0.id > $1.id }   // id is a lexically-sortable timestamp ⇒ newest first
     }
 
-    /// Whether a session's log holds at least one human-facing coaching event. The classifier also
-    /// keeps lifecycle and diagnostic rows written by older builds from making aborted runs visible.
+    /// Whether a session's log holds at least one human-facing coaching event. A terminal marker is
+    /// visible inside a retained session, but does not make an otherwise empty run worth retaining.
     private static func hasCoachingContent(_ sessionURL: URL) -> Bool {
         let url = sessionURL.appendingPathComponent("jarvis-activity.jsonl")
         guard let text = try? String(contentsOf: url, encoding: .utf8) else { return false }
@@ -73,10 +73,14 @@ public struct SessionStore: Sendable {
                     sessionURL.appendingPathComponent(name).path) else { return nil }
                 return name
             }
+            let kind = line.k.flatMap { ActivityLog.EventKind(rawValue: $0) }
+            if kind == .sessionEnded {
+                continue
+            }
             if ActivityLog.isHumanFacing(
                 message: line.m,
                 imageFile: shot,
-                kind: line.k.flatMap { ActivityLog.EventKind(rawValue: $0) }
+                kind: kind
             ) {
                 return true
             }

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -35,8 +35,8 @@ public struct SessionStore: Sendable {
         let t: String
         let m: String
         let s: String?
-        /// A raw value keeps rows with future kinds readable by older builds; only kinds known to
-        /// this build bypass the legacy human-copy classifier.
+        /// A raw value keeps rows with legacy or future kinds readable; only current kinds bypass the
+        /// legacy human-copy classifier.
         let k: String?
     }
 

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -10,7 +10,8 @@ public extension UserFacingError {
         .init(
             title: "Choose a provider",
             message: "Open Settings → Brain and choose a Primary provider, then press Start.",
-            severity: .fatal)
+            severity: .fatal,
+            sessionEndReason: .brainProviderNotConfigured)
     }
 
     /// No API key on Start. Realtime voice transcription always runs on the OpenAI key — whichever
@@ -18,7 +19,8 @@ public extension UserFacingError {
     static var noAPIKey: UserFacingError {
         .init(title: "No OpenAI API key set",
               message: "Voice transcription needs an OpenAI API key even when the brain runs on a local CLI. Open \u{201C}Settings\u{2026}\u{201D} \u{2192} Brain, paste your key, then press Start.",
-              severity: .fatal)
+              severity: .fatal,
+              sessionEndReason: .openAIAPIKeyMissing)
     }
 
     /// The selected brain provider's CLI isn't installed (or was removed since it was selected).
@@ -50,22 +52,28 @@ public extension UserFacingError {
 
     /// The finite user-authorized brain route was exhausted. Individual target failures never use
     /// this terminal path; their raw detail stays diagnostic while pending work moves forward.
-    static func brainRouteExhausted(lastProvider: String, reason: String) -> UserFacingError {
+    static func brainRouteExhausted(
+        lastProvider: BrainProvider,
+        reason: String
+    ) -> UserFacingError {
         .init(title: "Brain fallback route exhausted",
-              message: "\(reason)\n\nCoaching stopped after every configured target was exhausted. The last target was \(lastProvider). Check Settings → Brain, then Start again.",
-              severity: .terminal)
+              message: "\(reason)\n\nCoaching stopped after every configured target was exhausted. The last target was \(lastProvider.displayName). Check Settings → Brain, then Start again.",
+              severity: .terminal,
+              sessionEndReason: .brainRouteExhausted(lastProvider: lastProvider))
     }
 
     /// Audio capture couldn't be built or started. `reason` is the human-readable cause from the capture
     /// layer (no input device, permission, unreadable rate, …). Fatal — there's nothing to coach from.
     static func captureFailed(reason: String) -> UserFacingError {
-        .init(title: "Couldn't start audio capture", message: reason, severity: .fatal)
+        .init(title: "Couldn't start audio capture", message: reason, severity: .fatal,
+              sessionEndReason: .audioCaptureUnavailable)
     }
 
     /// Audio capture started, then became unavailable after a route rebuild. Coaching cannot
     /// continue, but a runtime failure must stop without activating the app.
     static func captureStopped(reason: String) -> UserFacingError {
-        .init(title: "Audio capture stopped", message: reason, severity: .terminal)
+        .init(title: "Audio capture stopped", message: reason, severity: .terminal,
+              sessionEndReason: .audioCaptureUnavailable)
     }
 
     /// The mic ("me") transcription socket gave up (bad key / quota / network) — NOT a mic-hardware
@@ -73,7 +81,8 @@ public extension UserFacingError {
     static func transcriptionStopped(reason: TranscriptionFailureReason) -> UserFacingError {
         .init(title: "Transcription stopped",
               message: "Jarvis could not continue because \(reason.activityDescription).",
-              severity: .terminal)
+              severity: .terminal,
+              sessionEndReason: .transcriptionStopped(reason: reason))
     }
 
     /// The system-audio ("them") socket gave up. The mic still works, so this is a graceful degrade —

--- a/Sources/JarvisCore/Diagnostics/UserFacingError.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError.swift
@@ -42,10 +42,15 @@ public struct UserFacingError: Error, Sendable, Equatable {
     public let title: String
     public let message: String
     public let severity: Severity
+    /// The fixed Activity reason used if this error ends a live session. Raw `message` detail is
+    /// intentionally separate and remains available only to the debug log and permitted startup UI.
+    public let sessionEndReason: SessionEndReason?
 
-    public init(title: String, message: String, severity: Severity) {
+    public init(title: String, message: String, severity: Severity,
+                sessionEndReason: SessionEndReason? = nil) {
         self.title = title
         self.message = message
         self.severity = severity
+        self.sessionEndReason = sessionEndReason
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -13,6 +13,9 @@ import Foundation
         #expect(ActivityLog.cssClass(for: "… nothing useful to add, staying silent") == "think")
         #expect(ActivityLog.cssClass(for: "🧠 brain switch applied — OpenAI API → Claude Code") == "think")
         #expect(ActivityLog.cssClass(for: "⏹ coaching stopped — Claude Code couldn't respond") == "think")
+        #expect(ActivityLog.cssClass(for: "⏹ session ended by user") == "think")
+        #expect(ActivityLog.cssClass(
+            for: "⏹ session ended by error — check jarvis-debug.log") == "err")
         #expect(ActivityLog.cssClass(for: "Jarvis realtime error event: oops") == "err")
         #expect(ActivityLog.cssClass(for: "Jarvis: coaching started.") == "")
         // A spoken tip can legitimately contain "failed"; it must stay a 💬 say line.
@@ -66,13 +69,13 @@ import Foundation
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
 
-        log.record(.coachingStopped(provider: .codexCLI))
+        log.record(.sessionEnded(reason: .stoppedByUser))
         log.flush()
 
         let jsonl = try String(
             contentsOf: dir.appendingPathComponent(ActivityLog.filename), encoding: .utf8)
-        #expect(jsonl.contains(#""k":"coachingStopped""#)
-            || jsonl.contains(#""k": "coachingStopped""#))
+        #expect(jsonl.contains(#""k":"sessionEnded""#)
+            || jsonl.contains(#""k": "sessionEnded""#))
     }
 
     @Test func attachSnapshotReplaysExistingEntriesWithImageBytes() throws {
@@ -141,23 +144,6 @@ import Foundation
         ))
     }
 
-    @Test func coachingStoppedPersistsOnlyADiscreetHumanFacingNotice() throws {
-        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
-        let log = ActivityLog(); log.enable(directory: dir)
-        log.record(.coachingStopped(provider: .claudeCode))
-        let snapshot = log.attach { _ in }
-
-        let row = try #require(snapshot.rows.first)
-        #expect(row.contains("coaching stopped"))
-        #expect(row.contains("Claude Code"))
-        #expect(row.contains("Settings"))
-        #expect(!row.contains("OAuth"))
-        #expect(ActivityLog.isHumanFacing(
-            message: "⏹ coaching stopped — Claude Code couldn't respond; check Settings → Brain",
-            imageFile: nil
-        ))
-    }
-
     @Test func temporaryBrainFailureSaysListeningContinuesWithoutDiagnosticDetail() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
@@ -204,18 +190,15 @@ import Foundation
         log.record(.brainRouteAdvanced(previous: .openAI, current: .claudeCode))
         log.record(.brainRouteAdvanced(previous: .claudeCode, current: .claudeCode))
         log.record(.brainRouteTargetSkipped(provider: .codexCLI))
-        log.record(.brainRouteExhausted(lastProvider: .claudeCode))
         let snapshot = log.attach { _ in }
 
-        #expect(snapshot.rows.count == 4)
+        #expect(snapshot.rows.count == 3)
         #expect(snapshot.rows[0].contains(
             "OpenAI API couldn't respond — continuing on Claude Code"))
         #expect(snapshot.rows[1].contains(
             "Claude Code target couldn't respond — continuing with the next Claude Code model"))
         #expect(snapshot.rows[2].contains(
             "Codex CLI target is unavailable — skipping it"))
-        #expect(snapshot.rows[3].contains(
-            "coaching stopped — all configured provider targets were exhausted; last target: Claude Code"))
         #expect(!snapshot.rows.joined().contains("timeout"))
         #expect(!snapshot.rows.joined().contains("OAuth"))
         #expect(!snapshot.rows.joined().contains("token"))
@@ -231,25 +214,24 @@ import Foundation
             ActivityLog.EventKind.brainRouteAdvanced.rawValue,
             ActivityLog.EventKind.brainRouteAdvanced.rawValue,
             ActivityLog.EventKind.brainRouteTargetSkipped.rawValue,
-            ActivityLog.EventKind.brainRouteExhausted.rawValue,
         ])
     }
 
     @Test func runtimeFailureNoticesStayFixedAndDiagnosticFree() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
-        log.record(.transcriptionStopped(reason: .connectionLost))
-        log.record(.transcriptionStopped(reason: .quotaExceeded))
-        log.record(.transcriptionStopped(reason: .authenticationFailed))
-        log.record(.transcriptionStopped(reason: .accessDenied))
-        log.record(.transcriptionStopped(reason: .configurationRejected))
-        log.record(.audioCaptureStopped)
+        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .connectionLost)))
+        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .quotaExceeded)))
+        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .authenticationFailed)))
+        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .accessDenied)))
+        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .configurationRejected)))
+        log.record(.sessionEnded(reason: .audioCaptureUnavailable))
         log.record(.systemAudioStopped)
         log.record(.settingsChangeNotApplied)
         let snapshot = log.attach { _ in }
 
         #expect(snapshot.rows.count == 8)
-        #expect(snapshot.rows[0].contains("session failed"))
+        #expect(snapshot.rows[0].contains("session ended by error"))
         #expect(snapshot.rows[0].contains("transcription connection was lost"))
         #expect(snapshot.rows[1].contains("API quota is exhausted"))
         #expect(snapshot.rows[1].contains("billing"))
@@ -269,11 +251,59 @@ import Foundation
             imageFile: nil
         ))
         #expect(ActivityLog.isHumanFacing(
-            message: "⏹ session failed — the OpenAI API quota is exhausted; check billing",
+            message: "⏹ session ended by error — the OpenAI API quota is exhausted; check billing",
             imageFile: nil
         ))
         #expect(ActivityLog.isHumanFacing(
             message: "⚠️ settings change wasn't applied — current coaching session continues; check Settings → Brain",
+            imageFile: nil
+        ))
+    }
+
+    @Test func sessionEndReasonsAreExplicitSanitizedAndStable() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+        let reasons: [SessionEndReason] = [
+            .stoppedByUser,
+            .applicationQuit,
+            .replacedByNewSession,
+            .openAIAPIKeyMissing,
+            .brainProviderNotConfigured,
+            .brainRouteExhausted(lastProvider: .claudeCode),
+            .transcriptionStopped(reason: .quotaExceeded),
+            .audioCaptureUnavailable,
+            .unexpectedError,
+        ]
+        for reason in reasons {
+            log.record(.sessionEnded(reason: reason))
+        }
+        let snapshot = log.attach { _ in }
+
+        #expect(snapshot.rows.count == reasons.count)
+        #expect(snapshot.rows[0].contains("session ended by user"))
+        #expect(snapshot.rows[1].contains("session ended because Jarvis quit"))
+        #expect(snapshot.rows[2].contains("session ended because a new session started"))
+        #expect(snapshot.rows[3].contains("API key is missing"))
+        #expect(snapshot.rows[4].contains("no Primary brain provider"))
+        #expect(snapshot.rows[5].contains("last target: Claude Code"))
+        #expect(snapshot.rows[6].contains("API quota is exhausted"))
+        #expect(snapshot.rows[7].contains("audio capture became unavailable"))
+        #expect(snapshot.rows[8].contains("check jarvis-debug.log"))
+        #expect(!snapshot.rows.joined().contains("OAuth"))
+        #expect(!snapshot.rows.joined().contains("AirPods"))
+        #expect(!snapshot.rows.joined().contains("item_"))
+
+        let jsonl = try String(
+            contentsOf: dir.appendingPathComponent(ActivityLog.filename), encoding: .utf8)
+        let kinds = try jsonl.split(separator: "\n").map { line in
+            let value = try #require(
+                try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            return value["k"] as? String
+        }
+        #expect(kinds == Array(repeating: ActivityLog.EventKind.sessionEnded.rawValue,
+                              count: reasons.count))
+        #expect(ActivityLog.isHumanFacing(
+            message: "⏹ session ended by user",
             imageFile: nil
         ))
     }

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -12,7 +12,6 @@ import Foundation
         #expect(ActivityLog.cssClass(for: "💭 thinking…") == "think")
         #expect(ActivityLog.cssClass(for: "… nothing useful to add, staying silent") == "think")
         #expect(ActivityLog.cssClass(for: "🧠 brain switch applied — OpenAI API → Claude Code") == "think")
-        #expect(ActivityLog.cssClass(for: "⏹ coaching stopped — Claude Code couldn't respond") == "think")
         #expect(ActivityLog.cssClass(for: "⏹ session ended by user") == "think")
         #expect(ActivityLog.cssClass(
             for: "⏹ session ended by error — check jarvis-debug.log") == "err")

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -77,6 +77,22 @@ import Foundation
             || jsonl.contains(#""k": "sessionEnded""#))
     }
 
+    @Test func sessionEndMarkerRejectsLaterActivity() throws {
+        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
+        let log = ActivityLog(); log.enable(directory: dir)
+
+        log.record(.tip(lines: ["before stop"]))
+        log.record(.sessionEnded(reason: .stoppedByUser))
+        log.record(.stayedSilent)
+        log.flush()
+
+        let snapshot = log.attach { _ in }
+        #expect(snapshot.rows.count == 2)
+        #expect(snapshot.rows[0].contains("before stop"))
+        #expect(snapshot.rows[1].contains("session ended by user"))
+        #expect(!snapshot.rows.joined().contains("stayed silent"))
+    }
+
     @Test func attachSnapshotReplaysExistingEntriesWithImageBytes() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
@@ -216,34 +232,34 @@ import Foundation
         ])
     }
 
-    @Test func runtimeFailureNoticesStayFixedAndDiagnosticFree() throws {
-        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
-        let log = ActivityLog(); log.enable(directory: dir)
-        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .connectionLost)))
-        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .quotaExceeded)))
-        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .authenticationFailed)))
-        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .accessDenied)))
-        log.record(.sessionEnded(reason: .transcriptionStopped(reason: .configurationRejected)))
-        log.record(.sessionEnded(reason: .audioCaptureUnavailable))
-        log.record(.systemAudioStopped)
-        log.record(.settingsChangeNotApplied)
-        let snapshot = log.attach { _ in }
+    @Test func runtimeFailureNoticesStayFixedAndDiagnosticFree() {
+        let events: [ActivityLog.Event] = [
+            .sessionEnded(reason: .transcriptionStopped(reason: .connectionLost)),
+            .sessionEnded(reason: .transcriptionStopped(reason: .quotaExceeded)),
+            .sessionEnded(reason: .transcriptionStopped(reason: .authenticationFailed)),
+            .sessionEnded(reason: .transcriptionStopped(reason: .accessDenied)),
+            .sessionEnded(reason: .transcriptionStopped(reason: .configurationRejected)),
+            .sessionEnded(reason: .audioCaptureUnavailable),
+            .systemAudioStopped,
+            .settingsChangeNotApplied,
+        ]
+        let messages = events.map { $0.rendered.message }
 
-        #expect(snapshot.rows.count == 8)
-        #expect(snapshot.rows[0].contains("session ended by error"))
-        #expect(snapshot.rows[0].contains("transcription connection was lost"))
-        #expect(snapshot.rows[1].contains("API quota is exhausted"))
-        #expect(snapshot.rows[1].contains("billing"))
-        #expect(snapshot.rows[2].contains("rejected the API key"))
-        #expect(snapshot.rows[3].contains("denied transcription access"))
-        #expect(snapshot.rows[4].contains("rejected the transcription configuration"))
-        #expect(snapshot.rows[5].contains("audio capture became unavailable"))
-        #expect(snapshot.rows[6].contains("microphone coaching continues"))
-        #expect(snapshot.rows[7].contains("current coaching session continues"))
-        for row in snapshot.rows {
-            #expect(!row.contains("OAuth"))
-            #expect(!row.contains("AirPods"))
-            #expect(!row.contains("item_"))
+        #expect(messages.count == 8)
+        #expect(messages[0].contains("session ended by error"))
+        #expect(messages[0].contains("transcription connection was lost"))
+        #expect(messages[1].contains("API quota is exhausted"))
+        #expect(messages[1].contains("billing"))
+        #expect(messages[2].contains("rejected the API key"))
+        #expect(messages[3].contains("denied transcription access"))
+        #expect(messages[4].contains("rejected the transcription configuration"))
+        #expect(messages[5].contains("audio capture became unavailable"))
+        #expect(messages[6].contains("microphone coaching continues"))
+        #expect(messages[7].contains("current coaching session continues"))
+        for message in messages {
+            #expect(!message.contains("OAuth"))
+            #expect(!message.contains("AirPods"))
+            #expect(!message.contains("item_"))
         }
         #expect(ActivityLog.isHumanFacing(
             message: "⚠️ system audio stopped — microphone coaching continues; check jarvis-debug.log",
@@ -259,9 +275,7 @@ import Foundation
         ))
     }
 
-    @Test func sessionEndReasonsAreExplicitSanitizedAndStable() throws {
-        let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
-        let log = ActivityLog(); log.enable(directory: dir)
+    @Test func sessionEndReasonsAreExplicitSanitizedAndStable() {
         let reasons: [SessionEndReason] = [
             .stoppedByUser,
             .applicationQuit,
@@ -273,34 +287,26 @@ import Foundation
             .audioCaptureUnavailable,
             .unexpectedError,
         ]
-        for reason in reasons {
-            log.record(.sessionEnded(reason: reason))
-        }
-        let snapshot = log.attach { _ in }
+        let rendered = reasons.map { ActivityLog.Event.sessionEnded(reason: $0).rendered }
+        let messages = rendered.map { $0.message }
 
-        #expect(snapshot.rows.count == reasons.count)
-        #expect(snapshot.rows[0].contains("session ended by user"))
-        #expect(snapshot.rows[1].contains("session ended because Jarvis quit"))
-        #expect(snapshot.rows[2].contains("session ended because a new session started"))
-        #expect(snapshot.rows[3].contains("API key is missing"))
-        #expect(snapshot.rows[4].contains("no Primary brain provider"))
-        #expect(snapshot.rows[5].contains("last target: Claude Code"))
-        #expect(snapshot.rows[6].contains("API quota is exhausted"))
-        #expect(snapshot.rows[7].contains("audio capture became unavailable"))
-        #expect(snapshot.rows[8].contains("check jarvis-debug.log"))
-        #expect(!snapshot.rows.joined().contains("OAuth"))
-        #expect(!snapshot.rows.joined().contains("AirPods"))
-        #expect(!snapshot.rows.joined().contains("item_"))
-
-        let jsonl = try String(
-            contentsOf: dir.appendingPathComponent(ActivityLog.filename), encoding: .utf8)
-        let kinds = try jsonl.split(separator: "\n").map { line in
-            let value = try #require(
-                try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
-            return value["k"] as? String
-        }
-        #expect(kinds == Array(repeating: ActivityLog.EventKind.sessionEnded.rawValue,
-                              count: reasons.count))
+        #expect(messages.count == reasons.count)
+        #expect(messages[0].contains("session ended by user"))
+        #expect(messages[1].contains("session ended because Jarvis quit"))
+        #expect(messages[2].contains("session ended because a new session started"))
+        #expect(messages[3].contains("API key is missing"))
+        #expect(messages[4].contains("no Primary brain provider"))
+        #expect(messages[5].contains("last target: Claude Code"))
+        #expect(messages[6].contains("API quota is exhausted"))
+        #expect(messages[7].contains("audio capture became unavailable"))
+        #expect(messages[8].contains("check jarvis-debug.log"))
+        #expect(!messages.joined().contains("OAuth"))
+        #expect(!messages.joined().contains("AirPods"))
+        #expect(!messages.joined().contains("item_"))
+        #expect(rendered.map { $0.kind } == Array(
+            repeating: ActivityLog.EventKind.sessionEnded,
+            count: reasons.count
+        ))
         #expect(ActivityLog.isHumanFacing(
             message: "⏹ session ended by user",
             imageFile: nil

--- a/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
@@ -15,7 +15,7 @@ import Foundation
         let activityJSONL = [
             #"{"t":"10:00:00","m":"heard question","k":"heard"}"#,
             #"{"t":"10:00:20","m":"coaching tip","k":"tip"}"#,
-            #"{"t":"10:00:30","m":"plain permanent failure","k":"coachingStopped"}"#,
+            #"{"t":"10:00:30","m":"session ended by error","k":"sessionEnded"}"#,
         ].joined(separator: "\n") + "\n"
         let activityURL = dir.appendingPathComponent(ActivityLog.filename)
         try Data(activityJSONL.utf8).write(to: activityURL)
@@ -28,7 +28,7 @@ import Foundation
         #expect(transcript.contains("=== call #1 · coach"))
         #expect(!transcript.contains("heard question"))
         #expect(!transcript.contains("coaching tip"))
-        #expect(!transcript.contains("plain permanent failure"))
+        #expect(!transcript.contains("session ended by error"))
         let perms = try FileManager.default.attributesOfItem(atPath: transcriptURL.path)[.posixPermissions] as? NSNumber
         #expect(perms?.int16Value == 0o600)
         // Preparation never rewrites or filters Activity; the agent receives the complete source file.
@@ -95,8 +95,8 @@ import Foundation
         #expect(prompt.contains("re-check every number"))
         #expect(prompt.contains("session-level UX failure"))
         #expect(prompt.contains("`session ended by error`"))
-        #expect(prompt.contains("legacy `coaching stopped`"))
-        #expect(prompt.contains("`session failed` phrases"))
+        #expect(!prompt.contains("coaching stopped"))
+        #expect(!prompt.contains("session failed"))
         #expect(prompt.contains("stable event kinds in `k`"))
     }
 

--- a/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/AgenticEvaluationTests.swift
@@ -94,6 +94,9 @@ import Foundation
         #expect(prompt.contains("MUST be counted here"))
         #expect(prompt.contains("re-check every number"))
         #expect(prompt.contains("session-level UX failure"))
+        #expect(prompt.contains("`session ended by error`"))
+        #expect(prompt.contains("legacy `coaching stopped`"))
+        #expect(prompt.contains("`session failed` phrases"))
         #expect(prompt.contains("stable event kinds in `k`"))
     }
 

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -64,21 +64,16 @@ import Foundation
             "{\"t\":\"10:00:02\",\"m\":\"🗣 heard (me): text only\"}",
             "{\"t\":\"10:00:03\",\"m\":\"💭 thinking…\"}",
             "{\"t\":\"10:00:04\",\"m\":\"🤫 stayed silent — nothing useful to add\"}",
-            """
-            {"t":"10:00:05","m":"⏹ coaching stopped — audio capture became unavailable; \
-            check jarvis-debug.log","k":"audioCaptureStopped"}
-            """,
         ], shot: ("shot-1.jpg", Data([0xFF, 0xD8, 0xFF, 0xD9])))
         let store = SessionStore(base: base, current: nil)
         let session = try #require(store.listSessions().first)
         let rows = store.entries(for: session)
-        #expect(rows.count == 4)                     // malformed + diagnostic rows skipped
+        #expect(rows.count == 3)                     // malformed + diagnostic rows skipped
         #expect(rows[0].0.message == "👁 looking at your screen")
         #expect(rows[0].1 != nil)                    // valid shot bytes loaded
         #expect(rows[1].0.message == "🗣 heard (me): text only")
         #expect(rows[1].1 == nil)                    // text-only coaching line
         #expect(rows[2].0.message.contains("stayed silent"))
-        #expect(rows[3].0.message.contains("audio capture became unavailable"))
     }
 
     @Test func entriesDropImageWhenShotFileMissing() throws {

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -37,6 +37,12 @@ import Foundation
             "{\"t\":\"09:00:01\",\"m\":\"💭 thinking…\"}",
             "{\"t\":\"09:00:02\",\"m\":\"Jarvis realtime error event: oops\"}",
         ])
+        // A typed end marker remains visible inside a real session, but is not coaching content alone.
+        try makeSession(base, "2026-06-16_09-30-00_eeee", lines: [
+            """
+            {"t":"09:30:00","m":"⏹ session ended by user","k":"sessionEnded"}
+            """,
+        ])
         // A past session that actually coached (has a 💬 line) — keep it.
         try makeSession(base, "2026-06-16_10-00-00_bbbb", lines: ["{\"t\":\"10:00:00\",\"m\":\"💬 try this\"}"])
         // A past session whose only content is a screenshot reference — keep it.
@@ -52,6 +58,7 @@ import Foundation
                         "2026-06-16_10-30-00_cccc",   // has a screenshot
                         "2026-06-16_10-00-00_bbbb"])  // has a coaching line
         #expect(!ids.contains("2026-06-16_09-00-00_aaaa"))   // aborted run hidden
+        #expect(!ids.contains("2026-06-16_09-30-00_eeee"))   // end-only run hidden
     }
 
     @Test func entriesDecodeTolerateMalformedAndGuardTraversal() throws {
@@ -64,16 +71,20 @@ import Foundation
             "{\"t\":\"10:00:02\",\"m\":\"🗣 heard (me): text only\"}",
             "{\"t\":\"10:00:03\",\"m\":\"💭 thinking…\"}",
             "{\"t\":\"10:00:04\",\"m\":\"🤫 stayed silent — nothing useful to add\"}",
+            """
+            {"t":"10:00:05","m":"⏹ session ended by user","k":"sessionEnded"}
+            """,
         ], shot: ("shot-1.jpg", Data([0xFF, 0xD8, 0xFF, 0xD9])))
         let store = SessionStore(base: base, current: nil)
         let session = try #require(store.listSessions().first)
         let rows = store.entries(for: session)
-        #expect(rows.count == 3)                     // malformed + diagnostic rows skipped
+        #expect(rows.count == 4)                     // malformed + diagnostic rows skipped
         #expect(rows[0].0.message == "👁 looking at your screen")
         #expect(rows[0].1 != nil)                    // valid shot bytes loaded
         #expect(rows[1].0.message == "🗣 heard (me): text only")
         #expect(rows[1].1 == nil)                    // text-only coaching line
         #expect(rows[2].0.message.contains("stayed silent"))
+        #expect(rows[3].0.message.contains("session ended by user"))
     }
 
     @Test func entriesDropImageWhenShotFileMissing() throws {

--- a/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionStoreTests.swift
@@ -64,16 +64,21 @@ import Foundation
             "{\"t\":\"10:00:02\",\"m\":\"🗣 heard (me): text only\"}",
             "{\"t\":\"10:00:03\",\"m\":\"💭 thinking…\"}",
             "{\"t\":\"10:00:04\",\"m\":\"🤫 stayed silent — nothing useful to add\"}",
+            """
+            {"t":"10:00:05","m":"⏹ coaching stopped — audio capture became unavailable; \
+            check jarvis-debug.log","k":"audioCaptureStopped"}
+            """,
         ], shot: ("shot-1.jpg", Data([0xFF, 0xD8, 0xFF, 0xD9])))
         let store = SessionStore(base: base, current: nil)
         let session = try #require(store.listSessions().first)
         let rows = store.entries(for: session)
-        #expect(rows.count == 3)                     // malformed + diagnostic rows skipped
+        #expect(rows.count == 4)                     // malformed + diagnostic rows skipped
         #expect(rows[0].0.message == "👁 looking at your screen")
         #expect(rows[0].1 != nil)                    // valid shot bytes loaded
         #expect(rows[1].0.message == "🗣 heard (me): text only")
         #expect(rows[1].1 == nil)                    // text-only coaching line
         #expect(rows[2].0.message.contains("stayed silent"))
+        #expect(rows[3].0.message.contains("audio capture became unavailable"))
     }
 
     @Test func entriesDropImageWhenShotFileMissing() throws {

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
@@ -10,11 +10,13 @@ import Testing
         #expect(error.severity == .fatal)
         #expect(error.severity.showsAlert)
         #expect(error.message.contains("Primary provider"))
+        #expect(error.sessionEndReason == .brainProviderNotConfigured)
     }
 
     @Test func noAPIKeyIsFatal() {
         #expect(UserFacingError.noAPIKey.severity == .fatal)
         #expect(UserFacingError.noAPIKey.severity.showsAlert)
+        #expect(UserFacingError.noAPIKey.sessionEndReason == .openAIAPIKeyMissing)
     }
 
     @Test func captureFailedIsFatalAndCarriesReason() {
@@ -22,6 +24,7 @@ import Testing
         #expect(e.severity == .fatal)
         #expect(e.severity.stopsSession)
         #expect(e.message.contains("no input device"))
+        #expect(e.sessionEndReason == .audioCaptureUnavailable)
     }
 
     @Test func runtimeCaptureFailureStopsQuietlyAndCarriesReason() {
@@ -30,6 +33,7 @@ import Testing
         #expect(e.severity.stopsSession)
         #expect(!e.severity.showsAlert)
         #expect(e.message.contains("route disappeared"))
+        #expect(e.sessionEndReason == .audioCaptureUnavailable)
     }
 
     @Test func transcriptionStoppedIsTerminal() {
@@ -39,6 +43,7 @@ import Testing
             #expect(error.severity.stopsSession)
             #expect(!error.severity.showsAlert)
             #expect(error.message.contains(reason.activityDescription))
+            #expect(error.sessionEndReason == .transcriptionStopped(reason: reason))
         }
     }
 
@@ -77,7 +82,7 @@ import Testing
 
     @Test func exhaustedBrainRouteStopsQuietlyAndKeepsDiagnosticDetail() {
         let e = UserFacingError.brainRouteExhausted(
-            lastProvider: "Claude Code",
+            lastProvider: .claudeCode,
             reason: "OAuth session expired")
         #expect(e.severity == .terminal)
         #expect(!e.severity.showsAlert)
@@ -85,5 +90,6 @@ import Testing
         #expect(e.title.contains("route exhausted"))
         #expect(e.message.contains("OAuth session expired"))
         #expect(e.message.contains("Claude Code"))
+        #expect(e.sessionEndReason == .brainRouteExhausted(lastProvider: .claudeCode))
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorTests.swift
@@ -42,5 +42,6 @@ import Testing
         #expect(e.title == "T")
         #expect(e.message == "M")
         #expect(e.severity == .fatal)
+        #expect(e.sessionEndReason == nil)
     }
 }

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -86,15 +86,16 @@ then just run the script) for packaging without CI. Distributed builds run on Ap
 Settings → **Activity** opens an **in-app `WKWebView`** into which `ActivityLog` pushes the typed,
 human-facing coaching exchange: finalized interviewer/user speech, manual hint requests, and every
 brain action — a successful or failed `capture_screen`, a displayed `speak` tip, or a deliberate
-`stay_silent`. It also shows fixed, non-sensitive notices for every runtime failure that stops or
-degrades coaching, as well as a settings preflight that was not applied and a failed live brain
-switch falling back to the previous provider. Provider names are allowed, while raw errors,
-authentication details, retries, and timing remain in `jarvis-debug.log`. Successful screen-view
-events carry their thumbnails as in-memory `data:` URIs. Chosen over a local HTTP server + SSE: for
-an app that already holds the entries in memory, pushing into an embedded WebView is less code, has
-zero network surface, and is the most testable (the production runtime *is* the test runtime). It
-also sidesteps the `file://` `fetch()` restriction that forced the original viewer's `<meta refresh>`
-reload.
+`stay_silent`. It also shows one fixed, non-sensitive reason whenever a live session ends — including
+user Stop, app quit, replacement by a new Start, and terminal runtime failures — plus fixed notices
+for failures that degrade coaching, a settings preflight that was not applied, and a failed live brain
+switch falling back to the previous provider. Provider names are allowed, while lifecycle sequencing,
+raw errors, authentication details, retries, and timing remain in `jarvis-debug.log`. Successful
+screen-view events carry their thumbnails as in-memory `data:` URIs. Chosen over a local HTTP server +
+SSE: for an app that already holds the entries in memory, pushing into an embedded WebView is less
+code, has zero network surface, and is the most testable (the production runtime *is* the test
+runtime). It also sidesteps the `file://` `fetch()` restriction that forced the original viewer's
+`<meta refresh>` reload.
 
 - New events stream in live (no reload, no flicker); thumbnails open in an in-page lightbox.
 - Each Start opens a fresh session (a Stop→Start gets a new log, never resuming the previous run),
@@ -140,6 +141,7 @@ the human-facing coaching record. The current validation priority lives in
   controls and preview follow the toggle, and confirm the choice survives relaunch.
 - If validating realtime recovery, disconnect the network, say a unique phrase, reconnect, and confirm
   the debug log reports buffered replay and the phrase appears exactly once after recovery.
-- Choose **Stop Jarvis** and confirm no later transcription or coaching events are produced.
+- Choose **Stop Jarvis** and confirm Activity ends with `session ended by user`, with no later
+  transcription or coaching events.
 - In Activity, choose the stopped session and click **Evaluate**. Confirm the button shows
   **Evaluating…**, the report opens when the agent finishes, and the button then shows **Open report**.


### PR DESCRIPTION
## Summary

- record exactly one typed `sessionEnded` Activity row for every live teardown, including manual Stop, app quit, session replacement, and terminal runtime failures
- distinguish allocated startup resources from a successfully started live session, so a cold-start capture failure tears down cleanly without inventing a session-end row
- make `sessionEnded` terminal within the Activity queue so canceled coaching work cannot append after it; canceled `stay_silent` work also checks cancellation at the action boundary
- keep an end-only run out of past coaching history while retaining the end row when browsing a contentful session
- carry sanitized end reasons through `UserFacingError` and `ErrorReporter`, while keeping raw diagnostics in `jarvis-debug.log`
- use only the current `sessionEnded` event and `session ended …` evaluator vocabulary; no compatibility guidance for pre-change development builds
- consolidate each Activity event's persisted kind, human-facing copy, and screenshot payload into one exhaustive mapping
- align the repository and Activity-viewer documentation with the fixed end-outcome boundary

## Root cause

`AppDelegate.stop()` only emitted a debug-log lifecycle message. Terminal failures wrote Activity rows at disparate call sites, while a manual Stop never wrote one at all. That left the normal user-driven teardown invisible and made duplicate or mismatched terminal events possible.

Startup also allocated transcribers before audio capture proved the session had started. Treating allocation as liveness could therefore record a terminal Activity row for a failed cold start. The app now tracks successful capture startup separately from provisional resources.

Because Activity writes and turn cancellation are asynchronous, teardown also needed an explicit terminal boundary: after `sessionEnded` reaches the serial Activity queue, later events for that session are discarded. Session history separately treats the end marker as visible context, not as coaching content by itself.

## Validation

- `swift build`
- `./scripts/run-tests.sh --filter AgenticEvaluationTests` — 9 tests passed
- `./scripts/run-tests.sh --filter ActivityLogTests` — 16 tests passed
- `./scripts/run-tests.sh --filter SessionStoreTests` — 8 tests passed
- `./scripts/run-tests.sh --filter CoachDriverPipelineTests` — 68 tests passed
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — 536 tests in 60 suites passed; the opt-in live capture test was skipped as expected

The parallel full run reproduced the documented `OverlayInvisibilityTests` AppKit timing flake. Its isolated suite passed 18/18, and the final full suite passed cleanly in the documented serial mode.