### PR TITLE
perf(brain): prewarm the first Codex thread

### DIFF
--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
@@ -3,9 +3,9 @@ import Foundation
 /// Subscription-backed brain client over a provider-native persistent local-agent runtime.
 ///
 /// Claude uses a preinitialized, single-use query lease with one replacement kept ready. Codex uses
-/// one session-scoped app-server and a fresh ephemeral thread per coaching attempt. Neither provider
-/// has a one-shot coaching fallback: runtime failure is a failed provider attempt and is handled by
-/// the ordered route.
+/// one session-scoped app-server, prewarms its first target-specific ephemeral thread, and opens a
+/// fresh thread for each later coaching attempt. Neither provider has a one-shot coaching fallback:
+/// runtime failure is a failed provider attempt and is handled by the ordered route.
 public struct CLIBrainClient: BrainClient, Sendable {
     let provider: BrainProvider
     let traffic: BrainTrafficLog?

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-/// One Codex app-server for the live Jarvis session. Each coaching attempt gets a fresh ephemeral
-/// thread; every model turn in that attempt stays on the thread and receives only incremental input.
+/// One Codex app-server for the live Jarvis session. Session Start prepares the first target-specific
+/// ephemeral thread; each later coaching attempt gets another fresh thread. Every model turn in an
+/// attempt stays on its thread and receives only incremental input.
 ///
 /// Codex exposes no control that removes every built-in tool (`codex app-server --help` and the
 /// generated `ThreadStartParams` schema on 0.145.0 have no such flag or field), so isolation is the
@@ -26,9 +27,19 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         "reasoning",
     ]
 
-    private struct Preparation: Sendable {
+    private struct ServerPreparation: Sendable {
         let id: UUID
         let task: Task<CodexAppServer, Error>
+    }
+
+    private struct PreparedThread: Sendable {
+        let id: String
+        let configuration: LocalAgentConversationConfiguration
+    }
+
+    private struct ThreadPreparation: Sendable {
+        let id: UUID
+        let task: Task<PreparedThread, Error>
     }
 
     fileprivate struct LaunchIdentity: Equatable {
@@ -42,7 +53,9 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     private let lifetime = AgentRuntimeLifetime()
     private var identity: LaunchIdentity?
     private var server: CodexAppServer?
-    private var preparing: Preparation?
+    private var preparingServer: ServerPreparation?
+    private var preparedThread: PreparedThread?
+    private var preparingThread: ThreadPreparation?
     private var nextRequestID = 0
     private var activeThreadID: String?
 
@@ -55,6 +68,13 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     }
 
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws {
+        let preparedServer = try await prepareServer(for: configuration)
+        try await prepareThread(for: configuration, server: preparedServer)
+    }
+
+    private func prepareServer(
+        for configuration: LocalAgentConversationConfiguration
+    ) async throws -> CodexAppServer {
         guard configuration.provider == .codexCLI else {
             preconditionFailure("CodexAppServerRuntime received \(configuration.provider)")
         }
@@ -67,13 +87,16 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         }
         identity = requested
         if let server, server.isRunning {
-            return
+            return server
         }
         server = nil
-        if preparing == nil {
+        preparedThread = nil
+        preparingThread = nil
+        activeThreadID = nil
+        if preparingServer == nil {
             let lifetime = self.lifetime
             let runtimeBaseDirectory = self.runtimeBaseDirectory
-            preparing = Preparation(
+            preparingServer = ServerPreparation(
                 id: UUID(),
                 task: Task.detached(priority: .utility) {
                     try await CodexAppServer.start(
@@ -83,96 +106,104 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                         lifetime: lifetime)
                 })
         }
-        guard let preparation = preparing else {
+        guard let preparation = preparingServer else {
             throw Self.error("Codex app-server preparation was unavailable")
         }
         do {
-            let preparedServer = try await awaitPreparation(preparation)
-            if preparing?.id == preparation.id {
+            let preparedServer = try await awaitServerPreparation(preparation)
+            if preparingServer?.id == preparation.id {
                 server = preparedServer
-                preparing = nil
+                preparingServer = nil
             }
+            return preparedServer
         } catch {
-            if preparing?.id == preparation.id {
-                preparing = nil
+            if preparingServer?.id == preparation.id {
+                preparingServer = nil
             }
             throw error
+        }
+    }
+
+    private func prepareThread(
+        for configuration: LocalAgentConversationConfiguration,
+        server: CodexAppServer
+    ) async throws {
+        while true {
+            guard activeThreadID == nil else { return }
+            if let preparedThread, preparedThread.configuration == configuration {
+                return
+            }
+
+            if let preparation = preparingThread {
+                do {
+                    let thread = try await awaitThreadPreparation(preparation)
+                    // Background prewarm and the first attempt may await the same task. Only the
+                    // first resumed waiter may install it.
+                    if preparingThread?.id == preparation.id {
+                        preparedThread = thread
+                        preparingThread = nil
+                    }
+                } catch {
+                    if preparingThread?.id == preparation.id {
+                        preparingThread = nil
+                    }
+                    invalidate(server)
+                    throw error
+                }
+                continue
+            }
+
+            let staleThread = preparedThread
+            preparedThread = nil
+            let cleanupRequestID = staleThread.map { _ in takeRequestID() }
+            let startRequestID = takeRequestID()
+            let supportedFeatures = self.supportedFeatures
+            preparingThread = ThreadPreparation(
+                id: UUID(),
+                task: Task.detached(priority: .utility) {
+                    if let staleThread, let cleanupRequestID {
+                        try await Self.unsubscribe(
+                            threadID: staleThread.id,
+                            server: server,
+                            requestID: cleanupRequestID)
+                    }
+                    return try await Self.startThread(
+                        for: configuration,
+                        server: server,
+                        requestID: startRequestID,
+                        supportedFeatures: supportedFeatures)
+                })
         }
     }
 
     func openConversation(for configuration: LocalAgentConversationConfiguration)
         async throws -> any LocalAgentConversation {
         try await prepare(for: configuration)
-        guard let server else { throw Self.error("Codex app-server was not ready") }
+        guard let server, server.isRunning else {
+            throw Self.error("Codex app-server was not ready")
+        }
         guard activeThreadID == nil else {
             throw Self.error("Codex app-server already has an active coaching conversation")
         }
-        do {
-            let requestID = takeRequestID()
-            let deadline = Date().addingTimeInterval(configuration.timeout)
-            var config: [String: Any] = [
-                "mcp_servers": [:],
-                "project_root_markers": [],
-                "project_doc_max_bytes": 0,
-                "model_reasoning_effort":
-                    CLIBrainClient.codexEffort(configuration.reasoningEffort),
-            ]
-            // `--disable <name>` is documented as equivalent to `-c features.<name>=false`, and
-            // openai/codex#21952 reports the launch flag not reaching the app-server's tool builder.
-            // Deliver the same disable set through the per-thread config override as well, so the
-            // deny-list `codex exec` coaching relied on is not silently inert here.
-            if !Self.disabledFeatures(advertised: supportedFeatures).isEmpty {
-                config["features"] = Self.disabledFeatures(advertised: supportedFeatures)
-            }
-            var parameters: [String: Any] = [
-                "cwd": configuration.workDirectory.path,
-                "approvalPolicy": "never",
-                "sandbox": "read-only",
-                "ephemeral": true,
-                "baseInstructions": CLIBrainClient.codexDirectResponseInstruction
-                    + "\n\n" + configuration.instructions,
-                "config": config,
-            ]
-            if !configuration.model.isEmpty {
-                parameters["model"] = configuration.model
-            }
-            try await server.send(
-                method: "thread/start",
-                parameters: parameters,
-                id: requestID,
-                timeout: max(0.01, deadline.timeIntervalSinceNow))
-            let result = try await waitForResponse(
-                id: requestID,
-                server: server,
-                deadline: deadline)
-            guard let thread = result["thread"] as? [String: Any],
-                  let threadID = thread["id"] as? String else {
-                throw Self.error("Codex thread/start returned no thread")
-            }
-            let instructionSources = result["instructionSources"] as? [Any] ?? []
-            guard thread["ephemeral"] as? Bool == true,
-                  thread["path"] == nil || thread["path"] is NSNull,
-                  instructionSources.isEmpty else {
-                throw Self.error(
-                    "Codex returned a non-ephemeral or instruction-loaded thread: "
-                    + Self.jsonDescription(result))
-            }
-            activeThreadID = threadID
-            return CodexAppServerConversation(
-                runtime: self,
-                threadID: threadID,
-                configuration: configuration)
-        } catch {
+        guard let thread = preparedThread, thread.configuration == configuration else {
             invalidate(server)
-            throw error
+            throw Self.error("Codex target thread was not ready")
         }
+        preparedThread = nil
+        activeThreadID = thread.id
+        return CodexAppServerConversation(
+            runtime: self,
+            threadID: thread.id,
+            configuration: configuration)
     }
 
     nonisolated func terminateNow() {
         lifetime.terminateAll()
     }
 
-    private func awaitPreparation(_ preparation: Preparation) async throws -> CodexAppServer {
+    private func awaitServerPreparation(
+        _ preparation: ServerPreparation
+    ) async throws -> CodexAppServer {
         let lifetime = self.lifetime
         return try await withTaskCancellationHandler {
             try await preparation.task.value
@@ -180,6 +211,97 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
             preparation.task.cancel()
             lifetime.terminateAll()
         }
+    }
+
+    private func awaitThreadPreparation(
+        _ preparation: ThreadPreparation
+    ) async throws -> PreparedThread {
+        let lifetime = self.lifetime
+        return try await withTaskCancellationHandler {
+            try await preparation.task.value
+        } onCancel: {
+            preparation.task.cancel()
+            lifetime.terminateAll()
+        }
+    }
+
+    private static func startThread(
+        for configuration: LocalAgentConversationConfiguration,
+        server: CodexAppServer,
+        requestID: Int,
+        supportedFeatures: Set<String>
+    ) async throws -> PreparedThread {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        let deadline = Date().addingTimeInterval(configuration.timeout)
+        var config: [String: Any] = [
+            "mcp_servers": [:],
+            "project_root_markers": [],
+            "project_doc_max_bytes": 0,
+            "model_reasoning_effort":
+                CLIBrainClient.codexEffort(configuration.reasoningEffort),
+        ]
+        // `--disable <name>` is documented as equivalent to `-c features.<name>=false`, and
+        // openai/codex#21952 reports the launch flag not reaching the app-server's tool builder.
+        // Deliver the same disable set through the per-thread config override as well, so the
+        // deny-list `codex exec` coaching relied on is not silently inert here.
+        let disabledFeatures = disabledFeatures(advertised: supportedFeatures)
+        if !disabledFeatures.isEmpty {
+            config["features"] = disabledFeatures
+        }
+        var parameters: [String: Any] = [
+            "cwd": configuration.workDirectory.path,
+            "approvalPolicy": "never",
+            "sandbox": "read-only",
+            "ephemeral": true,
+            "baseInstructions": CLIBrainClient.codexDirectResponseInstruction
+                + "\n\n" + configuration.instructions,
+            "config": config,
+        ]
+        if !configuration.model.isEmpty {
+            parameters["model"] = configuration.model
+        }
+        try await server.send(
+            method: "thread/start",
+            parameters: parameters,
+            id: requestID,
+            timeout: max(0.01, deadline.timeIntervalSinceNow))
+        let result = try await waitForResponse(
+            id: requestID,
+            server: server,
+            deadline: deadline)
+        guard let thread = result["thread"] as? [String: Any],
+              let threadID = thread["id"] as? String else {
+            throw error("Codex thread/start returned no thread")
+        }
+        let instructionSources = result["instructionSources"] as? [Any] ?? []
+        guard thread["ephemeral"] as? Bool == true,
+              thread["path"] == nil || thread["path"] is NSNull,
+              instructionSources.isEmpty else {
+            throw error(
+                "Codex returned a non-ephemeral or instruction-loaded thread: "
+                + jsonDescription(result))
+        }
+        let readyMs = Int(
+            (DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000)
+        jlog("Jarvis: Codex target thread ready in \(readyMs)ms")
+        return PreparedThread(id: threadID, configuration: configuration)
+    }
+
+    private static func unsubscribe(
+        threadID: String,
+        server: CodexAppServer,
+        requestID: Int
+    ) async throws {
+        let deadline = Date().addingTimeInterval(threadCleanupTimeout)
+        try await server.send(
+            method: "thread/unsubscribe",
+            parameters: ["threadId": threadID],
+            id: requestID,
+            timeout: max(0.01, deadline.timeIntervalSinceNow))
+        _ = try await waitForResponse(
+            id: requestID,
+            server: server,
+            deadline: deadline)
     }
 
     fileprivate func respond(
@@ -303,23 +425,17 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         guard let server, server.isRunning else { return }
         do {
             let requestID = takeRequestID()
-            let deadline = Date().addingTimeInterval(Self.threadCleanupTimeout)
-            try await server.send(
-                method: "thread/unsubscribe",
-                parameters: ["threadId": threadID],
-                id: requestID,
-                timeout: max(0.01, deadline.timeIntervalSinceNow))
-            _ = try await waitForResponse(
-                id: requestID,
+            try await Self.unsubscribe(
+                threadID: threadID,
                 server: server,
-                deadline: deadline)
+                requestID: requestID)
         } catch {
             jlog("Jarvis: Codex thread unsubscribe failed: \(error.localizedDescription)")
             invalidate(server)
         }
     }
 
-    private func waitForResponse(
+    private static func waitForResponse(
         id: Int,
         server: CodexAppServer,
         deadline: Date
@@ -350,8 +466,11 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
 
     private func invalidate(_ server: CodexAppServer) {
         guard self.server === server else { return }
+        preparingThread?.task.cancel()
         server.finish()
         self.server = nil
+        preparedThread = nil
+        preparingThread = nil
         activeThreadID = nil
     }
 

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
@@ -22,6 +22,52 @@ import Testing
         try await assertCancellingPreparationStopsProcess(provider: .codexCLI)
     }
 
+    @Test func cancellingCodexThreadPreparationStopsTheAppServer() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("pid")
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "blocked-codex-thread",
+            script: """
+                #!/bin/sh
+                printf '%s\\n' "$$" > '\(shellQuoted(pidFile.path))'
+                while IFS= read -r line; do
+                  printf 'input: %s\\n' "$line" >> '\(shellQuoted(trace.path))'
+                  request_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
+                  method=$(printf '%s' "$line" | sed -n 's/.*"method":"\\([^"]*\\)".*/\\1/p' | tr -d '\\\\')
+                  if [ "$method" = "initialize" ]; then
+                    printf '{"id":%s,"result":{}}\\n' "$request_id"
+                  fi
+                done
+                """)
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let client = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: false)
+        let task = Task {
+            try await client.makeConversation()
+        }
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+        let pid = try #require(
+            pid_t(String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+
+        task.cancel()
+        let result = await task.result
+        guard case .failure(let error) = result else {
+            Issue.record("expected cancelled Codex thread preparation")
+            return
+        }
+        #expect(error is CancellationError)
+        try await waitForProcessExit(pid)
+        #expect(kill(pid, 0) == -1)
+    }
+
     @Test func claudeInitializationSkipsMalformedOutput() async throws {
         let directory = try makeWorkDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -89,6 +135,101 @@ import Testing
         let conversation = try await client.makeConversation()
         await conversation.finish()
         runtime.terminateNow()
+    }
+
+    @Test func codexPrewarmsAndLeasesTheFirstTargetThread() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(trace: trace, threadResult: Self.ephemeralThreadResult))
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let client = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: true)
+
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+        #expect(requests(method: "turn/start", in: trace).isEmpty)
+
+        let first = try await client.makeConversation()
+        #expect(requests(method: "thread/start", in: trace).count == 1)
+        await first.finish()
+
+        let second = try await client.makeConversation()
+        #expect(requests(method: "thread/start", in: trace).count == 2)
+        await second.finish()
+        runtime.terminateNow()
+    }
+
+    @Test func codexReplacesAPrewarmedThreadForAnotherTargetConfiguration() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(trace: trace, threadResult: Self.ephemeralThreadResult))
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let firstTarget = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: true)
+        _ = firstTarget
+        let replacementTarget = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: false,
+            systemPrompt: "replacement coach prompt")
+
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+        let replacement = try await replacementTarget.makeConversation()
+        #expect(requests(method: "thread/start", in: trace).count == 2)
+        #expect(requests(method: "thread/unsubscribe", in: trace).count == 1)
+        await replacement.finish()
+        runtime.terminateNow()
+    }
+
+    @Test func releasingPreparedCodexRuntimeStopsItsSessionProcess() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pidFile = directory.appendingPathComponent("pid")
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(
+                pidFile: pidFile,
+                trace: trace,
+                threadResult: Self.ephemeralThreadResult))
+        var runtime: CLIBrainRuntime? = makeRuntime(
+            provider: .codexCLI,
+            directory: directory)
+        var client: CLIBrainClient? = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: try #require(runtime),
+            prewarm: true)
+        _ = client
+
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+        let pid = try #require(
+            pid_t(String(contentsOf: pidFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)))
+
+        client = nil
+        runtime = nil
+        try await waitForProcessExit(pid)
+        #expect(kill(pid, 0) == -1)
     }
 
     @Test func claudeLaunchUsesOAuthCompatibleCustomizationAndToolIsolation() async throws {
@@ -505,15 +646,19 @@ import Testing
     /// with a single `stay_silent` agent message.
     private func codexScript(
         argumentsFile: URL? = nil,
+        pidFile: URL? = nil,
         trace: URL,
         threadResult: String
     ) -> String {
         let recordArguments = argumentsFile.map {
             "printf 'arg=<%s>\\n' \"$@\" > '\(shellQuoted($0.path))'\n"
         } ?? ""
+        let recordPID = pidFile.map {
+            "printf '%s\\n' \"$$\" > '\(shellQuoted($0.path))'\n"
+        } ?? ""
         return """
             #!/bin/sh
-            \(recordArguments)while IFS= read -r line; do
+            \(recordPID)\(recordArguments)while IFS= read -r line; do
               printf 'input: %s\\n' "$line" >> '\(shellQuoted(trace.path))'
               request_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
               method=$(printf '%s' "$line" | sed -n 's/.*"method":"\\([^"]*\\)".*/\\1/p' | tr -d '\\\\')
@@ -613,6 +758,21 @@ import Testing
             try await Task.sleep(nanoseconds: 20_000_000)
         }
         Issue.record("timed out waiting for \(expected) launches")
+    }
+
+    private func waitForRequestCount(
+        _ expected: Int,
+        method: String,
+        in trace: URL
+    ) async throws {
+        let deadline = Date().addingTimeInterval(3)
+        while Date() < deadline {
+            if requests(method: method, in: trace).count >= expected {
+                return
+            }
+            try await Task.sleep(nanoseconds: 20_000_000)
+        }
+        Issue.record("timed out waiting for \(expected) \(method) requests")
     }
 
     private func waitForProcessExit(_ pid: pid_t) async throws {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -133,7 +133,7 @@ plugins ship only with full Xcode, and Jarvis builds **CLT-only** (see
 | **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` decides the lifecycle consequence; an explicit startup/runtime context decides presentation. Startup failures may alert, but runtime failures never activate Jarvis or present UI even when they stop the session. `BrainFailure` feeds attempt outcomes into the finite provider route; only route exhaustion enters terminal reporting. Fixed, typed Activity outcomes carry stable on-disk identities while raw detail stays in `JarvisLog`. | AppKit (`NSAlert`) for startup only. |
 | **Transcriber** | Maintain a rolling, speaker-labeled, **spoken-time timestamped** transcript; emit speech-activity, turn-end, and backing-off silence events (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript. A per-`item_id` ledger reconciles out-of-order delta/completed/failed/VAD events and salvages streamed text. An utterance-local failure with no usable words stays diagnostic and cannot trigger the brain; a permanent account or configuration rejection stops the unusable session with a fixed Activity reason. A privacy-preserving continuity witness records content-free capture/delivery/socket/server checkpoints and locally derived activity intervals, so the session log can locate a future gap without retaining PCM or adding pseudo-speech to model context. A socket is ready only after the server acknowledges its configuration; active ping/pong probes, send/receive errors, and startup timeouts all drive the same reconnect path. | `gpt-4o-transcribe` (Realtime API; tuned `server_vad`). |
 | **CoachDriver** | Coordinate one single-flighted coaching attempt from a natural trigger or pending-work wake-up: snapshot one route target plus the latest conversation, route its tool calls, commit only a complete terminal action, and report one outcome to the scheduler. No speaking cooldown/rate cap — restraint is the model's; the only client-side content skip is the filler-only turn-end gate (`TurnSubstance`). | The selected OpenAI Responses API, Claude Code, or Codex route target; See [§4 Local CLI brain providers](#local-cli-brain-providers). Provider-specific summary tiers are defined in `BrainModelCatalog`. |
-| **Local agent runtime** | Keep provider startup outside the coaching latency path while preserving the attempt boundary: a `BrainConversation` lease owns every model turn in one attempt, including a `capture_screen` continuation, then is explicitly finished. Claude leases one initialized safe-mode query; Codex opens a fresh ephemeral thread on one session-scoped app-server. A runtime failure fails the attempt; it never switches to a one-shot transport. | Claude Code stream-json control protocol; Codex app-server JSON-RPC over stdio. |
+| **Local agent runtime** | Keep provider startup outside the coaching latency path while preserving the attempt boundary: a `BrainConversation` lease owns every model turn in one attempt, including a `capture_screen` continuation, then is explicitly finished. Claude leases one initialized safe-mode query; Codex prepares the first target-specific ephemeral thread at Session Start and opens a fresh thread for each later attempt on one session-scoped app-server. A runtime failure fails the attempt; it never switches to a one-shot transport. | Claude Code stream-json control protocol; Codex app-server JSON-RPC over stdio. |
 | **ScreenTool** | Fulfill `capture_screen`: silently shoot the **active window** (default scope) — the window-server frontmost, on whichever display, clean even when partially covered — and attach an **on-device OCR** of the shot to the tool result so the model reads exact text instead of pixels. Falls back to a full-display capture (no OCR) — the Settings-chosen display in Entire-display scope, the main display when no window is eligible; the overlay window is excluded either way. See [settings-window.md](./settings-window.md#capture-scope). | macOS `screencapture` CLI + Apple Vision (`VNRecognizeTextRequest`). |
 | **Overlay Caption** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. Switchable from Settings — **off by default**; when off, tips are suppressed. | AppKit NSPanel; `OverlayCaptionPanel`. |
 | **Overlay Box** | A persistent window logging every `speak` tip in full, timestamped — the scrollable history of what the caption flashed one line at a time. Movable, resizable, opaque, also excluded from capture; switched on/off from Settings (**on by default**), cleared on each Start. Fed by the same `speak` call as the caption via **`BroadcastOverlay`**, which fans one `OverlayRendering.render` out to both sinks (so `CoachDriver` is unchanged). | AppKit NSPanel; `OverlayBoxPanel`. |
@@ -364,10 +364,13 @@ provider-route policy, and traffic recording are unchanged — only the transpor
   to one async closure and its teardown stops tracking a group when the leader is gone, so adopting
   it would retain these wrappers while adding a dependency.
 - **Codex keeps one app-server for the session.** Session Start launches a single `codex app-server`
-  under a private owner-only `CODEX_HOME` containing nothing but an `auth.json` symlink, so no user
-  config, profile, plugin, prompt, or `.rules` file can be loaded. Each coaching attempt opens a
-  fresh ephemeral thread and closes it when the lease ends, which is why coach and summarizer can
-  share one runtime: model, prompt, and effort travel per `thread/start`, not in the launch identity.
+  under a private owner-only `CODEX_HOME` containing nothing but an `auth.json` symlink, then prepares
+  the first target-specific ephemeral thread while transcription connects. The first coaching
+  attempt leases that verified thread; each later attempt opens a fresh one and closes it when the
+  lease ends. Coach and summarizer can share one runtime because model, prompt, and effort travel per
+  `thread/start`, not in the launch identity. A changed target configuration replaces any unused
+  prepared thread before opening its own, and releasing the session or route runtime terminates the
+  app-server and every prepared, active, or preparing thread.
   The isolation goal is to exclude user/project customization, constrain side effects, and reject
   provider-native actions outside Jarvis's coaching contract; the concrete launch and per-thread
   settings live in
@@ -413,14 +416,29 @@ provider-route policy, and traffic recording are unchanged — only the transpor
   guarantee. The durable invariant is that provider startup is removed from the attempt path and a
   capture continuation does not replay the full client-managed history.
 
+  A target-thread-prewarm A/B against the merged persistent-runtime implementation used the same
+  production `CLIBrainClient`, real signed-in Codex model, deterministic instructions, low effort,
+  and a 1.5-second Session Start prewarm window. All 16 attempts (22 model turns) completed with the
+  expected action:
+
+  | Codex attempt | App-server-only p50 (range) | Target-thread prewarm p50 (range) | p50 saved | Improvement |
+  |---|---:|---:|---:|---:|
+  | Text-only, one turn (`n=5`) | 7,970 ms (7,225–9,091) | 7,121 ms (5,527–10,275) | 849 ms | 10.7% |
+  | Capture continuation, two turns (`n=3`) | 11,148 ms (9,946–13,190) | 7,382 ms (7,071–9,837) | 3,766 ms | 33.8% |
+
+  Across all eight attempts per revision, median conversation-open latency fell from 2,269 ms to
+  713 ms (68.6%). The first target-thread preparation itself varied from 1,950–5,070 ms, so a trigger
+  after the controlled 1.5-second window sometimes still waited for completion; the overlapping
+  text-only ranges remain the appropriate caution against treating the p50 as a guarantee.
+
 ### Latency
 
 Target for the direct API path: **turn-end → first overlay line < 2s.** Transcription is continuous
 (no STT latency at trigger time) and most turns are text-only. Local subscription latency depends on
-the provider, model, and network. Claude keeps query startup off the attempt path; Codex keeps
-app-server startup off it. Both make a capture follow-up incremental, but neither promises the
-direct API target. The overlay reveals the already-returned lines one at a time (paced by `Config`);
-the brain response itself is not streamed to the overlay.
+the provider, model, and network. Claude keeps query startup off the attempt path; Codex begins both
+app-server and first target-thread preparation at Session Start. Both make a capture follow-up
+incremental, but neither promises the direct API target. The overlay reveals the already-returned
+lines one at a time (paced by `Config`); the brain response itself is not streamed to the overlay.
 
 ### Resilience
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -44,10 +44,11 @@ complete tool loop while preparing its replacement. It disables built-in tools, 
 session persistence, and MCP servers while preserving the user's OAuth session. Its runtime miss or
 crash fails the provider attempt; there is no one-shot CLI fallback. Stop kills ready, leased, and
 preparing process trees. Codex keeps one session-scoped app-server under a private `CODEX_HOME` and
-opens a fresh ephemeral thread per attempt, so its coach and summarizer share one runtime. Its
-read-only, never-approval, empty-MCP, feature-disable envelope matches what `codex exec` coaching
-enforced, plus verified thread ephemerality and a message/reasoning event allowlist that aborts a
-turn on any other item.
+prepares the first target-specific ephemeral thread at Session Start while transcription connects.
+The first attempt leases it; later attempts open fresh threads, so coach and summarizer share one
+runtime without crossing target configuration. Its read-only, never-approval, empty-MCP,
+feature-disable envelope matches what `codex exec` coaching enforced, plus verified thread
+ephemerality and a message/reasoning event allowlist that aborts a turn on any other item.
 Saving an API key while running also preserves those live objects: existing Realtime sockets take
 the key on their next reconnect, and an OpenAI brain update remains transactional. Audio
 route rebuilds likewise retry before declaring capture unavailable, and stale capture callbacks
@@ -75,8 +76,9 @@ disabled model/Add fallback, and Add API key), then configure multiple fallbacks
 failure-budget transition, a proven-permanent one-attempt transition, an unavailable-target skip, and
 final route exhaustion. Confirm no provider-specific tool state crosses attempts and verify a
 successful fallback remains active without changing preferences. Configure Codex as Primary and
-confirm a coaching turn completes on its app-server; then Stop and confirm neither the app-server nor
-its private runtime home survives. Then Stop the Claude smoke and confirm no query child remains. The signed-in
+confirm `jarvis-debug.log` reports the target thread ready before the first coaching request and that
+the turn completes on its app-server; then Stop and confirm neither the app-server nor its private
+runtime home survives. Then Stop the Claude smoke and confirm no query child remains. The signed-in
 Foundation-level Claude POC already verifies two turns on one native conversation; this remaining
 smoke covers app wiring, TCC, audio, and overlay presentation. Exercise one
 audio-route switch: Activity should say listening continues, the


### PR DESCRIPTION
Follow-up to #115.

## What changed

- Prewarm and verify the first target-specific ephemeral Codex thread at Session Start, alongside app-server startup.
- Lease that exact prepared thread for the first coaching attempt, while keeping every later attempt on a fresh thread.
- Replace an unused prepared thread when the target configuration changes, and terminate prepared or in-flight work when the session runtime is released.
- Add cancellation, reuse, configuration-replacement, and teardown coverage, and update the architecture/status documentation.

## Why

PR #115 moved app-server launch out of the coaching path, but its follow-up measurement showed that the first `thread/start` still cost about 2.25 seconds after a 1.5-second prewarm window. This change moves that target-specific work into Session Start without weakening the one-thread-per-attempt boundary.

## Real A/B

The benchmark used the same production `CLIBrainClient`, signed-in Codex model, deterministic instructions, low effort, and a 1.5-second Session Start prewarm window. All 16 attempts / 22 model turns completed with the expected action.

| Attempt | App-server only p50 (range) | Target-thread prewarm p50 (range) | p50 saved |
|---|---:|---:|---:|
| Text-only, one turn (n=5) | 7,970 ms (7,225–9,091) | 7,121 ms (5,527–10,275) | 849 ms (10.7%) |
| Capture continuation, two turns (n=3) | 11,148 ms (9,946–13,190) | 7,382 ms (7,071–9,837) | 3,766 ms (33.8%) |

Across all eight attempts per revision, median conversation-open latency fell from 2,269 ms to 713 ms (68.6%). Target-thread preparation varied from 1,950–5,070 ms, so the overlapping text-only ranges remain an important caveat rather than a latency guarantee.

## Validation

- `swift build`
- Focused `CLIBrainRuntimeTests`: 19 tests passed
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh`: 571 tests in 65 suites passed
- Real Codex A/B: 16 attempts / 22 model turns succeeded

The serial gate is the repository's documented recovery after the initial parallel run hit the known AppKit overlay timing flake.