### PR TITLE
fix(transcription): clarify realtime recovery diagnostics

### DIFF
--- a/Sources/JarvisApp/Capture/RealtimeContinuityReporter.swift
+++ b/Sources/JarvisApp/Capture/RealtimeContinuityReporter.swift
@@ -20,7 +20,7 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
     private let lock = NSLock()
     private var timer: Timer?
     private var stopped = true
-    private var overflowAccumulator = ReconnectBufferOverflowAccumulator()
+    private var evictionAccumulator = ReplayBufferEvictionAccumulator()
 
     init(
         speaker: Speaker,
@@ -38,7 +38,7 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
     func start() {
         lock.lock()
         stopped = false
-        overflowAccumulator.reset()
+        evictionAccumulator.reset()
         lock.unlock()
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
@@ -58,11 +58,11 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
         stopped = true
         let timer = self.timer
         self.timer = nil
-        let overflow = overflowAccumulator.flush(at: now)
+        let evictionReport = evictionAccumulator.flush(at: now)
         lock.unlock()
         DispatchQueue.main.async { timer?.invalidate() }
-        if let overflow {
-            handle(witness.recordReconnectBufferOverflow(evictedSequences: overflow, at: now))
+        if let evictionReport {
+            handle(evictionReport)
         }
         handle(witness.poll(at: now, forceSnapshot: true))
     }
@@ -101,14 +101,22 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
             sessionAudioTime: sessionAudioTime, observedAt: now))
     }
 
-    func recordBufferEviction(_ chunks: [PCMBuffer.Chunk]) {
+    func recordBufferEviction(_ chunks: [PCMBuffer.Chunk], replayCoverageAtRisk: Bool) {
         guard !chunks.isEmpty else { return }
         let timestamp = now
         lock.lock()
-        let sequences = overflowAccumulator.record(chunks.compactMap(\.sequenceNumber), at: timestamp)
+        let report = evictionAccumulator.record(
+            chunks.compactMap(\.sequenceNumber),
+            replayCoverageAtRisk: replayCoverageAtRisk,
+            at: timestamp)
         lock.unlock()
-        guard let sequences else { return }
-        consume(witness.recordReconnectBufferOverflow(evictedSequences: sequences, at: timestamp))
+        guard let report else { return }
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.lock.lock(); let stopped = self.stopped; self.lock.unlock()
+            guard !stopped else { return }
+            self.handle(report)
+        }
     }
 
     private var now: TimeInterval { clock.now() - sessionStart }
@@ -163,7 +171,7 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
             case .reconnectBufferOverflow(let evictedChunks, let firstSequence, let lastSequence):
                 let first = firstSequence.map(String.init) ?? "unknown"
                 let last = lastSequence.map(String.init) ?? "unknown"
-                jlog("⚠️ audio continuity [\(speaker.rawValue)] reconnect buffer overflow: "
+                jlog("⚠️ audio continuity [\(speaker.rawValue)] reconnect replay coverage lost: "
                      + "evicted=\(evictedChunks), sequences=\(first)...\(last)")
             case .localActivityUnmatched(let activeSince, let duration):
                 jlog("⚠️ audio continuity [\(speaker.rawValue)] local activity had no provider speech "
@@ -173,6 +181,19 @@ final class RealtimeContinuityReporter: @unchecked Sendable {
                      + "the prior warning: activity_since=\(Self.seconds(activeSince)), "
                      + "server_at=\(Self.seconds(serverObservedAt))")
             }
+        }
+    }
+
+    private func handle(_ report: ReplayBufferEvictionAccumulator.Report) {
+        switch report {
+        case .boundedReplayWindowReached(let sequences):
+            let first = sequences.first.map(String.init) ?? "unknown"
+            let last = sequences.last.map(String.init) ?? "unknown"
+            jlog("ℹ️ audio continuity [\(speaker.rawValue)] bounded replay window reached with no "
+                 + "active recovery: expired=\(sequences.count), sequences=\(first)...\(last); "
+                 + "further steady-state expiry suppressed")
+        case .replayCoverageLost(let sequences):
+            handle(witness.recordReconnectBufferOverflow(evictedSequences: sequences, at: now))
         }
     }
 

--- a/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriber.swift
@@ -266,11 +266,12 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
             duration: TranscriptionAudioFormat.pcm16Mono.duration(forByteCount: pcm.count))
         lock.lock()
         guard !stopped else { lock.unlock(); return }
+        let connectionUnavailable = !connected
         let readyChunks = jarvisManagedSpeechBuffer?.append(chunk) ?? [chunk]
         let evicted = appendToAudioBuffer(readyChunks)
         lock.unlock()
         continuityReporter.recordDelivery(sequence: sequenceNumber, pcm16: pcm, at: observedAt)
-        reportBufferEviction(evicted)
+        reportBufferEviction(evicted, connectionUnavailable: connectionUnavailable)
         pumpAudioIfReady()
     }
 
@@ -285,9 +286,10 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
             transcriptionLifecycle.recordLocalSpeechStarted()
             lock.lock()
             guard !stopped else { lock.unlock(); return }
+            let connectionUnavailable = !connected
             let evicted = appendToAudioBuffer(jarvisManagedSpeechBuffer?.speechStarted() ?? [])
             lock.unlock()
-            reportBufferEviction(evicted)
+            reportBufferEviction(evicted, connectionUnavailable: connectionUnavailable)
             pumpAudioIfReady()
         case .ended(let startedAt, let commitAt):
             jlog("Jarvis realtime [\(speaker.rawValue)]: local speech ended "
@@ -317,10 +319,15 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
         }
     }
 
-    private func reportBufferEviction(_ evicted: [PCMBuffer.Chunk]) {
+    private func reportBufferEviction(
+        _ evicted: [PCMBuffer.Chunk],
+        connectionUnavailable: Bool
+    ) {
         guard !evicted.isEmpty else { return }
-        transcriptionLifecycle.recordReplayCoverageLoss()
-        continuityReporter.recordBufferEviction(evicted)
+        let recoveryWasActive = transcriptionLifecycle.recordReplayCoverageLoss()
+        continuityReporter.recordBufferEviction(
+            evicted,
+            replayCoverageAtRisk: connectionUnavailable || recoveryWasActive)
     }
 
     private func pumpAudioIfReady() {
@@ -419,7 +426,7 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
             }
             self.lock.unlock()
             if let completion {
-                self.reportBufferEviction(completion.evicted)
+                self.reportBufferEviction(completion.evicted, connectionUnavailable: false)
                 self.pumpAudioIfReady()
             }
         }
@@ -501,10 +508,12 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
 
         switch type {
         case RealtimeSession.audioBufferCommittedType:
-            guard model.turnDetectionStrategy == .clientCommit,
-                  let itemID = obj["item_id"] as? String else {
-                jlog("Jarvis realtime [\(speaker.rawValue)]: malformed Jarvis-managed "
-                     + "commit acknowledgement")
+            let commitEvent = RealtimeSession.audioBufferCommitEvent(from: obj, model: model)
+            guard case .acknowledgement(let itemID) = commitEvent else {
+                if commitEvent == .malformedAcknowledgement {
+                    jlog("Jarvis realtime [\(speaker.rawValue)]: malformed Jarvis-managed "
+                         + "commit acknowledgement")
+                }
                 break
             }
             lock.lock()
@@ -823,7 +832,7 @@ final class RealtimeTranscriber: NSObject, TranscriptionSession, URLSessionWebSo
         let interruptedItems = transcriptionLifecycle.beginReconnectRecovery(
             replayAvailable: audioBuffer.bufferedChunkCount > 0)
         reportDroppedJarvisManagedTurns(droppedJarvisManagedTurns)
-        reportBufferEviction(replay.evicted)
+        reportBufferEviction(replay.evicted, connectionUnavailable: true)
         // Old-socket deltas are now held by the reconnect recovery gate. They remain a fallback if
         // every handshake fails or bounded replay loses coverage, without keeping stale item IDs in
         // the replacement ledger or releasing a partial coaching turn early.

--- a/Sources/JarvisApp/Capture/RealtimeTranscriptionLifecycle.swift
+++ b/Sources/JarvisApp/Capture/RealtimeTranscriptionLifecycle.swift
@@ -240,13 +240,16 @@ final class RealtimeTranscriptionLifecycle: @unchecked Sendable {
                      waitingForReplay: waiting)
     }
 
-    func recordReplayCoverageLoss() {
+    @discardableResult
+    func recordReplayCoverageLoss() -> Bool {
         lock.lock()
+        let recoveryWasActive = reconnectRecovery.isActive
         let fallbackItems = reconnectRecovery.recordCoverageLoss()
         for item in fallbackItems { appendFinalizedItemLocked(item, reason: "replay coverage lost") }
         updateCoachingActivityLocked()
         lock.unlock()
         if !fallbackItems.isEmpty { cancelReplayRecoveryDeadline() }
+        return recoveryWasActive
     }
 
     func finalizeInterrupted(reason: String) {

--- a/Sources/JarvisCore/Audio/ReplayBufferEvictionAccumulator.swift
+++ b/Sources/JarvisCore/Audio/ReplayBufferEvictionAccumulator.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Separates routine bounded replay-window aging from eviction that can affect active recovery.
+/// Healthy delivery reports the first expiry once; recovery loss remains periodically visible.
+public struct ReplayBufferEvictionAccumulator: Sendable {
+    public enum Report: Equatable, Sendable {
+        case boundedReplayWindowReached([UInt64])
+        case replayCoverageLost([UInt64])
+    }
+
+    private var recoveryLossAccumulator: ReconnectBufferOverflowAccumulator
+    private var reportedBoundedReplayWindow = false
+
+    public init(recoveryLossReportInterval: TimeInterval = 5) {
+        recoveryLossAccumulator = ReconnectBufferOverflowAccumulator(
+            reportInterval: recoveryLossReportInterval)
+    }
+
+    public mutating func record(
+        _ sequences: [UInt64],
+        replayCoverageAtRisk: Bool,
+        at timestamp: TimeInterval
+    ) -> Report? {
+        guard !sequences.isEmpty else { return nil }
+        if replayCoverageAtRisk {
+            guard let lost = recoveryLossAccumulator.record(sequences, at: timestamp) else {
+                return nil
+            }
+            return .replayCoverageLost(lost)
+        }
+        guard !reportedBoundedReplayWindow else { return nil }
+        reportedBoundedReplayWindow = true
+        return .boundedReplayWindowReached(sequences)
+    }
+
+    public mutating func flush(at timestamp: TimeInterval) -> Report? {
+        recoveryLossAccumulator.flush(at: timestamp).map(Report.replayCoverageLost)
+    }
+
+    public mutating func reset() {
+        reportedBoundedReplayWindow = false
+        recoveryLossAccumulator.reset()
+    }
+}

--- a/Sources/JarvisCore/Transcription/RealtimeSession.swift
+++ b/Sources/JarvisCore/Transcription/RealtimeSession.swift
@@ -124,6 +124,28 @@ public enum RealtimeSession {
     public static let audioBufferCommittedType = "input_audio_buffer.committed"
     public static let deltaTranscriptionType = "conversation.item.input_audio_transcription.delta"
 
+    /// Server-VAD sessions may emit `input_audio_buffer.committed` as part of their normal server-owned
+    /// turn lifecycle. Only client-commit models bind that event to a Jarvis-managed local boundary.
+    public enum AudioBufferCommitEvent: Equatable, Sendable {
+        case ignored
+        case malformedAcknowledgement
+        case acknowledgement(itemID: String)
+    }
+
+    public static func audioBufferCommitEvent(
+        from event: [String: Any],
+        model: OpenAITranscriptionModel
+    ) -> AudioBufferCommitEvent {
+        guard event["type"] as? String == audioBufferCommittedType,
+              model.turnDetectionStrategy == .clientCommit else {
+            return .ignored
+        }
+        guard let itemID = event["item_id"] as? String else {
+            return .malformedAcknowledgement
+        }
+        return .acknowledgement(itemID: itemID)
+    }
+
     /// The event type the server emits when an utterance's transcription is final.
     public static let completedTranscriptionType = "conversation.item.input_audio_transcription.completed"
     public static let failedTranscriptionType = "conversation.item.input_audio_transcription.failed"

--- a/Tests/JarvisCoreTests/Audio/ReplayBufferEvictionAccumulatorTests.swift
+++ b/Tests/JarvisCoreTests/Audio/ReplayBufferEvictionAccumulatorTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct ReplayBufferEvictionAccumulatorTests {
+    @Test func healthyWindowReportsOnceWithoutMaskingLaterRecoveryLoss() {
+        var accumulator = ReplayBufferEvictionAccumulator(recoveryLossReportInterval: 5)
+
+        #expect(accumulator.record([1], replayCoverageAtRisk: false, at: 0)
+                == .boundedReplayWindowReached([1]))
+        #expect(accumulator.record([2], replayCoverageAtRisk: false, at: 1) == nil)
+        #expect(accumulator.record([3], replayCoverageAtRisk: true, at: 2)
+                == .replayCoverageLost([3]))
+        #expect(accumulator.record([4], replayCoverageAtRisk: true, at: 3) == nil)
+        #expect(accumulator.record([5], replayCoverageAtRisk: true, at: 8)
+                == .replayCoverageLost([4, 5]))
+    }
+
+    @Test func flushPreservesOnlyRecoveryLossAndResetStartsAFreshSession() {
+        var accumulator = ReplayBufferEvictionAccumulator(recoveryLossReportInterval: 5)
+
+        _ = accumulator.record([10], replayCoverageAtRisk: false, at: 0)
+        #expect(accumulator.flush(at: 1) == nil)
+        #expect(accumulator.record([11], replayCoverageAtRisk: true, at: 1)
+                == .replayCoverageLost([11]))
+        #expect(accumulator.record([12], replayCoverageAtRisk: true, at: 2) == nil)
+        #expect(accumulator.flush(at: 3) == .replayCoverageLost([12]))
+
+        accumulator.reset()
+        #expect(accumulator.record([20], replayCoverageAtRisk: false, at: 3)
+                == .boundedReplayWindowReached([20]))
+        #expect(accumulator.record([21], replayCoverageAtRisk: true, at: 3)
+                == .replayCoverageLost([21]))
+    }
+}

--- a/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
+++ b/Tests/JarvisCoreTests/Transcription/RealtimeSessionTests.swift
@@ -143,6 +143,24 @@ import Testing
         #expect(input["turn_detection"] is NSNull)
     }
 
+    @Test func commitEventClassificationIgnoresServerVADAndValidatesClientAcknowledgements() {
+        let event: [String: Any] = [
+            "type": RealtimeSession.audioBufferCommittedType,
+            "item_id": "item-42",
+        ]
+
+        #expect(RealtimeSession.audioBufferCommitEvent(from: event, model: .gpt4oTranscribe)
+                == .ignored)
+        #expect(RealtimeSession.audioBufferCommitEvent(from: event, model: .gptTranscribe)
+                == .acknowledgement(itemID: "item-42"))
+        #expect(RealtimeSession.audioBufferCommitEvent(
+            from: ["type": RealtimeSession.audioBufferCommittedType],
+            model: .gptLiveTranscribe) == .malformedAcknowledgement)
+        #expect(RealtimeSession.audioBufferCommitEvent(
+            from: ["type": RealtimeSession.speechStartedType, "item_id": "item-42"],
+            model: .gptLiveTranscribe) == .ignored)
+    }
+
     /// Layer 1 (pre-VAD): noise reduction is sent as an OBJECT `{"type": "near_field"}` nested under
     /// `audio.input` (GA shape — a string here is the documented LiveKit bug the server rejects). It
     /// filters the buffer before VAD, cutting the non-speech blips that trigger phantom transcripts.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -18,8 +18,13 @@ default**, keeps **GPT-4o Transcribe** as its default model, adds opt-in **GPT T
 language expectations default to Automatic rather than English; English, Mandarin Chinese, and
 English + Mandarin Chinese remain session-level hints rather than per-turn language choices. One
 Start snapshots the provider, OpenAI model/profile, or Apple locale for both `me` and `them`; there
-is no automatic provider or model fallback. Apple Speech prepares the selected
-supported locale before replacing a running pipeline, submits every captured sample to
+is no automatic provider or model fallback. An initial same-input macOS 26 system-audio comparison
+keeps GPT-4o Transcribe as the default: among the tested GPT-4o, GPT Live, and Apple Speech arms, it
+alone preserved the English, Mandarin, and within-sentence language-switching inputs. This is
+directional evidence rather than a full benchmark: GPT Transcribe landed afterward, and
+[issue #136](https://github.com/JINGBANZ/jarvis/issues/136) owns repeated system-audio runs plus an
+explicitly opt-in reconnect/replay scenario before any future default change. Apple Speech prepares
+the selected supported locale before replacing a running pipeline, submits every captured sample to
 `SpeechAnalyzer`, records only final results, and uses content-free local activity solely to keep
 coaching from waking mid-utterance. An OpenAI key is required only when OpenAI supplies
 transcription or appears in the brain route. The detailed model, language, turn-detection, context,
@@ -75,19 +80,13 @@ fixed notices remain available in Activity. The gate statically rejects unreview
 
 ## Next action
 
-Run a same-input English/Mandarin transcription comparison on macOS 26 first. Use OpenAI with the
-same English + Mandarin Chinese profile for one GPT-4o Transcribe, one GPT Transcribe, and one GPT
-Live Transcribe session; exercise both microphone and system audio, include a within-sentence
-language switch, and compare final `heard:` text, completion latency, and reconnect stability.
-Confirm the debug log names the selected model/profile, GPT-4o sends no single-language hint for the
-mixed profile, GPT Transcribe and GPT Live log acknowledged local commits without a
-`turn_detection` configuration rejection, and GPT Transcribe logs completion-language metadata. Then
-run Apple Speech once per relevant conversation locale; confirm it downloads or reuses the selected
-model before capture, reaches Listening, preserves `me`/`them` ordering, emits no mid-utterance
-coaching turn, and stops cleanly. Confirm Apple Speech plus a CLI-only brain route starts without an
-API key, while any OpenAI transcription or brain target still requires one. Change any transcription
-setting during a live run and confirm the current snapshot remains active until the next Start; force
-an Apple analyzer failure and confirm Jarvis never sends audio to OpenAI as an implicit fallback.
+Finish the remaining transcription configuration smoke without expanding the performance benchmark:
+confirm Apple Speech plus a CLI-only brain route starts without an API key, while any OpenAI
+transcription or brain target still requires one. Change a transcription setting during a live run
+and confirm the current snapshot remains active until the next Start; force an Apple analyzer failure
+and confirm Jarvis never sends audio to OpenAI as an implicit fallback. Microphone benchmarking and
+Apple-specific finalization optimization are not required; the repeated model matrix and opt-in
+network interruption belong to [issue #136](https://github.com/JINGBANZ/jarvis/issues/136).
 
 Then run the live prompt smoke on a fresh session: show an interview question without speaking its
 details, ask “Jarvis, how can I solve this in one pass?”, and confirm the first action is

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -21,7 +21,7 @@ Start snapshots the provider, OpenAI model/profile, or Apple locale for both `me
 is no automatic provider or model fallback. An initial same-input macOS 26 system-audio comparison
 keeps GPT-4o Transcribe as the default: among the tested GPT-4o, GPT Live, and Apple Speech arms, it
 alone preserved the English, Mandarin, and within-sentence language-switching inputs. This is
-directional evidence rather than a full benchmark: GPT Transcribe landed afterward, and
+directional evidence rather than a full benchmark because it does not include GPT Transcribe;
 [issue #136](https://github.com/JINGBANZ/jarvis/issues/136) owns repeated system-audio runs plus an
 explicitly opt-in reconnect/replay scenario before any future default change. Apple Speech prepares
 the selected supported locale before replacing a running pipeline, submits every captured sample to


### PR DESCRIPTION
## Summary

- treat `input_audio_buffer.committed` as a Jarvis-managed acknowledgement only for client-commit models, so GPT-4o's normal server-VAD event is ignored instead of logged as malformed
- distinguish routine bounded recovery-tail aging from eviction that threatens active reconnect recovery
  - healthy delivery emits one informational replay-window line per endpoint/session
  - connection/recovery loss retains coalesced warning diagnostics
- update `wiki/status.md` with the initial macOS 26 system-audio comparison, preserve the remaining configuration smokes, and point repeated model/reconnect certification to #136

## Root cause

The Realtime event handler used one guard for both model capability and acknowledgement shape. A valid GPT-4o server-owned commit event therefore fell into the same branch as a malformed client-commit acknowledgement.

Separately, every bounded `PCMBuffer` eviction was labeled as a reconnect overflow. GPT-4o continuously advances its unconfirmed in-memory recovery tail while a healthy idle stream has no server speech boundary to retire it, so normal window aging produced repeated failure-looking warnings. The new Core accumulator reports that expected state once while keeping real recovery coverage loss visible.

## Validation

- `xcodebuildmcp swift-package build --package-path /private/tmp/jarvis-realtime-diagnostic-noise --configuration debug` — passed
- `./scripts/run-tests.sh --filter 'ReplayBufferEvictionAccumulatorTests|RealtimeSessionTests'` — 28 tests across 2 suites passed
- `swift build` — passed as the first half of the repository gate
- default-parallel full suite — all changed and adjacent transcription/recovery tests passed; local and CI runs ended on pre-existing AppKit, CLI-process, or transcription-coordinator timing failures covered by open stabilization PR #134
- GitHub CI on `82ca492` — the only failure was `TranscriptionCoachingCoordinatorTests.silenceUsesTheSharedTranscriptClock()` (2 timing expectations); #134 directly hardens that suite's observable wait
- serial classification — changed and adjacent suites passed; one existing `AgentRuntimeProcessTests` startup race remained, also within #134's test-harness scope
- ghost-mode and audio-capture guards passed on every test invocation
- the opt-in ScreenCaptureKit test remained skipped

No live microphone or network-disruption run was performed. Those are not required for this diagnostic-only change; future repeated system-audio and opt-in reconnect validation is tracked in #136.
