### PR TITLE
fix(audio): start capture without system playback

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -16,6 +16,8 @@
   <key>LSUIElement</key><true/>
   <key>NSMicrophoneUsageDescription</key>
   <string>Jarvis listens to you think aloud to offer coaching tips.</string>
+  <key>NSAudioCaptureUsageDescription</key>
+  <string>Jarvis captures system audio so it can hear the other side of your call and coach you in context.</string>
   <key>NSScreenCaptureUsageDescription</key>
   <string>Jarvis captures the meeting audio (the other side of your call) and screen so it can hear what others say and coach you in context.</string>
 </dict>

--- a/Sources/JarvisApp/Capture/AggregateEchoCapture.swift
+++ b/Sources/JarvisApp/Capture/AggregateEchoCapture.swift
@@ -147,7 +147,9 @@ final class AggregateEchoCapture: @unchecked Sendable {
             kAudioAggregateDeviceTapListKey: [
                 [kAudioSubTapUIDKey: tapDesc.uuid.uuidString, kAudioSubTapDriftCompensationKey: 1],
             ],
-            kAudioAggregateDeviceTapAutoStartKey: true,
+            // Deliberately omit tap auto-start. Enabling it waits for a tapped process to begin
+            // writing system audio before starting the entire aggregate, including the microphone.
+            // Quiet sessions would otherwise arm successfully without ever delivering an IOProc.
         ]
         var agg = AudioObjectID(kAudioObjectUnknown)
         guard AudioHardwareCreateAggregateDevice(description as CFDictionary, &agg) == noErr,

--- a/scripts/check-audio-capture-config.sh
+++ b/scripts/check-audio-capture-config.sh
@@ -3,12 +3,20 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 capture_source="Sources/JarvisApp/Capture/AggregateEchoCapture.swift"
+if [ ! -f "$capture_source" ]; then
+    echo "Audio capture guard: $capture_source not found; refusing to pass." >&2
+    exit 1
+fi
 if /usr/bin/grep -Eq '^[[:space:]]*kAudioAggregateDeviceTapAutoStartKey[[:space:]]*:' "$capture_source"; then
     echo "Aggregate capture must start immediately; tap auto-start waits for system-audio writers and stalls the microphone." >&2
     exit 1
 fi
 
-usage_description="$(/usr/libexec/PlistBuddy -c 'Print :NSAudioCaptureUsageDescription' Resources/Info.plist 2>/dev/null || true)"
+usage_description=""
+if ! usage_description="$(/usr/libexec/PlistBuddy -c 'Print :NSAudioCaptureUsageDescription' Resources/Info.plist 2>/dev/null)"; then
+    echo "Resources/Info.plist must describe system-audio capture for Core Audio process taps." >&2
+    exit 1
+fi
 if [ -z "$usage_description" ]; then
     echo "Resources/Info.plist must describe system-audio capture for Core Audio process taps." >&2
     exit 1

--- a/scripts/check-audio-capture-config.sh
+++ b/scripts/check-audio-capture-config.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+capture_source="Sources/JarvisApp/Capture/AggregateEchoCapture.swift"
+if /usr/bin/grep -Eq '^[[:space:]]*kAudioAggregateDeviceTapAutoStartKey[[:space:]]*:' "$capture_source"; then
+    echo "Aggregate capture must start immediately; tap auto-start waits for system-audio writers and stalls the microphone." >&2
+    exit 1
+fi
+
+usage_description="$(/usr/libexec/PlistBuddy -c 'Print :NSAudioCaptureUsageDescription' Resources/Info.plist 2>/dev/null || true)"
+if [ -z "$usage_description" ]; then
+    echo "Resources/Info.plist must describe system-audio capture for Core Audio process taps." >&2
+    exit 1
+fi
+
+echo "Audio capture configuration guard passed."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 ./scripts/check-ghost-mode.sh
+./scripts/check-audio-capture-config.sh
 
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -29,8 +29,9 @@ needs — so a SwiftUI + ScreenCaptureKit binary builds with plain `swift build`
 `scripts/build-app.sh` assembles the executable into a hand-built `.app` bundle (the bundle layout
 and the stable bundle id live in the script and `Resources/Info.plist`).
 
-**Permission persistence is a signing problem.** macOS TCC keys a Screen-Recording/Microphone grant
-to **code signature + bundle id + bundle path**. An ad-hoc signature changes every build, so macOS
+**Permission persistence is a signing problem.** macOS TCC keys Screen-Recording, Microphone, and
+System Audio Recording grants to **code signature + bundle id + bundle path**. An ad-hoc signature
+changes every build, so macOS
 forgets the grant and re-prompts on each rebuild. So `build-app.sh` always signs with a **stable
 self-signed identity (`Jarvis Dev`**, created automatically on first build) — there is **no ad-hoc
 fallback**. With the identity, bundle id, and path all fixed, grants persist across rebuilds and
@@ -39,8 +40,9 @@ relaunches. On the first build macOS prompts once to let `codesign` use the new 
 
 - Recover a stale *denied* state (which macOS won't re-prompt for) with
   `tccutil reset Microphone com.jarvis.coach` (or `ScreenCapture`), then relaunch and Allow.
-- Screen Recording + Microphone are granted by **TCC prompts at first run**, not an App-Sandbox
-  entitlement file. `Permissions.primeAll()` requests them at launch and is idempotent.
+- Screen Recording + Microphone are granted by **TCC prompts at first launch**, not an App-Sandbox
+  entitlement file. `Permissions.primeAll()` requests them at launch and is idempotent. Core Audio
+  requests System Audio Recording when Jarvis first builds its process tap after Start.
 
 ## Distribution — signed, notarized releases from CI
 
@@ -75,8 +77,9 @@ then just run the script) for packaging without CI. Distributed builds run on Ap
 | `./scripts/build-app.sh --run` | Same build, then launch. Per-session logs land in the workspace `.jarvis/` (see below). |
 
 - **Always launch with `open ./Jarvis.app`**, never the bare binary — running it from a shell makes
-  TCC attribute the grant to the *terminal*, so the app reports Microphone/Screen Recording as
-  "denied" even when granted. Pass flags with `open ./Jarvis.app --args …`.
+  TCC attribute the grant to the *terminal*, so the app reports Microphone, System Audio Recording,
+  or Screen Recording as "denied" even when granted. Pass flags with
+  `open ./Jarvis.app --args …`.
 - Jarvis does **not** auto-start: set the OpenAI key once (Settings → Brain, saved to an owner-only
   file; `OPENAI_API_KEY` is a headless fallback), then **Start / Stop** from the menu. The icon shows
   two states only: ⚪️ stopped, 🟢 running.
@@ -128,8 +131,11 @@ Some behavior can only be verified with a real key, a mic, and granted permissio
 the human-facing coaching record. The current validation priority lives in
 [`status.md`](./status.md#next-action).
 
-- Wait for `Jarvis: coaching ready (mic + system audio).` in the debug log. Speak into the microphone
-  and play speech through system audio; confirm both appear as finalized `heard:` entries in Activity.
+- Start while no other app is playing audio. Confirm the macOS recording indicator appears
+  immediately and the first audio-witness snapshot has nonzero capture counters; system playback
+  must not be required to wake the microphone. Then wait for
+  `Jarvis: coaching ready (mic + system audio).`, speak into the microphone, and play speech through
+  system audio; confirm both appear as finalized `heard:` entries in Activity.
 - Show an interview question without speaking its details, then ask, “Jarvis, how can I solve this in
   one pass?” Confirm Activity shows exactly one screen view followed by a screen-specific tip. A fully
   stated behavioral question should not cause an unnecessary capture.

--- a/wiki/sandbox.md
+++ b/wiki/sandbox.md
@@ -10,8 +10,8 @@ Two layers below are **relaxed** for the personal build, by explicit decision:
 
 - **No App Sandbox.** The app is **unsandboxed**, signed with a **stable self-signed identity
   (`Jarvis Dev`)** — not ad-hoc, so TCC grants persist across rebuilds (see
-  [build-and-run.md](./build-and-run.md)). Screen Recording + Microphone
-  are granted via **TCC prompts** at first run. Consequence: the app *could* read the user's files —
+  [build-and-run.md](./build-and-run.md)). Screen Recording, Microphone, and System Audio Recording
+  are granted via **TCC prompts**. Consequence: the app *could* read the user's files —
   accepted for a personal tool. (Hardened model: §1.)
 - **No separate account.** The build and the app run in the **main `forrest` account**, inside a
   **git worktree** for recoverability, rather than a restricted `jarvisbuild` account. The former
@@ -39,6 +39,9 @@ The app ships with the macOS App Sandbox enabled and requests **only** the entit
 - Microphone / audio input.
 - Outbound network (to reach the OpenAI APIs).
 
+System-audio process-tap access is separately purpose-described in `Resources/Info.plist` and gated
+by TCC; it is not a general filesystem entitlement.
+
 It requests **no** general filesystem entitlement. It cannot read the user's documents, browser
 data, or home directory. The only files it touches are its own sandbox container and transient
 screenshot temp files it creates and deletes.
@@ -61,7 +64,7 @@ A Standard account `dev` already exists on this Mac and could serve, or add a fr
 **System Settings → Users & Groups → add a Standard user (e.g. `jarvisbuild`) →** log in via Fast
 User Switching → run Claude Code there (the session runs *as* that user — true isolation). Note the
 build still needs one-time **admin** setup from `forrest` (TCC grants, any tool installs), since a
-Standard account cannot grant itself Screen Recording.
+Standard account cannot grant itself Screen Recording or System Audio Recording.
 
 ### 3. Secrets
 
@@ -72,8 +75,9 @@ logged.
 We deliberately **don't** use the macOS Keychain. macOS keys Keychain access to a per-build code
 *partition* — for a self-signed app with no Apple Team ID, that partition is the binary's `cdhash`,
 which changes on every build — so each rebuild is treated as a new program and re-prompts for the
-login-keychain password. (TCC grants for Microphone/Screen Recording don't have this problem: they
-key to the stable signing identity, not the `cdhash`.) The only ways to avoid the re-prompt are an
+login-keychain password. (TCC grants for Microphone, System Audio Recording, and Screen Recording
+don't have this problem: they key to the stable signing identity, not the `cdhash`.) The only ways
+to avoid the re-prompt are an
 Apple Developer Team ID (stable `teamid:` partition) or moving off the Keychain. A `0600` file has
 the same practical trust boundary as the `OPENAI_API_KEY` headless fallback — any process running as
 this user can read it — but never prompts and survives every rebuild. If Jarvis ever ships under a

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -85,7 +85,8 @@ audio-route switch: Activity should say listening continues, the
 next turn should include any unsent speech, and capture should recover
 without rotating the session. Stop that session, click **Evaluate**, and confirm the agentic report
 opens and identifies the temporary miss from the complete Activity log without misclassifying it as
-a stopped conversation. The standard release checklist remains in
+a stopped conversation. The standard release checklist, including quiet-start capture before system
+playback, remains in
 [build-and-run.md](./build-and-run.md).
 
 ## Built
@@ -105,7 +106,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisCore/Diagnostics/` — logging, always-on activity log with stable persisted event kinds and fixed typed brain-change/failure notices, privacy-preserving audio continuity evidence, session-history store, wire-level brain traffic capture + the read-only agentic audit over the complete session directory, user-facing errors (`ActivityLog`, `AudioContinuityWitness`, `SessionStore`, `BrainTrafficLog`, `EvaluationTranscript`, `AgenticEvaluation`, `AgenticEvaluator`, `UserFacingError`).
 - `Sources/JarvisOverlay/` — the capture-invisible `NSPanel` surfaces: `OverlayCaptionPanel` (transient), `OverlayBoxPanel` (persistent), `NSPanel+CaptureExclusion`.
 - `Sources/JarvisApp/App/` + `MenuBar/` — entry point, connection-aware menu status, Start/Stop, `ErrorReporter` (startup alerts plus an unconditional no-presentation runtime policy).
-- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
+- `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture that starts without waiting for a system-audio writer, with AEC3 echo cancellation + resampling (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `Resampler`), Realtime item/readiness/liveness/transactional-reconnect/witness handling (`RealtimeTranscriber`, `NetworkPathDiagnostics`), permissions, plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain / Overlay / Screen / Activity sections), with shared page, rounded-card, responsive-row, and scroll primitives so every tab keeps one visual system without coupling section behavior.
 - `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon ⌥⌘J on-demand-hint hotkey.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with an exact selectable/copyable session ID and one-click **Evaluate** / **Open report** agentic audit flow.


### PR DESCRIPTION
## Summary

- start the one-clock mic + process-tap aggregate immediately instead of waiting for a system-audio writer
- add the required `NSAudioCaptureUsageDescription` to the shipped app bundle
- add a normal-gate regression guard and document the separate System Audio Recording permission plus quiet-start smoke
- harden the guard against missing source files and failed or empty plist lookups

## Root cause

`kAudioAggregateDeviceTapAutoStartKey: true` tells Core Audio to wait until a tapped process begins writing audio before it starts the aggregate. Because Jarvis puts the microphone and system tap on the same aggregate, a quiet session could leave the microphone idle even though `AudioDeviceStart` returned successfully. The macOS recording indicator stayed absent and both continuity witnesses remained at `capture=0/0`.

The fixed aggregate deliberately omits tap auto-start, so microphone capture does not depend on system playback.

## Validation

- `swift build`
- `bash -n scripts/check-audio-capture-config.sh`
- `plutil -lint Resources/Info.plist`
- capture-config guard fixtures:
  - current production configuration passes
  - missing source file, missing purpose key, and empty purpose value are each rejected
- `./scripts/run-tests.sh --filter OverlayInvisibilityTests`
  - 18-test suite passed; the opt-in live ScreenCaptureKit test remained skipped as expected
- `SWT_EXPERIMENTAL_MAXIMUM_PARALLELIZATION_WIDTH=1 ./scripts/run-tests.sh`
  - 580 tests in 65 suites passed
  - the opt-in live ScreenCaptureKit test remained skipped as expected
- signed worktree-app quiet-start smoke, with no diagnostic playback:
  - macOS reported Microphone and System Audio Recording in use immediately
  - Core Audio entered `StartIO` and `State: Running` without registering an autostart context or waiting for writers
  - at 15 seconds both streams had captured 1,397 chunks and delivered 1,396 with zero send failures

The initial parallel test run hit the repository's known timing contention in AppKit overlay and process-lifecycle suites; the isolated overlay suite and prescribed serialized full gate passed cleanly.