### PR TITLE
perf(brain): bound local coaching latency

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -247,6 +247,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                        model: target.modelID,
                                        reasoningEffort: effort.rawValue,
                                        workDirectory: sessionDir,
+                                       timeout: CLIBrainClient.liveCoachingTimeout,
                                        traffic: sessionTraffic, trafficTag: "coach",
                                        systemPrompt: coachSystemPrompt,
                                        tools: coachTools,

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
@@ -19,6 +19,8 @@ public struct CLIBrainClient: BrainClient, Sendable {
     public static let defaultTimeout: TimeInterval = 120
     /// A silent Codex runtime stall must not batch later transcript turns for two minutes.
     public static let codexDefaultTimeout: TimeInterval = 30
+    /// Live coaching abandons a stalled local-agent turn in favor of a fresh attempt.
+    public static let liveCoachingTimeout: TimeInterval = 15
 
     public init(
         provider: BrainProvider,

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
@@ -16,6 +16,7 @@ import Testing
         replies: [String],
         tools: [ToolDef] = coachTools,
         toolChoice: ToolChoice = .required,
+        timeout: TimeInterval? = nil,
         traffic: BrainTrafficLog? = nil
     ) -> (CLIBrainClient, FakeLocalAgentRuntime) {
         let backend = FakeLocalAgentRuntime(replies: replies)
@@ -26,6 +27,7 @@ import Testing
             model: provider == .claudeCode ? "claude-sonnet-5" : "gpt-5.6-sol",
             reasoningEffort: "low",
             workDirectory: workDir,
+            timeout: timeout,
             traffic: traffic,
             trafficTag: "coach",
             systemPrompt: "coach prompt",
@@ -34,6 +36,33 @@ import Testing
             runtime: runtime,
             prewarm: false)
         return (client, backend)
+    }
+
+    @Test func liveCoachingOverrideDoesNotChangeProviderDefaults() throws {
+        let workDir = try makeWorkDir()
+        let (claudeCoach, _) = client(
+            .claudeCode,
+            workDir: workDir,
+            replies: [],
+            timeout: CLIBrainClient.liveCoachingTimeout)
+        let (codexCoach, _) = client(
+            .codexCLI,
+            workDir: workDir,
+            replies: [],
+            timeout: CLIBrainClient.liveCoachingTimeout)
+        let (defaultClaude, _) = client(.claudeCode, workDir: workDir, replies: [])
+        let (defaultCodex, _) = client(.codexCLI, workDir: workDir, replies: [])
+
+        #expect(CLIBrainClient.liveCoachingTimeout == 15)
+        #expect(claudeCoach.configuration.timeout == CLIBrainClient.liveCoachingTimeout)
+        #expect(codexCoach.configuration.timeout == CLIBrainClient.liveCoachingTimeout)
+        #expect(defaultClaude.configuration.timeout == CLIBrainClient.defaultTimeout)
+        #expect(defaultCodex.configuration.timeout == CLIBrainClient.codexDefaultTimeout)
+
+        claudeCoach.terminate()
+        codexCoach.terminate()
+        defaultClaude.terminate()
+        defaultCodex.terminate()
     }
 
     @Test func persistentRuntimeParsesStaySilent() async throws {

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -540,6 +540,8 @@
   coaching transport with Codex app-server/SDK — substantially more lifecycle and protocol surface
   when this call needs one final text object.
 - **Supersedes in part:** 2026-07-16 — Local Claude Code / Codex CLIs as alternative brain providers.
+- **Superseded in part by:** 2026-07-30 — Live local-agent coaching shares one latency deadline.
+  Provider defaults remain provider-specific; the live coach passes an explicit common deadline.
 - **Detail:** [architecture.md → Local CLI brain providers](./architecture.md#local-cli-brain-providers),
   `Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient+Invocation.swift`,
   `AgentCLIProcessRunner.swift`.
@@ -982,3 +984,20 @@
   [sandbox.md → Data Egress](./sandbox.md#data-egress),
   `Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift`,
   `Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexRuntimeHome.swift`.
+
+### 2026-07-30 — Live local-agent coaching shares one latency deadline
+
+- **Chose:** Give the live Claude Code and Codex coaching clients one explicit latency deadline.
+  Keep local-agent provider defaults unchanged for summarization and every other caller. The
+  completed-session evaluator, failure classification, fresh-attempt scheduling, observation
+  carryover, and ordered-route budgets are unchanged.
+- **Why:** In session `2026-07-30_16-41-44_687E`, five Codex turns completed in 3.1–6.6 seconds,
+  while one stalled turn reached the prior live ceiling and pushed the recovered useful answer to
+  about 45 seconds after the request. The existing fresh-attempt boundary recovered correctly; the
+  latency-sensitive overlay should stop waiting sooner without changing that recovery policy.
+- **Rejected:** (a) Lowering `CLIBrainClient` provider defaults globally — that would also change
+  summarization and other auxiliary clients. (b) Giving the two live local providers different
+  deadlines — they serve the same overlay latency contract. (c) Changing API, evaluator, routing,
+  retry, or failure semantics — the session evidence did not justify those broader changes.
+- **Detail:** `Sources/JarvisApp/App/AppDelegate.swift`,
+  `Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift`.


### PR DESCRIPTION
## Summary

- add one named 15-second deadline for live local-agent coaching
- apply it to both Claude Code and Codex coach clients
- preserve provider defaults for summarizers and every other caller
- document the role-specific timeout decision

## Why

Session `2026-07-30_16-41-44_687E` had five Codex coaching calls complete in 3.1–6.6 seconds, while one stalled call reached the prior 30-second ceiling and pushed the recovered useful answer to roughly 45 seconds after the request. The existing fresh-attempt boundary recovered correctly; this change bounds the latency-sensitive overlay wait without changing that recovery policy.

## Scope

OpenAI coaching, local-agent summarizers, completed-session evaluation, failure classification, fresh-attempt scheduling, observation carryover, and ordered-route budgets are unchanged. Provider-wide Claude and Codex defaults remain 120 and 30 seconds for non-live-coaching callers.

Provider-consistent history-compaction deadlines are tracked separately in #121.

## Validation

- `./scripts/run-tests.sh --filter CLIBrainClientTests` — 15 tests passed
- `swift build` — passed
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — 572 tests passed across 65 suites; the opt-in live ScreenCaptureKit test was skipped as expected

The initial parallel full-suite run hit the repository's known timing-sensitive overlay/runtime tests; the repository-recommended serial rerun passed cleanly.