### PR TITLE
perf(brain): bound history compaction consistently across providers

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -247,7 +247,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                        model: target.modelID,
                                        reasoningEffort: effort.rawValue,
                                        workDirectory: sessionDir,
-                                       timeout: CLIBrainClient.liveCoachingTimeout,
+                                       timeout: BrainWorkloadTimeout.liveCoaching,
                                        traffic: sessionTraffic, trafficTag: "coach",
                                        systemPrompt: coachSystemPrompt,
                                        tools: coachTools,
@@ -258,7 +258,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                         model: BrainModelCatalog.summarizerModelID(for: target.provider),
                                         reasoningEffort: ReasoningEffort.low.rawValue,
                                         workDirectory: sessionDir,
-                                        timeout: CoachDriver.historyCompactionTimeout,
+                                        timeout: BrainWorkloadTimeout.historyCompaction,
                                         traffic: sessionTraffic, trafficTag: "summarizer",
                                         systemPrompt: CoachDriver.summaryInstructions,
                                         tools: [],
@@ -269,12 +269,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             coachBase = OpenAIBrainClient(
                 apiKey: key, model: target.modelID,
                 reasoningEffort: effort.rawValue,
+                timeout: BrainWorkloadTimeout.liveCoaching,
                 maxOutputTokens: effort.maxOutputTokens,
                 traffic: sessionTraffic, trafficTag: "coach")
             summarizer = OpenAIBrainClient(
                 apiKey: key, model: BrainModelCatalog.summarizerModelID(for: .openAI),
                 reasoningEffort: ReasoningEffort.low.rawValue,
-                timeout: CoachDriver.historyCompactionTimeout, maxOutputTokens: 2_048,
+                timeout: BrainWorkloadTimeout.historyCompaction, maxOutputTokens: 2_048,
                 traffic: sessionTraffic, trafficTag: "summarizer")
         }
         return BrainRuntime(coach: coachBase, summarizer: summarizer)

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -258,6 +258,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                         model: BrainModelCatalog.summarizerModelID(for: target.provider),
                                         reasoningEffort: ReasoningEffort.low.rawValue,
                                         workDirectory: sessionDir,
+                                        timeout: CoachDriver.historyCompactionTimeout,
                                         traffic: sessionTraffic, trafficTag: "summarizer",
                                         systemPrompt: CoachDriver.summaryInstructions,
                                         tools: [],
@@ -272,7 +273,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 traffic: sessionTraffic, trafficTag: "coach")
             summarizer = OpenAIBrainClient(
                 apiKey: key, model: BrainModelCatalog.summarizerModelID(for: .openAI),
-                reasoningEffort: ReasoningEffort.low.rawValue, maxOutputTokens: 2_048,
+                reasoningEffort: ReasoningEffort.low.rawValue,
+                timeout: CoachDriver.historyCompactionTimeout, maxOutputTokens: 2_048,
                 traffic: sessionTraffic, trafficTag: "summarizer")
         }
         return BrainRuntime(coach: coachBase, summarizer: summarizer)

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
@@ -15,20 +15,13 @@ public struct CLIBrainClient: BrainClient, Sendable {
     let runtime: CLIBrainRuntime
     private let runtimeLease: CLIBrainRuntime.Lease
 
-    /// A local agent turn's remote inference still needs a generous hang backstop.
-    public static let defaultTimeout: TimeInterval = 120
-    /// A silent Codex runtime stall must not batch later transcript turns for two minutes.
-    public static let codexDefaultTimeout: TimeInterval = 30
-    /// Live coaching abandons a stalled local-agent turn in favor of a fresh attempt.
-    public static let liveCoachingTimeout: TimeInterval = 15
-
     public init(
         provider: BrainProvider,
         executable: URL,
         model: String,
         reasoningEffort: String = ReasoningEffort.default.rawValue,
         workDirectory: URL,
-        timeout: TimeInterval? = nil,
+        timeout: TimeInterval = BrainWorkloadTimeout.liveCoaching,
         traffic: BrainTrafficLog? = nil,
         trafficTag: String = "coach",
         systemPrompt: String,
@@ -51,8 +44,7 @@ public struct CLIBrainClient: BrainClient, Sendable {
             reasoningEffort: reasoningEffort,
             workDirectory: workDirectory,
             instructions: instructions,
-            timeout: timeout ?? (provider == .codexCLI
-                                 ? Self.codexDefaultTimeout : Self.defaultTimeout))
+            timeout: timeout)
         self.provider = provider
         self.traffic = traffic
         self.trafficTag = trafficTag
@@ -66,10 +58,23 @@ public struct CLIBrainClient: BrainClient, Sendable {
     }
 
     public func makeConversation() async throws -> any BrainConversation {
+        let deadline = Date().addingTimeInterval(configuration.timeout)
+        return try await makeConversation(openDeadline: deadline, responseDeadline: nil)
+    }
+
+    private func makeConversation(
+        openDeadline: Date,
+        responseDeadline: Date?
+    ) async throws -> any BrainConversation {
         let openEntered = DispatchTime.now().uptimeNanoseconds
         do {
-            let transport = try await runtime.openConversation(for: configuration)
-            return CLIBrainConversation(client: self, transport: transport)
+            let transport = try await runtime.openConversation(
+                for: configuration,
+                deadline: openDeadline)
+            return CLIBrainConversation(
+                client: self,
+                transport: transport,
+                responseDeadline: responseDeadline)
         } catch {
             if Task.isCancelled || error is CancellationError { throw error }
             recordFailure(error, requestRecord: nil, respondEntered: openEntered)
@@ -86,10 +91,14 @@ public struct CLIBrainClient: BrainClient, Sendable {
     }
 
     /// Auxiliary callers such as memory compaction still use the simple `respond` surface. It opens
-    /// and closes a provider-native conversation; it never falls back to a per-turn command.
+    /// and closes a provider-native conversation under one setup-plus-inference deadline; it never
+    /// falls back to a per-turn command.
     public func respond(messages: [ChatMessage], tools: [ToolDef],
                         toolChoice: ToolChoice) async throws -> BrainResponse {
-        let conversation = try await makeConversation()
+        let deadline = Date().addingTimeInterval(configuration.timeout)
+        let conversation = try await makeConversation(
+            openDeadline: deadline,
+            responseDeadline: deadline)
         do {
             let response = try await conversation.respond(
                 messages: messages, tools: tools, toolChoice: toolChoice)
@@ -105,7 +114,8 @@ public struct CLIBrainClient: BrainClient, Sendable {
         messages: [ChatMessage],
         previousMessageIdentities: [MessageIdentity],
         tools: [ToolDef],
-        toolChoice: ToolChoice
+        toolChoice: ToolChoice,
+        timeout: TimeInterval? = nil
     ) throws -> (turn: LocalAgentTurn, requestRecord: Data, identities: [MessageIdentity]) {
         let identities = messages.map(MessageIdentity.init)
         let isFirst = previousMessageIdentities.isEmpty
@@ -176,7 +186,7 @@ public struct CLIBrainClient: BrainClient, Sendable {
             "input": auditInput,
         ]
         return (
-            LocalAgentTurn(input: input, timeout: configuration.timeout),
+            LocalAgentTurn(input: input, timeout: timeout ?? configuration.timeout),
             Self.recordData(record),
             identities)
     }
@@ -304,17 +314,33 @@ public struct CLIBrainClient: BrainClient, Sendable {
         NSError(domain: "CLIBrainClient", code: code,
                 userInfo: [NSLocalizedDescriptionKey: message])
     }
+
+    static func timeoutError(seconds: TimeInterval) -> NSError {
+        NSError(
+            domain: "CLIBrainClient",
+            code: NSURLErrorTimedOut,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "local agent request timed out after \(seconds)s",
+            ])
+    }
 }
 
 private actor CLIBrainConversation: BrainConversation {
     let client: CLIBrainClient
     let transport: any LocalAgentConversation
+    let responseDeadline: Date?
     var previousMessageIdentities: [CLIBrainClient.MessageIdentity] = []
     var isFinished = false
 
-    init(client: CLIBrainClient, transport: any LocalAgentConversation) {
+    init(
+        client: CLIBrainClient,
+        transport: any LocalAgentConversation,
+        responseDeadline: Date?
+    ) {
         self.client = client
         self.transport = transport
+        self.responseDeadline = responseDeadline
     }
 
     func respond(messages: [ChatMessage], tools: [ToolDef],
@@ -325,11 +351,23 @@ private actor CLIBrainConversation: BrainConversation {
         let respondEntered = DispatchTime.now().uptimeNanoseconds
         var requestRecord: Data?
         do {
+            let remainingTimeout: TimeInterval?
+            if let responseDeadline {
+                let remaining = responseDeadline.timeIntervalSinceNow
+                guard remaining >= 0.01 else {
+                    throw CLIBrainClient.timeoutError(
+                        seconds: client.configuration.timeout)
+                }
+                remainingTimeout = remaining
+            } else {
+                remainingTimeout = nil
+            }
             let prepared = try client.prepareTurn(
                 messages: messages,
                 previousMessageIdentities: previousMessageIdentities,
                 tools: tools,
-                toolChoice: toolChoice)
+                toolChoice: toolChoice,
+                timeout: remainingTimeout)
             requestRecord = prepared.requestRecord
             previousMessageIdentities = prepared.identities
             let result = try await transport.respond(to: prepared.turn)

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainRuntime.swift
@@ -35,7 +35,10 @@ protocol LocalAgentConversation: Sendable {
 
 protocol LocalAgentRuntimeBackend: Sendable {
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws
-    func openConversation(for configuration: LocalAgentConversationConfiguration)
+    func openConversation(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    )
         async throws -> any LocalAgentConversation
     func terminateNow()
 }
@@ -136,9 +139,12 @@ public final class CLIBrainRuntime: @unchecked Sendable {
         }
     }
 
-    func openConversation(for configuration: LocalAgentConversationConfiguration)
+    func openConversation(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    )
         async throws -> any LocalAgentConversation {
-        try await backend.openConversation(for: configuration)
+        try await backend.openConversation(for: configuration, deadline: deadline)
     }
 
     func terminateNow() {

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/ClaudeCode/ClaudeCodeRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/ClaudeCode/ClaudeCodeRuntime.swift
@@ -15,6 +15,15 @@ actor ClaudeCodeRuntime: LocalAgentRuntimeBackend {
     private var preparing: Preparation?
 
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws {
+        try await prepare(
+            for: configuration,
+            deadline: Date().addingTimeInterval(configuration.timeout))
+    }
+
+    private func prepare(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    ) async throws {
         guard configuration.provider == .claudeCode else {
             preconditionFailure("ClaudeCodeRuntime received \(configuration.provider)")
         }
@@ -26,7 +35,7 @@ actor ClaudeCodeRuntime: LocalAgentRuntimeBackend {
             return
         }
         ready = nil
-        startPreparationIfNeeded(configuration)
+        startPreparationIfNeeded(configuration, deadline: deadline)
         guard let preparation = preparing else {
             throw Self.error("Claude warm-query preparation was unavailable")
         }
@@ -46,9 +55,12 @@ actor ClaudeCodeRuntime: LocalAgentRuntimeBackend {
         }
     }
 
-    func openConversation(for configuration: LocalAgentConversationConfiguration)
+    func openConversation(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    )
         async throws -> any LocalAgentConversation {
-        try await prepare(for: configuration)
+        try await prepare(for: configuration, deadline: deadline)
         guard let query = ready else {
             throw Self.error("Claude warm query was not ready")
         }
@@ -61,14 +73,20 @@ actor ClaudeCodeRuntime: LocalAgentRuntimeBackend {
         lifetime.terminateAll()
     }
 
-    private func startPreparationIfNeeded(_ configuration: LocalAgentConversationConfiguration) {
+    private func startPreparationIfNeeded(
+        _ configuration: LocalAgentConversationConfiguration,
+        deadline: Date? = nil
+    ) {
         guard preparing == nil, ready == nil else { return }
         let lifetime = self.lifetime
+        let preparationDeadline = deadline
+            ?? Date().addingTimeInterval(configuration.timeout)
         preparing = Preparation(
             id: UUID(),
             task: Task.detached(priority: .utility) {
                 try await ClaudeCodeQuery.start(
                     configuration: configuration,
+                    deadline: preparationDeadline,
                     lifetime: lifetime)
             })
     }
@@ -125,6 +143,7 @@ private final class ClaudeCodeQuery: @unchecked Sendable {
     var isRunning: Bool { process.isRunning }
 
     static func start(configuration: LocalAgentConversationConfiguration,
+                      deadline: Date,
                       lifetime: AgentRuntimeLifetime) async throws -> ClaudeCodeQuery {
         var arguments = [
             "-p", "--verbose",
@@ -152,7 +171,6 @@ private final class ClaudeCodeQuery: @unchecked Sendable {
             try lifetime.register(process)
             let query = ClaudeCodeQuery(process: process, lifetime: lifetime)
             let requestID = "jarvis_initialize_\(UUID().uuidString)"
-            let deadline = Date().addingTimeInterval(configuration.timeout)
             try await process.sendJSONObject([
                 "type": "control_request",
                 "request_id": requestID,

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -26,6 +26,21 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         "agentMessage",
         "reasoning",
     ]
+    private static let terminalTurnStatuses: Set<String> = [
+        "completed",
+        "interrupted",
+        "failed",
+    ]
+
+    /// The turn exceeded its workload deadline, but Codex confirmed a scoped interrupt and terminal
+    /// turn state. The caller may retire the thread without tearing down the healthy app-server.
+    private struct RecoveredTurnTimeout: LocalizedError {
+        let seconds: TimeInterval
+
+        var errorDescription: String? {
+            "Codex turn timed out after \(seconds)s"
+        }
+    }
 
     private struct ServerPreparation: Sendable {
         let id: UUID
@@ -68,12 +83,27 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     }
 
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws {
-        let preparedServer = try await prepareServer(for: configuration)
-        try await prepareThread(for: configuration, server: preparedServer)
+        try await prepare(
+            for: configuration,
+            deadline: Date().addingTimeInterval(configuration.timeout))
+    }
+
+    private func prepare(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    ) async throws {
+        let preparedServer = try await prepareServer(
+            for: configuration,
+            deadline: deadline)
+        try await prepareThread(
+            for: configuration,
+            server: preparedServer,
+            deadline: deadline)
     }
 
     private func prepareServer(
-        for configuration: LocalAgentConversationConfiguration
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
     ) async throws -> CodexAppServer {
         guard configuration.provider == .codexCLI else {
             preconditionFailure("CodexAppServerRuntime received \(configuration.provider)")
@@ -102,7 +132,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                     try await CodexAppServer.start(
                         identity: requested,
                         runtimeBaseDirectory: runtimeBaseDirectory,
-                        timeout: configuration.timeout,
+                        deadline: deadline,
                         lifetime: lifetime)
                 })
         }
@@ -126,7 +156,8 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
 
     private func prepareThread(
         for configuration: LocalAgentConversationConfiguration,
-        server: CodexAppServer
+        server: CodexAppServer,
+        deadline: Date
     ) async throws {
         while true {
             guard activeThreadID == nil else { return }
@@ -165,20 +196,25 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                         try await Self.unsubscribe(
                             threadID: staleThread.id,
                             server: server,
-                            requestID: cleanupRequestID)
+                            requestID: cleanupRequestID,
+                            deadline: deadline)
                     }
                     return try await Self.startThread(
                         for: configuration,
                         server: server,
                         requestID: startRequestID,
-                        supportedFeatures: supportedFeatures)
+                        supportedFeatures: supportedFeatures,
+                        deadline: deadline)
                 })
         }
     }
 
-    func openConversation(for configuration: LocalAgentConversationConfiguration)
+    func openConversation(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    )
         async throws -> any LocalAgentConversation {
-        try await prepare(for: configuration)
+        try await prepare(for: configuration, deadline: deadline)
         guard let server, server.isRunning else {
             throw Self.error("Codex app-server was not ready")
         }
@@ -229,10 +265,10 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         for configuration: LocalAgentConversationConfiguration,
         server: CodexAppServer,
         requestID: Int,
-        supportedFeatures: Set<String>
+        supportedFeatures: Set<String>,
+        deadline: Date
     ) async throws -> PreparedThread {
         let startedAt = DispatchTime.now().uptimeNanoseconds
-        let deadline = Date().addingTimeInterval(configuration.timeout)
         var config: [String: Any] = [
             "mcp_servers": [:],
             "project_root_markers": [],
@@ -264,7 +300,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
             method: "thread/start",
             parameters: parameters,
             id: requestID,
-            timeout: max(0.01, deadline.timeIntervalSinceNow))
+            timeout: try remainingTimeout(until: deadline))
         let result = try await waitForResponse(
             id: requestID,
             server: server,
@@ -290,18 +326,21 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     private static func unsubscribe(
         threadID: String,
         server: CodexAppServer,
-        requestID: Int
+        requestID: Int,
+        deadline: Date? = nil
     ) async throws {
-        let deadline = Date().addingTimeInterval(threadCleanupTimeout)
+        let cleanupDeadline = min(
+            deadline ?? .distantFuture,
+            Date().addingTimeInterval(threadCleanupTimeout))
         try await server.send(
             method: "thread/unsubscribe",
             parameters: ["threadId": threadID],
             id: requestID,
-            timeout: max(0.01, deadline.timeIntervalSinceNow))
+            timeout: try remainingTimeout(until: cleanupDeadline))
         _ = try await waitForResponse(
             id: requestID,
             server: server,
-            deadline: deadline)
+            deadline: cleanupDeadline)
     }
 
     fileprivate func respond(
@@ -346,16 +385,33 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                     "effort": CLIBrainClient.codexEffort(configuration.reasoningEffort),
                 ],
                 id: requestID,
-                timeout: max(0.01, deadline.timeIntervalSinceNow))
+                timeout: try Self.remainingTimeout(until: deadline))
 
             var firstAssistantAt: UInt64?
             var completedText: String?
             var fragments: [String] = []
+            var turnID: String?
             while true {
-                let line = try await server.nextLine(deadline: deadline)
+                guard let line = try await server.nextLineBefore(deadline: deadline) else {
+                    guard let turnID else {
+                        throw Self.timeoutError(
+                            "Codex turn timed out before turn/start returned an id")
+                    }
+                    try await interruptTimedOutTurn(
+                        threadID: threadID,
+                        turnID: turnID,
+                        server: server)
+                    throw RecoveredTurnTimeout(seconds: turn.timeout)
+                }
                 guard let payload = Self.object(from: line.text) else { continue }
-                if payload["id"] as? Int == requestID, let rpcError = payload["error"] {
-                    throw Self.error("Codex turn/start failed: \(Self.jsonDescription(rpcError))")
+                if payload["id"] as? Int == requestID {
+                    if let rpcError = payload["error"] {
+                        throw Self.error(
+                            "Codex turn/start failed: \(Self.jsonDescription(rpcError))")
+                    }
+                    if let result = payload["result"] as? [String: Any] {
+                        turnID = Self.turnID(in: result) ?? turnID
+                    }
                 }
 
                 let method = payload["method"] as? String
@@ -368,6 +424,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                    notificationThread != threadID {
                     continue
                 }
+                turnID = Self.turnID(in: parameters) ?? turnID
 
                 if Self.isDisallowedItemEvent(method: method, parameters: parameters) {
                     throw Self.error(
@@ -409,9 +466,69 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                     firstAssistantAt: firstAssistantAt,
                     completedAt: completedAt)
             }
+        } catch let error as RecoveredTurnTimeout {
+            throw error
         } catch {
             invalidate(server)
             throw error
+        }
+    }
+
+    /// Recover a workload timeout at the narrowest provider scope. The server is reusable only after
+    /// both the interrupt RPC and the matching terminal turn notification are observed; otherwise
+    /// the caller invalidates it because the shared stream's state is uncertain.
+    private func interruptTimedOutTurn(
+        threadID: String,
+        turnID: String,
+        server: CodexAppServer
+    ) async throws {
+        let requestID = takeRequestID()
+        let deadline = Date().addingTimeInterval(Self.threadCleanupTimeout)
+        try await server.send(
+            method: "turn/interrupt",
+            parameters: [
+                "threadId": threadID,
+                "turnId": turnID,
+            ],
+            id: requestID,
+            timeout: try Self.remainingTimeout(until: deadline))
+
+        var acknowledged = false
+        var terminal = false
+        while !acknowledged || !terminal {
+            let line = try await server.nextLine(deadline: deadline)
+            guard let payload = Self.object(from: line.text) else { continue }
+            if Self.isServerRequest(payload) {
+                throw Self.error(
+                    "Codex emitted an unexpected server request while interrupting a turn")
+            }
+            if payload["id"] as? Int == requestID {
+                if let rpcError = payload["error"] {
+                    throw Self.error(
+                        "Codex turn/interrupt failed: \(Self.jsonDescription(rpcError))")
+                }
+                acknowledged = true
+                continue
+            }
+
+            let method = payload["method"] as? String
+            let parameters = payload["params"] as? [String: Any]
+            if let notificationThread = parameters?["threadId"] as? String,
+               notificationThread != threadID {
+                continue
+            }
+            if Self.isDisallowedItemEvent(method: method, parameters: parameters) {
+                throw Self.error(
+                    "Codex emitted a disallowed item event while interrupting a turn")
+            }
+            guard method == "turn/completed",
+                  Self.turnID(in: parameters) == turnID,
+                  let completedTurn = parameters?["turn"] as? [String: Any],
+                  let status = completedTurn["status"] as? String,
+                  Self.terminalTurnStatuses.contains(status) else {
+                continue
+            }
+            terminal = true
         }
     }
 
@@ -493,6 +610,13 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         try? JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any]
     }
 
+    private static func turnID(in object: [String: Any]?) -> String? {
+        if let turnID = object?["turnId"] as? String {
+            return turnID
+        }
+        return (object?["turn"] as? [String: Any])?["id"] as? String
+    }
+
     /// The agentic feature names to switch off, intersected with what this installation advertises
     /// so a renamed or absent name is never passed. Shared by the launch argv and the per-thread
     /// config override, which are the two delivery paths for the same `features.<name>=false` knob.
@@ -553,6 +677,21 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     fileprivate static func error(_ detail: String) -> NSError {
         NSError(domain: "CodexAppServerRuntime", code: 1,
                 userInfo: [NSLocalizedDescriptionKey: detail])
+    }
+
+    fileprivate static func timeoutError(_ detail: String) -> NSError {
+        NSError(
+            domain: "CodexAppServerRuntime",
+            code: NSURLErrorTimedOut,
+            userInfo: [NSLocalizedDescriptionKey: detail])
+    }
+
+    fileprivate static func remainingTimeout(until deadline: Date) throws -> TimeInterval {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining >= 0.01 else {
+            throw timeoutError("Codex app-server request timed out")
+        }
+        return remaining
     }
 }
 
@@ -630,7 +769,7 @@ private final class CodexAppServer: @unchecked Sendable {
 
     static func start(identity: CodexAppServerRuntime.LaunchIdentity,
                       runtimeBaseDirectory: URL,
-                      timeout: TimeInterval,
+                      deadline: Date,
                       lifetime: AgentRuntimeLifetime) async throws -> CodexAppServer {
         let runtimeHome = try CodexRuntimeHome.create(in: runtimeBaseDirectory)
         var didStart = false
@@ -661,7 +800,6 @@ private final class CodexAppServer: @unchecked Sendable {
                 process: process,
                 lifetime: lifetime,
                 runtimeHome: runtimeHome)
-            let deadline = Date().addingTimeInterval(timeout)
             try await server.send(
                 method: "initialize",
                 parameters: [
@@ -672,7 +810,7 @@ private final class CodexAppServer: @unchecked Sendable {
                     ],
                 ],
                 id: 0,
-                timeout: max(0.01, deadline.timeIntervalSinceNow))
+                timeout: try CodexAppServerRuntime.remainingTimeout(until: deadline))
             while true {
                 let line = try await server.nextLine(deadline: deadline)
                 guard let payload = try? JSONSerialization.jsonObject(
@@ -697,7 +835,7 @@ private final class CodexAppServer: @unchecked Sendable {
                 method: "initialized",
                 parameters: nil,
                 id: nil,
-                timeout: max(0.01, deadline.timeIntervalSinceNow))
+                timeout: try CodexAppServerRuntime.remainingTimeout(until: deadline))
             let readyMs = Int(
                 (DispatchTime.now().uptimeNanoseconds - process.launchedAt) / 1_000_000)
             jlog("Jarvis: Codex app-server ready in \(readyMs)ms")
@@ -723,15 +861,16 @@ private final class CodexAppServer: @unchecked Sendable {
     }
 
     func nextLine(deadline: Date) async throws -> AgentRuntimeProcess.Line {
-        let remaining = deadline.timeIntervalSinceNow
-        guard remaining > 0 else {
-            process.terminateNow()
-            throw NSError(
-                domain: "CodexAppServerRuntime",
-                code: NSURLErrorTimedOut,
-                userInfo: [NSLocalizedDescriptionKey: "Codex app-server response timed out"])
-        }
+        let remaining = try CodexAppServerRuntime.remainingTimeout(until: deadline)
         return try await process.nextLine(timeout: remaining)
+    }
+
+    /// A turn deadline is recoverable at thread scope, so observing it must not kill the shared
+    /// process. Callers either synchronize with `turn/interrupt` or invalidate the server themselves.
+    func nextLineBefore(deadline: Date) async throws -> AgentRuntimeProcess.Line? {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining >= 0.01 else { return nil }
+        return try await process.nextLineOrNil(timeout: remaining)
     }
 
     func finish() {

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/Runtime/AgentRuntimeProcess.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/Runtime/AgentRuntimeProcess.swift
@@ -235,7 +235,31 @@ final class AgentRuntimeProcess: @unchecked Sendable {
             try await withCheckedThrowingContinuation { continuation in
                 DispatchQueue.global(qos: .userInitiated).async { [self] in
                     continuation.resume(with: Result {
-                        try waitForLine(timeout: timeout)
+                        guard let line = try waitForLine(
+                            timeout: timeout,
+                            terminateOnTimeout: true
+                        ) else {
+                            preconditionFailure("a terminating line wait cannot time out softly")
+                        }
+                        return line
+                    })
+                }
+            }
+        } onCancel: {
+            self.terminateNow()
+        }
+    }
+
+    /// Read under a recoverable protocol deadline. Unlike `nextLine`, expiry leaves the process
+    /// alive so the owning protocol can interrupt and drain only the timed-out operation.
+    func nextLineOrNil(timeout: TimeInterval) async throws -> Line? {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async { [self] in
+                    continuation.resume(with: Result {
+                        try waitForLine(
+                            timeout: timeout,
+                            terminateOnTimeout: false)
                     })
                 }
             }
@@ -417,7 +441,10 @@ final class AgentRuntimeProcess: @unchecked Sendable {
         condition.broadcast()
     }
 
-    private func waitForLine(timeout: TimeInterval) throws -> Line {
+    private func waitForLine(
+        timeout: TimeInterval,
+        terminateOnTimeout: Bool
+    ) throws -> Line? {
         let deadline = Date().addingTimeInterval(max(0.01, timeout))
         condition.lock()
         defer { condition.unlock() }
@@ -441,6 +468,7 @@ final class AgentRuntimeProcess: @unchecked Sendable {
                 continue
             }
             guard condition.wait(until: deadline) else {
+                guard terminateOnTimeout else { return nil }
                 condition.unlock()
                 terminateNow()
                 condition.lock()

--- a/Sources/JarvisCore/Brain/Adapters/OpenAI/OpenAIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/Adapters/OpenAI/OpenAIBrainClient.swift
@@ -28,17 +28,11 @@ public struct OpenAIBrainClient: BrainClient, @unchecked Sendable {
     private let traffic: BrainTrafficLog?
     private let trafficTag: String
 
-    /// A generous request ceiling that is a HANG backstop, not a latency knob. Normal coaching turns
-    /// finish in a few seconds; this only fires on a genuinely stuck request, so it sits well above the
-    /// slow-but-real reasoning tail — a tight value (the old 15s) abandons a still-generating turn
-    /// that would have finished.
-    public static let defaultTimeout: TimeInterval = 60
-
     public init(apiKey: String,
                 model: String,
                 reasoningEffort: String = ReasoningEffort.default.rawValue,
                 endpoint: URL = URL(string: "https://api.openai.com/v1/responses")!,
-                timeout: TimeInterval = OpenAIBrainClient.defaultTimeout,
+                timeout: TimeInterval = BrainWorkloadTimeout.liveCoaching,
                 // The cap MUST track the effort: it's a combined reasoning+output budget, so a value
                 // too small for the effort truncates the run (the high-effort bug). Callers pass the
                 // budget for the *selected* effort (`AppDelegate` → `effort.maxOutputTokens`); this

--- a/Sources/JarvisCore/Brain/BrainWorkloadTimeout.swift
+++ b/Sources/JarvisCore/Brain/BrainWorkloadTimeout.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Response deadlines belong to the work Jarvis is waiting on, not to the provider transport.
+public enum BrainWorkloadTimeout {
+    /// A live coaching request should yield quickly so newer conversation is not batched behind it.
+    public static let liveCoaching: TimeInterval = 15
+
+    /// Compaction is auxiliary and lossless on failure, so it shares the same short latency ceiling.
+    public static let historyCompaction: TimeInterval = 15
+}

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -1017,9 +1017,6 @@ public final class CoachDriver: @unchecked Sendable {
 
     // MARK: - History compaction
 
-    /// A stalled auxiliary summary must not hold the active handling slot indefinitely.
-    public static let historyCompactionTimeout: TimeInterval = 15
-
     /// Auxiliary compaction fails soft and never counts against provider route health.
     private func compactIfNeeded(using attempt: AttemptBrain) async {
         guard history.estimatedTokens > config.historyCompactionTokenThreshold else { return }

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -1017,6 +1017,9 @@ public final class CoachDriver: @unchecked Sendable {
 
     // MARK: - History compaction
 
+    /// A stalled auxiliary summary must not hold the active handling slot indefinitely.
+    public static let historyCompactionTimeout: TimeInterval = 15
+
     /// Auxiliary compaction fails soft and never counts against provider route health.
     private func compactIfNeeded(using attempt: AttemptBrain) async {
         guard history.estimatedTokens > config.historyCompactionTokenThreshold else { return }

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
@@ -65,6 +65,39 @@ import Testing
         defaultCodex.terminate()
     }
 
+    @Test func historyCompactionOverrideDoesNotChangeProviderDefaults() throws {
+        let workDir = try makeWorkDir()
+        let (claudeSummarizer, _) = client(
+            .claudeCode,
+            workDir: workDir,
+            replies: [],
+            tools: [],
+            toolChoice: .auto,
+            timeout: CoachDriver.historyCompactionTimeout)
+        let (codexSummarizer, _) = client(
+            .codexCLI,
+            workDir: workDir,
+            replies: [],
+            tools: [],
+            toolChoice: .auto,
+            timeout: CoachDriver.historyCompactionTimeout)
+        let (defaultClaude, _) = client(.claudeCode, workDir: workDir, replies: [])
+        let (defaultCodex, _) = client(.codexCLI, workDir: workDir, replies: [])
+
+        #expect(CoachDriver.historyCompactionTimeout == 15)
+        #expect(CLIBrainClient.defaultTimeout == 120)
+        #expect(CLIBrainClient.codexDefaultTimeout == 30)
+        #expect(claudeSummarizer.configuration.timeout == CoachDriver.historyCompactionTimeout)
+        #expect(codexSummarizer.configuration.timeout == CoachDriver.historyCompactionTimeout)
+        #expect(defaultClaude.configuration.timeout == CLIBrainClient.defaultTimeout)
+        #expect(defaultCodex.configuration.timeout == CLIBrainClient.codexDefaultTimeout)
+
+        claudeSummarizer.terminate()
+        codexSummarizer.terminate()
+        defaultClaude.terminate()
+        defaultCodex.terminate()
+    }
+
     @Test func persistentRuntimeParsesStaySilent() async throws {
         let (client, backend) = client(
             workDir: try makeWorkDir(),

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
@@ -16,10 +16,13 @@ import Testing
         replies: [String],
         tools: [ToolDef] = coachTools,
         toolChoice: ToolChoice = .required,
-        timeout: TimeInterval? = nil,
-        traffic: BrainTrafficLog? = nil
+        timeout: TimeInterval = BrainWorkloadTimeout.liveCoaching,
+        traffic: BrainTrafficLog? = nil,
+        openDelay: TimeInterval = 0
     ) -> (CLIBrainClient, FakeLocalAgentRuntime) {
-        let backend = FakeLocalAgentRuntime(replies: replies)
+        let backend = FakeLocalAgentRuntime(
+            replies: replies,
+            openDelay: openDelay)
         let runtime = CLIBrainRuntime(backend: backend)
         let client = CLIBrainClient(
             provider: provider,
@@ -38,34 +41,20 @@ import Testing
         return (client, backend)
     }
 
-    @Test func liveCoachingOverrideDoesNotChangeProviderDefaults() throws {
+    @Test func localProviderDefaultsUseTheLiveCoachingWorkload() throws {
         let workDir = try makeWorkDir()
-        let (claudeCoach, _) = client(
-            .claudeCode,
-            workDir: workDir,
-            replies: [],
-            timeout: CLIBrainClient.liveCoachingTimeout)
-        let (codexCoach, _) = client(
-            .codexCLI,
-            workDir: workDir,
-            replies: [],
-            timeout: CLIBrainClient.liveCoachingTimeout)
-        let (defaultClaude, _) = client(.claudeCode, workDir: workDir, replies: [])
-        let (defaultCodex, _) = client(.codexCLI, workDir: workDir, replies: [])
+        let (claude, _) = client(.claudeCode, workDir: workDir, replies: [])
+        let (codex, _) = client(.codexCLI, workDir: workDir, replies: [])
 
-        #expect(CLIBrainClient.liveCoachingTimeout == 15)
-        #expect(claudeCoach.configuration.timeout == CLIBrainClient.liveCoachingTimeout)
-        #expect(codexCoach.configuration.timeout == CLIBrainClient.liveCoachingTimeout)
-        #expect(defaultClaude.configuration.timeout == CLIBrainClient.defaultTimeout)
-        #expect(defaultCodex.configuration.timeout == CLIBrainClient.codexDefaultTimeout)
+        #expect(BrainWorkloadTimeout.liveCoaching == 15)
+        #expect(claude.configuration.timeout == BrainWorkloadTimeout.liveCoaching)
+        #expect(codex.configuration.timeout == BrainWorkloadTimeout.liveCoaching)
 
-        claudeCoach.terminate()
-        codexCoach.terminate()
-        defaultClaude.terminate()
-        defaultCodex.terminate()
+        claude.terminate()
+        codex.terminate()
     }
 
-    @Test func historyCompactionOverrideDoesNotChangeProviderDefaults() throws {
+    @Test func historyCompactionDeadlineIsProviderNeutral() throws {
         let workDir = try makeWorkDir()
         let (claudeSummarizer, _) = client(
             .claudeCode,
@@ -73,29 +62,46 @@ import Testing
             replies: [],
             tools: [],
             toolChoice: .auto,
-            timeout: CoachDriver.historyCompactionTimeout)
+            timeout: BrainWorkloadTimeout.historyCompaction)
         let (codexSummarizer, _) = client(
             .codexCLI,
             workDir: workDir,
             replies: [],
             tools: [],
             toolChoice: .auto,
-            timeout: CoachDriver.historyCompactionTimeout)
-        let (defaultClaude, _) = client(.claudeCode, workDir: workDir, replies: [])
-        let (defaultCodex, _) = client(.codexCLI, workDir: workDir, replies: [])
+            timeout: BrainWorkloadTimeout.historyCompaction)
 
-        #expect(CoachDriver.historyCompactionTimeout == 15)
-        #expect(CLIBrainClient.defaultTimeout == 120)
-        #expect(CLIBrainClient.codexDefaultTimeout == 30)
-        #expect(claudeSummarizer.configuration.timeout == CoachDriver.historyCompactionTimeout)
-        #expect(codexSummarizer.configuration.timeout == CoachDriver.historyCompactionTimeout)
-        #expect(defaultClaude.configuration.timeout == CLIBrainClient.defaultTimeout)
-        #expect(defaultCodex.configuration.timeout == CLIBrainClient.codexDefaultTimeout)
+        #expect(BrainWorkloadTimeout.historyCompaction == 15)
+        #expect(claudeSummarizer.configuration.timeout
+                == BrainWorkloadTimeout.historyCompaction)
+        #expect(codexSummarizer.configuration.timeout
+                == BrainWorkloadTimeout.historyCompaction)
 
         claudeSummarizer.terminate()
         codexSummarizer.terminate()
-        defaultClaude.terminate()
-        defaultCodex.terminate()
+    }
+
+    @Test func auxiliaryResponseDoesNotRestartItsDeadlineAfterSetup() async throws {
+        let (client, backend) = client(
+            workDir: try makeWorkDir(),
+            replies: [#"{"tool":"stay_silent","arguments":{}}"#],
+            timeout: 0.05,
+            openDelay: 0.15)
+
+        do {
+            _ = try await client.respond(
+                messages: [.system("coach prompt"), .user("hello")],
+                tools: coachTools,
+                toolChoice: .required)
+            Issue.record("expected the setup-plus-inference deadline to expire")
+        } catch {
+            #expect(error.localizedDescription.contains("timed out"))
+        }
+
+        let turns = await backend.turns
+        let finishCount = await backend.finishCount
+        #expect(turns.isEmpty)
+        #expect(finishCount == 1)
     }
 
     @Test func persistentRuntimeParsesStaySilent() async throws {
@@ -460,10 +466,12 @@ private actor FakeLocalAgentRuntime: LocalAgentRuntimeBackend {
     struct RecordedTurn: Sendable {
         let text: String
         let imageCount: Int
+        let timeout: TimeInterval
     }
 
     private var replies: [String]
     private let openError: (any Error)?
+    private let openDelay: TimeInterval
     private(set) var configurations: [LocalAgentConversationConfiguration] = []
     private(set) var turns: [RecordedTurn] = []
     private(set) var openCount = 0
@@ -471,19 +479,31 @@ private actor FakeLocalAgentRuntime: LocalAgentRuntimeBackend {
     nonisolated let termination = RuntimeTerminationRecorder()
     nonisolated var terminationCount: Int { termination.count }
 
-    init(replies: [String], openError: (any Error)? = nil) {
+    init(
+        replies: [String],
+        openError: (any Error)? = nil,
+        openDelay: TimeInterval = 0
+    ) {
         self.replies = replies
         self.openError = openError
+        self.openDelay = openDelay
     }
 
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws {
         configurations.append(configuration)
     }
 
-    func openConversation(for configuration: LocalAgentConversationConfiguration)
+    func openConversation(
+        for configuration: LocalAgentConversationConfiguration,
+        deadline: Date
+    )
         async throws -> any LocalAgentConversation {
         configurations.append(configuration)
         openCount += 1
+        if openDelay > 0 {
+            try await Task.sleep(
+                nanoseconds: UInt64(openDelay * 1_000_000_000))
+        }
         if terminationCount > 0 {
             throw NSError(
                 domain: "FakeLocalAgentRuntime",
@@ -507,7 +527,10 @@ private actor FakeLocalAgentRuntime: LocalAgentRuntimeBackend {
             if case .imageJPEG = $0 { return true }
             return false
         })
-        turns.append(RecordedTurn(text: text, imageCount: imageCount))
+        turns.append(RecordedTurn(
+            text: text,
+            imageCount: imageCount,
+            timeout: turn.timeout))
         guard !replies.isEmpty else {
             throw NSError(
                 domain: "FakeLocalAgentRuntime",

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
@@ -400,6 +400,106 @@ import Testing
         #expect(requests(method: "initialize", in: trace).count == 1)
     }
 
+    @Test func timedOutCodexCompactionInterruptsOnlyItsThread() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: """
+                #!/bin/sh
+                thread_number=0
+                while IFS= read -r line; do
+                  printf 'input: %s\\n' "$line" >> '\(shellQuoted(trace.path))'
+                  request_id=$(printf '%s' "$line" | sed -n 's/.*"id":\\([0-9][0-9]*\\).*/\\1/p')
+                  method=$(printf '%s' "$line" | sed -n 's/.*"method":"\\([^"]*\\)".*/\\1/p' | tr -d '\\\\')
+                  case "$method" in
+                    initialize)
+                      printf '{"id":%s,"result":{}}\\n' "$request_id"
+                      ;;
+                    thread/start)
+                      thread_number=$((thread_number + 1))
+                      active_thread="thread-$thread_number"
+                      printf '{"id":%s,"result":{"thread":{"id":"%s","ephemeral":true,"path":null},"instructionSources":[]}}\\n' "$request_id" "$active_thread"
+                      ;;
+                    thread/unsubscribe)
+                      printf '{"id":%s,"result":{}}\\n' "$request_id"
+                      ;;
+                    turn/start)
+                      active_thread=$(printf '%s' "$line" | sed -n 's/.*"threadId":"\\([^"]*\\)".*/\\1/p')
+                      turn_number=${active_thread#thread-}
+                      active_turn="turn-$turn_number"
+                      printf '{"id":%s,"result":{"turn":{"id":"%s","status":"inProgress","items":[]}}}\\n' "$request_id" "$active_turn"
+                      if [ "$active_thread" != "thread-2" ]; then
+                        printf '{"method":"item/completed","params":{"threadId":"%s","turnId":"%s","item":{"type":"agentMessage","text":"%s"}}}\\n' "$active_thread" "$active_turn" '{\\"tool\\":\\"stay_silent\\",\\"arguments\\":{}}'
+                        printf '{"method":"turn/completed","params":{"threadId":"%s","turn":{"id":"%s","status":"completed","items":[{"type":"agentMessage"}]}}}\\n' "$active_thread" "$active_turn"
+                      fi
+                      ;;
+                    turn/interrupt)
+                      interrupted_thread=$(printf '%s' "$line" | sed -n 's/.*"threadId":"\\([^"]*\\)".*/\\1/p')
+                      interrupted_turn=$(printf '%s' "$line" | sed -n 's/.*"turnId":"\\([^"]*\\)".*/\\1/p')
+                      printf '{"id":%s,"result":{}}\\n' "$request_id"
+                      printf '{"method":"turn/completed","params":{"threadId":"%s","turn":{"id":"%s","status":"interrupted","items":[]}}}\\n' "$interrupted_thread" "$interrupted_turn"
+                      ;;
+                  esac
+                done
+                """)
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let coach = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: false,
+            timeout: 2)
+        let summarizer = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: false,
+            systemPrompt: "summarize",
+            tools: [],
+            toolChoice: .auto,
+            timeout: 0.2)
+
+        let firstConversation = try await coach.makeConversation()
+        _ = try await firstConversation.respond(
+            messages: [.system("coach prompt"), .user("first")],
+            tools: coachTools,
+            toolChoice: .required)
+        await firstConversation.finish()
+
+        do {
+            _ = try await summarizer.respond(
+                messages: [.system("summarize"), .user("older turns")],
+                tools: [],
+                toolChoice: .auto)
+            Issue.record("expected compaction to time out")
+        } catch {
+            #expect(error.localizedDescription.contains("timed out"))
+        }
+
+        let nextConversation = try await coach.makeConversation()
+        let nextResponse = try await nextConversation.respond(
+            messages: [.system("coach prompt"), .user("newer speech")],
+            tools: coachTools,
+            toolChoice: .required)
+        await nextConversation.finish()
+        guard case .staySilent = try #require(nextResponse.toolCalls.first) else {
+            Issue.record("expected the next coaching turn to use the shared server")
+            return
+        }
+        runtime.terminateNow()
+
+        #expect(requests(method: "initialize", in: trace).count == 1)
+        #expect(requests(method: "thread/start", in: trace).count == 3)
+        let interrupt = try #require(request(method: "turn/interrupt", in: trace))
+        #expect(interrupt["threadId"] as? String == "thread-2")
+        #expect(interrupt["turnId"] as? String == "turn-2")
+    }
+
     @Test func overlappingClaudePrewarmInstallsOneQueryAndKeepsItsReplacement() async throws {
         let directory = try makeWorkDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -609,14 +709,15 @@ import Testing
         prewarm: Bool,
         systemPrompt: String = "coach prompt",
         tools: [ToolDef] = coachTools,
-        toolChoice: ToolChoice = .required
+        toolChoice: ToolChoice = .required,
+        timeout: TimeInterval = 10
     ) -> CLIBrainClient {
         CLIBrainClient(
             provider: provider,
             executable: executable,
             model: "",
             workDirectory: directory,
-            timeout: 10,
+            timeout: timeout,
             systemPrompt: systemPrompt,
             tools: tools,
             toolChoice: toolChoice,

--- a/Tests/JarvisCoreTests/Brain/Adapters/OpenAI/OpenAIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/OpenAI/OpenAIBrainClientTests.swift
@@ -161,13 +161,13 @@ private func speakResponseBody(arguments: String) -> Data {
         #expect(resp.toolCalls.isEmpty)
     }
 
-    @Test func historyCompactionOverrideDoesNotChangeDefaultTimeout() async throws {
+    @Test func openAIDefaultAndCompactionUseWorkloadDeadlines() async throws {
         let timeouts = CapturedTimeouts()
         let response = Data(#"{"output":[]}"#.utf8)
         let summarizer = OpenAIBrainClient(
             apiKey: "sk-x",
             model: "gpt-5.4-mini",
-            timeout: CoachDriver.historyCompactionTimeout,
+            timeout: BrainWorkloadTimeout.historyCompaction,
             send: { request in
                 timeouts.append(request.timeoutInterval)
                 return (response, http(200))
@@ -183,11 +183,11 @@ private func speakResponseBody(arguments: String) -> Data {
         _ = try await summarizer.respond(messages: [.user("condense this")], tools: [])
         _ = try await defaultClient.respond(messages: [.user("condense this")], tools: [])
 
-        #expect(CoachDriver.historyCompactionTimeout == 15)
-        #expect(OpenAIBrainClient.defaultTimeout == 60)
+        #expect(BrainWorkloadTimeout.liveCoaching == 15)
+        #expect(BrainWorkloadTimeout.historyCompaction == 15)
         #expect(timeouts.values == [
-            CoachDriver.historyCompactionTimeout,
-            OpenAIBrainClient.defaultTimeout,
+            BrainWorkloadTimeout.historyCompaction,
+            BrainWorkloadTimeout.liveCoaching,
         ])
     }
 

--- a/Tests/JarvisCoreTests/Brain/Adapters/OpenAI/OpenAIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/OpenAI/OpenAIBrainClientTests.swift
@@ -161,6 +161,36 @@ private func speakResponseBody(arguments: String) -> Data {
         #expect(resp.toolCalls.isEmpty)
     }
 
+    @Test func historyCompactionOverrideDoesNotChangeDefaultTimeout() async throws {
+        let timeouts = CapturedTimeouts()
+        let response = Data(#"{"output":[]}"#.utf8)
+        let summarizer = OpenAIBrainClient(
+            apiKey: "sk-x",
+            model: "gpt-5.4-mini",
+            timeout: CoachDriver.historyCompactionTimeout,
+            send: { request in
+                timeouts.append(request.timeoutInterval)
+                return (response, http(200))
+            })
+        let defaultClient = OpenAIBrainClient(
+            apiKey: "sk-x",
+            model: "gpt-5.4-mini",
+            send: { request in
+                timeouts.append(request.timeoutInterval)
+                return (response, http(200))
+            })
+
+        _ = try await summarizer.respond(messages: [.user("condense this")], tools: [])
+        _ = try await defaultClient.respond(messages: [.user("condense this")], tools: [])
+
+        #expect(CoachDriver.historyCompactionTimeout == 15)
+        #expect(OpenAIBrainClient.defaultTimeout == 60)
+        #expect(timeouts.values == [
+            CoachDriver.historyCompactionTimeout,
+            OpenAIBrainClient.defaultTimeout,
+        ])
+    }
+
     /// Any non-2xx fails fast — there is no in-request retry. A failure throws to the driver, which
     /// recovers on the next trigger by re-sending the (still-uncommitted) backlog — fresher than
     /// retrying a stale body in place.
@@ -405,6 +435,14 @@ final class CapturedBody: @unchecked Sendable {
     private let lock = NSLock()
     func set(_ d: Data?) { lock.lock(); data = d; lock.unlock() }
     func get() -> Data? { lock.lock(); defer { lock.unlock() }; return data }
+}
+
+/// Thread-safe timeout recorder for request-policy tests.
+final class CapturedTimeouts: @unchecked Sendable {
+    private var recorded: [TimeInterval] = []
+    private let lock = NSLock()
+    func append(_ timeout: TimeInterval) { lock.lock(); recorded.append(timeout); lock.unlock() }
+    var values: [TimeInterval] { lock.lock(); defer { lock.unlock() }; return recorded }
 }
 
 /// Thread-safe call counter for retry tests.

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -1798,18 +1798,21 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// Compaction fails soft: if the summarizer errors, the full history simply rides along.
     @Test func compactionFailureKeepsFullHistory() async {
         let clock = ManualClock(now: 0)
+        let recorder = BrainFailureRecorder()
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")]),
         ])
         let summarizer = ScriptedThrowBrain(script: [nil])
         let (driver, transcript) = makeDriver(brain: brain, summarizer: summarizer, clock: clock,
-                                              config: Config(historyCompactionTokenThreshold: 5))
+                                              config: Config(historyCompactionTokenThreshold: 5),
+                                              onBrainFailure: { recorder.record($0) })
         transcript.append(.init(speaker: .me, text: "a reasonably long problem statement to remember", at: 0))
         await driver.handleTrigger(.turnEnd)
         transcript.append(.init(speaker: .me, text: "next thought", at: 5))
         await driver.handleTrigger(.turnEnd)
         let second = brain.calls[1].compactMap(\.text).joined(separator: "\n")
         #expect(second.contains("a reasonably long problem statement to remember"))   // nothing lost
+        #expect(recorder.failures.isEmpty)   // auxiliary failure never enters route health
     }
 
     // MARK: - Observability: structured turn outcomes

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -311,8 +311,10 @@ rather than a per-turn screenshot.
   and past a token threshold (see
   `Config.historyCompactionTokenThreshold`) the oldest span is **compacted** into a short structured
   summary written by a cheaper model (`gpt-5.4-mini`), so the problem statement never falls out of
-  context. Requests are sent `store:true` so they stay inspectable in the OpenAI dashboard for
-  debugging — the retention tradeoff is documented in [sandbox.md](./sandbox.md).
+  context. Compaction uses one Core-owned workload deadline across providers and fails soft: a slow
+  or failed summary leaves the full history intact for a later attempt. Requests are sent `store:true`
+  so they stay inspectable in the OpenAI dashboard for debugging — the retention tradeoff is
+  documented in [sandbox.md](./sandbox.md).
 - **Transcription — `gpt-4o-transcribe` over the GA Realtime API** with **tuned `server_vad`** (not
   `semantic_vad`, which is reported flaky in transcription-only mode — it can stop emitting
   `…transcription.completed` entirely). Turn-end fires on `…transcription.completed`, plus a
@@ -377,7 +379,10 @@ provider-route policy, and traffic recording are unchanged — only the transpor
   [`CodexAppServerRuntime.swift`](../Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift).
   Codex publishes no control that removes built-in tools, so the runtime also verifies the thread
   boundary and aborts on server requests or item events outside the message/reasoning contract. The
-  completed-session evaluator remains separate and intentionally agentic.
+  completed-session evaluator remains separate and intentionally agentic. If inference reaches its
+  workload deadline, Jarvis interrupts that turn and waits for its matching terminal event before
+  retiring the thread; the shared app-server stays available. Failure to confirm that scoped cleanup
+  instead invalidates the server because its event stream is no longer known to be synchronized.
 - **The JSON action contract remains provider-neutral.** The CLIs do not expose Jarvis's native
   function calls, so the same `ToolDef`s are rendered as a JSON output protocol and parsed back into
   `ToolInvocation`. `BrainConversation` changes transport ownership, not `CoachHistory`: completed
@@ -484,8 +489,10 @@ The always-on legs are built to survive transient failure rather than die on it:
   their retained PCM is transcribed by the replacement session instead of first emitting a partial
   or gap that the replay would duplicate. Stale speech state therefore cannot suppress silence
   coaching after reconnect. Reconnect uses capped exponential backoff.
-- **The brain call** is single-flighted (a turn can't double-speak) and runs under a provider-aware
-  request timeout. The API, Claude, and Codex ceilings stay well above the reasoning-turn tail.
+- **The brain call** is single-flighted (a turn can't double-speak) and runs under a Core-owned
+  workload deadline shared by the API, Claude, and Codex transports. A one-shot local auxiliary
+  response uses one absolute budget across provider setup and inference rather than restarting the
+  full deadline for each phase.
   Stop terminates every ready, leased, and preparing local process. Termination and escalation
   target only process identities observed while the original group was proven alive, including
   descendants snapshotted before an immediately exited leader is reaped, and persistent stdout
@@ -500,8 +507,10 @@ The always-on legs are built to survive transient failure rather than die on it:
   attempt. In both cases, only the next fresh attempt runs the next target on the forward-only route.
   A terminal success resets the active target's count and keeps that target installed. No provider
   is probed concurrently, and no automatic recovery returns to the primary. Cancellation remains
-  quiet. Memory **compaction** fails soft outside this route: a failed summary simply leaves the full
-  history for the next attempt.
+  quiet. A timed-out Codex inference first interrupts and drains only that turn, preserving the
+  session-scoped app-server when the matching terminal state confirms the stream is healthy;
+  uncertain protocol cleanup still invalidates the server. Memory **compaction** fails soft outside
+  this route: a failed summary simply leaves the full history for the next attempt.
 - **The audit edge** drains Activity's asynchronous writer as Stop completes. An explicit
   Activity → **Evaluate** click then runs the read-only agentic evaluator over the source checkout
   plus the completed session directory; it reads `jarvis-activity.jsonl` itself in full, so no

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -240,6 +240,9 @@
 - **Superseded in part by:** 2026-07-25 — Coaching attempts exhaust an ordered provider route. The
   no-in-request-replay boundary returns, and pending work now schedules a new attempt even without a
   natural trigger.
+- **Superseded in part by:** 2026-07-31 — Brain response deadlines are workload-owned. The
+  no-in-request-replay and next-trigger recovery boundaries stand; a generic provider-owned
+  generous ceiling does not.
 - **Detail:** [architecture.md → Resilience](./architecture.md#resilience).
 
 ### 2026-07-06 — Silence is a tool call; audio turns require one
@@ -999,27 +1002,39 @@
   summarization and other auxiliary clients. (b) Giving the two live local providers different
   deadlines — they serve the same overlay latency contract. (c) Changing API, evaluator, routing,
   retry, or failure semantics — the session evidence did not justify those broader changes.
-- **Superseded in part by:** 2026-07-31 — History compaction has one cross-provider deadline. The
-  live coaching deadline and provider defaults stand; compaction no longer inherits those defaults.
+- **Superseded in part by:** 2026-07-31 — Brain response deadlines are workload-owned. The common
+  live deadline stands; generic provider-specific defaults do not.
 - **Detail:** `Sources/JarvisApp/App/AppDelegate.swift`,
   `Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift`.
 
-### 2026-07-31 — History compaction has one cross-provider deadline
+### 2026-07-31 — Brain response deadlines are workload-owned
 
-- **Chose:** Give OpenAI, Claude Code, and Codex history-compaction summarizers one explicit,
-  Core-owned deadline, passed when `AppDelegate` constructs those role-specific clients. Keep
-  compaction awaited, tool-less, low-effort, and tagged `summarizer`; an empty result, timeout, or
-  other failure keeps the full history and never enters provider-route health. Generic provider
-  defaults, live coaching, ordered routing, retry scheduling, and the completed-session evaluator
-  remain unchanged.
-- **Why:** Compaction runs before the active handling slot is released, so inheriting a transport's
-  broad hang backstop can batch newer speech behind an auxiliary operation. Abandoning a stalled
-  summary is lossless because the uncompressed history remains available and compaction retries
-  after a later successful turn.
-- **Rejected:** (a) Lowering provider defaults — unrelated callers need their existing ceilings.
-  (b) Reusing the local-only live-coaching constant — compaction is a distinct cross-provider role.
-  (c) Detaching compaction into background work — history ordering and snapshot races need a separate
-  design.
-- **Detail:** `CoachDriver.historyCompactionTimeout` in
-  `Sources/JarvisCore/Coach/CoachDriver.swift`,
+- **Chose:** Define live-coaching and history-compaction deadlines as Core workload policy, shared
+  by OpenAI, Claude Code, and Codex instead of keeping transport-specific defaults. Generic clients
+  default to the live workload; `AppDelegate` still passes each role explicitly. A one-shot local
+  auxiliary request calculates one absolute deadline before provider setup and gives inference only
+  the remaining budget. Compaction stays awaited, tool-less, low-effort, and tagged `summarizer`; an
+  empty result, timeout, or other failure keeps the full history and never enters provider-route
+  health.
+- **Chose:** Recover an in-flight Codex turn timeout at thread scope: send `turn/interrupt`, consume
+  its response and the matching terminal turn event, then let normal conversation finish retire the
+  thread. Keep the shared app-server for later coaching. Invalidate it only when the turn cannot be
+  identified or scoped interruption/terminal cleanup cannot be confirmed, because its shared stream
+  is then uncertain.
+- **Why:** Provider transport does not determine how long newer speech may wait; the foreground or
+  auxiliary workload does. Compaction runs before the active handling slot is released, so separate
+  setup and inference ceilings could double that delay. A failed summary is lossless, while
+  restarting a healthy session-scoped Codex transport adds latency to the next coaching attempt.
+- **Rejected:** (a) Provider-specific defaults — they encode workload policy at the wrong boundary.
+  (b) A separate Codex summarizer app-server — duplicates a healthy session transport and its
+  startup cost. (c) Unsubscribing a timed-out thread without first interrupting and draining its
+  terminal event — that leaves the shared event stream unsynchronized. (d) Detached compaction —
+  history ordering and snapshot races need a separate design.
+- **Supersedes in part:** 2026-07-03 — Brain call: generous ceiling, one attempt, recover on next
+  trigger; 2026-07-18 — Codex coaching invocations are isolated and bounded; and 2026-07-30 — Live
+  local-agent coaching shares one latency deadline. Their recovery, isolation, and common
+  live-latency decisions stand; provider-owned timeout defaults do not.
+- **Detail:** `Sources/JarvisCore/Brain/BrainWorkloadTimeout.swift`,
+  `Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift`,
+  `Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift`,
   `Sources/JarvisApp/App/AppDelegate.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -999,5 +999,27 @@
   summarization and other auxiliary clients. (b) Giving the two live local providers different
   deadlines — they serve the same overlay latency contract. (c) Changing API, evaluator, routing,
   retry, or failure semantics — the session evidence did not justify those broader changes.
+- **Superseded in part by:** 2026-07-31 — History compaction has one cross-provider deadline. The
+  live coaching deadline and provider defaults stand; compaction no longer inherits those defaults.
 - **Detail:** `Sources/JarvisApp/App/AppDelegate.swift`,
   `Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift`.
+
+### 2026-07-31 — History compaction has one cross-provider deadline
+
+- **Chose:** Give OpenAI, Claude Code, and Codex history-compaction summarizers one explicit,
+  Core-owned deadline, passed when `AppDelegate` constructs those role-specific clients. Keep
+  compaction awaited, tool-less, low-effort, and tagged `summarizer`; an empty result, timeout, or
+  other failure keeps the full history and never enters provider-route health. Generic provider
+  defaults, live coaching, ordered routing, retry scheduling, and the completed-session evaluator
+  remain unchanged.
+- **Why:** Compaction runs before the active handling slot is released, so inheriting a transport's
+  broad hang backstop can batch newer speech behind an auxiliary operation. Abandoning a stalled
+  summary is lossless because the uncompressed history remains available and compaction retries
+  after a later successful turn.
+- **Rejected:** (a) Lowering provider defaults — unrelated callers need their existing ceilings.
+  (b) Reusing the local-only live-coaching constant — compaction is a distinct cross-provider role.
+  (c) Detaching compaction into background work — history ordering and snapshot races need a separate
+  design.
+- **Detail:** `CoachDriver.historyCompactionTimeout` in
+  `Sources/JarvisCore/Coach/CoachDriver.swift`,
+  `Sources/JarvisApp/App/AppDelegate.swift`.


### PR DESCRIPTION
## Summary

- define Core-owned workload timeout policy and apply the same live-coaching and history-compaction budgets to OpenAI, Claude Code, and Codex
- enforce one absolute auxiliary-request deadline across runtime setup and inference, passing only the remaining budget into the model turn
- recover a timed-out Codex turn with `turn/interrupt` plus matching terminal confirmation so a healthy shared app-server can serve the next attempt
- invalidate the Codex app-server only when the turn cannot be identified or interrupt/terminal cleanup leaves stream state uncertain
- keep history compaction fail-soft: timeout, empty output, or another failure preserves the full history for a later compaction attempt
- cover provider parity, end-to-end deadline accounting, and shared-server reuse with regression tests; update the design documentation

## Why

Timeouts describe Jarvis workloads, not providers. A single deadline also prevents setup and inference from each receiving a fresh timeout window. For Codex, scoped turn cancellation preserves the healthy transport while still ensuring late events from a timed-out turn cannot leak into the next request.

Closes #121.

## Validation

- `swift build` — passed
- `./scripts/run-tests.sh --filter CLIBrainClientTests` — passed, 17 tests
- `./scripts/run-tests.sh --filter CLIBrainRuntimeTests` — passed, 20 tests
- `./scripts/run-tests.sh --filter OpenAIBrainClientTests` — passed, 26 tests
- `./scripts/run-tests.sh --filter ScreenCaptureRunnerTests` — passed, 7 tests
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh` — passed, 577 tests in 65 suites (one opt-in screen-capture test skipped as expected)
- GitHub's parallel CI attempts hit varying timing-sensitive tests outside this diff (`AgentRuntimeProcessTests`/`CoachDriverPipelineTests`, then `ScreenCaptureRunnerTests`); the changed deadline and Codex recovery regressions passed in every run