### PR TITLE
fix(coach): reduce noisy coaching context

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -769,22 +769,29 @@ public final class CoachDriver: @unchecked Sendable {
             reason: reason,
             sessionElapsedSeconds: now - sessionStart)
         let delta = transcript.renderFrom(index: currentCommittedTranscriptCount())
+        let substantiveLines = delta.lines.filter(TurnSubstance.isSubstantive)
+        let substantiveDeltaText = RollingTranscript.render(substantiveLines)
 
-        // Filler-only natural events do not spend a provider attempt. A natural wake may also
-        // coalesce with failed pending work whose transcript delta is empty (for example, a silence
-        // attempt); that automatic attempt must still run.
+        // Filler-only natural events do not spend a provider attempt or enter later brain context.
+        // Activity has already recorded the finalized transcript, so consuming this boundary loses
+        // no user-visible evidence. A natural wake may also coalesce with failed pending work whose
+        // transcript delta is empty (for example, a silence attempt); that automatic attempt must
+        // still run.
         if reason == .turnEnd && !work.hasFailedAttempt
-            && !delta.lines.contains(where: TurnSubstance.isSubstantive) {
+            && substantiveLines.isEmpty {
             let preview = delta.lines.isEmpty
                 ? "nothing new"
                 : String(delta.lines.map(\.text).joined(separator: " · ").prefix(80))
             jlog("… skipped as filler (\(preview)) — not calling the brain")
+            commitTranscript(through: delta.upTo)
             return .skipped(.skippedFillerOnly)
         }
 
         let historyBase: [ChatMessage] = [.system(JarvisPrompts.Coach.system)] + history.snapshot()
         let userText = [
-            delta.text.isEmpty ? nil : JarvisPrompts.Coach.newSpeech(delta.text),
+            substantiveDeltaText.isEmpty
+                ? nil
+                : JarvisPrompts.Coach.newSpeech(substantiveDeltaText),
             context.promptLine,
         ].compactMap { $0 }.joined(separator: "\n\n")
         var turnMessages: [ChatMessage] = [.user(userText)] + work.observations
@@ -965,7 +972,7 @@ public final class CoachDriver: @unchecked Sendable {
                     }
                     jlog("… nothing useful to add, staying silent")
                     ActivityLog.shared.record(.stayedSilent)
-                    commitIfWorthKeeping(turnMessages, deltaText: delta.text)
+                    commitIfWorthKeeping(turnMessages, deltaText: substantiveDeltaText)
                     commitTranscript(through: delta.upTo)
                     return .completed(.silentByModel)
                 }

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -68,9 +68,6 @@ public final class CoachDriver: @unchecked Sendable {
         /// or call/result linkage.
         var observations: [ChatMessage] = []
         var manualHintPrepared = false
-        /// Distinguishes a fresh natural event from a failed attempt whose automatic wake was
-        /// coalesced with that event. Filler suppression must never cancel the latter.
-        var hasFailedAttempt = false
     }
 
     private enum AttemptResult {
@@ -704,7 +701,6 @@ public final class CoachDriver: @unchecked Sendable {
                 if let reason = wake.reason {
                     failedWork.reason = Self.coalescing(failedWork.reason, with: reason)
                 }
-                failedWork.hasFailedAttempt = true
                 work = failedWork
                 automaticSequence += 1
 
@@ -772,13 +768,18 @@ public final class CoachDriver: @unchecked Sendable {
         let substantiveLines = delta.lines.filter(TurnSubstance.isSubstantive)
         let substantiveDeltaText = RollingTranscript.render(substantiveLines)
 
-        // Filler-only natural events do not spend a provider attempt or enter later brain context.
-        // Activity has already recorded the finalized transcript, so consuming this boundary loses
-        // no user-visible evidence. A natural wake may also coalesce with failed pending work whose
-        // transcript delta is empty (for example, a silence attempt); that automatic attempt must
-        // still run.
-        if reason == .turnEnd && !work.hasFailedAttempt
-            && substantiveLines.isEmpty {
+        let userText = [
+            substantiveDeltaText.isEmpty
+                ? nil
+                : JarvisPrompts.Coach.newSpeech(substantiveDeltaText),
+            context.promptLine,
+        ].compactMap { $0 }.joined(separator: "\n\n")
+        var turnMessages = userText.isEmpty ? work.observations : [.user(userText)] + work.observations
+
+        // A request needs meaningful speech, a trigger instruction, or a provider-neutral
+        // observation completed by the failed attempt. Activity has already retained finalized
+        // filler, so an empty fresh attempt has no value to send and needs no synthetic placeholder.
+        if turnMessages.isEmpty {
             let preview = delta.lines.isEmpty
                 ? "nothing new"
                 : String(delta.lines.map(\.text).joined(separator: " · ").prefix(80))
@@ -786,15 +787,7 @@ public final class CoachDriver: @unchecked Sendable {
             commitTranscript(through: delta.upTo)
             return .skipped(.skippedFillerOnly)
         }
-
         let historyBase: [ChatMessage] = [.system(JarvisPrompts.Coach.system)] + history.snapshot()
-        let userText = [
-            substantiveDeltaText.isEmpty
-                ? nil
-                : JarvisPrompts.Coach.newSpeech(substantiveDeltaText),
-            context.promptLine,
-        ].compactMap { $0 }.joined(separator: "\n\n")
-        var turnMessages: [ChatMessage] = [.user(userText)] + work.observations
 
         if reason == .manualHint && !work.manualHintPrepared {
             if let prompt = context.promptLine {

--- a/Sources/JarvisCore/Coach/CoachHistory.swift
+++ b/Sources/JarvisCore/Coach/CoachHistory.swift
@@ -93,8 +93,9 @@ public final class CoachHistory: @unchecked Sendable {
         return calls.isEmpty ? nil : .assistantToolCalls(calls)
     }
 
-    /// Rough size of the memory in tokens (chars/4) — used only to decide WHEN to compact, so
-    /// precision doesn't matter. No image term: screenshots are stubbed to text at commit.
+    /// Rough size of the memory in tokens — used only to decide WHEN to compact. ASCII text uses the
+    /// common chars/4 heuristic; every non-ASCII scalar counts as one so Chinese and other scripts do
+    /// not wait several times too long. No image term: screenshots are stubbed to text at commit.
     public var estimatedTokens: Int {
         lock.lock(); defer { lock.unlock() }
         return Self.estimate(messages)
@@ -102,10 +103,25 @@ public final class CoachHistory: @unchecked Sendable {
 
     private static func estimate(_ messages: [ChatMessage]) -> Int {
         messages.reduce(0) { total, m in
-            var t = total + ((m.text?.count ?? 0) / 4)
-            if let calls = m.toolCalls { t += calls.reduce(0) { $0 + ($1.argumentsJSON.count / 4) + 8 } }
+            var t = total + (m.text.map(estimatedTextTokens) ?? 0)
+            if let calls = m.toolCalls {
+                t += calls.reduce(0) { $0 + estimatedTextTokens($1.argumentsJSON) + 8 }
+            }
             return t
         }
+    }
+
+    private static func estimatedTextTokens(_ text: String) -> Int {
+        var asciiCount = 0
+        var nonASCIICount = 0
+        for scalar in text.unicodeScalars {
+            if scalar.value < 128 {
+                asciiCount += 1
+            } else {
+                nonASCIICount += 1
+            }
+        }
+        return ((asciiCount + 3) / 4) + nonASCIICount
     }
 
     /// The oldest span to summarize: the longest message prefix holding roughly `fraction` of the

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -16,7 +16,8 @@ public struct Config: Sendable {
     /// When the client-managed session memory (`CoachHistory`) grows past this many estimated tokens,
     /// the driver condenses its oldest span into a short summary (see `CoachDriver.compactIfNeeded`).
     /// Sized to industry practice for conversational loads (~5–20k): big enough that compaction is
-    /// rare (a few times an hour), small enough that per-request input stays cheap.
+    /// rare (a few times an hour), small enough that per-request input stays cheap. The estimator is
+    /// conservative for non-ASCII scripts so this boundary is useful in multilingual sessions.
     public var historyCompactionTokenThreshold: Int
     /// Fixed time added to every overlay line before its reading time. Unlike a movie viewer (eyes on
     /// the screen, audio reinforcing the text), our user is mid-conversation and only *glances* at the

--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -11,6 +11,11 @@ extension JarvisPrompts {
         # Context
         - "me:" is the user you coach. "them:" is the interviewer or caller. Speak only to "me"; never
           answer "them" directly.
+        - Never speak as if you are "me" or claim you performed an action. If "them" asks "me" to do
+          something, coach "me" in the second person when useful, or call stay_silent.
+        - Your only actions are capture_screen, speak, and stay_silent. capture_screen lets you inspect the
+          screen; it does not share it. Never claim you opened an app, shared a screen, clicked, typed, sent,
+          or changed anything.
         - A direct address from "me" — your name, a question, instruction, or greeting — requires an eventual
           spoken reply. "them:" is context; offer "me" a tip only when useful.
         - New speech appears under "New since last turn" with [mm:ss] timestamps. A

--- a/Sources/JarvisCore/Prompts/JarvisPrompts+HistorySummary.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+HistorySummary.swift
@@ -3,10 +3,12 @@ import Foundation
 extension JarvisPrompts {
     public enum HistorySummary {
         public static let system = """
-        You condense a live coding-interview coaching session's history into a briefing the coach will \
-        rely on for the rest of the session. Keep, in this order: the interview problem statement (all \
-        load-bearing details); the user's current approach and how far they've got; every tip the coach \
-        already gave (so it isn't repeated); any open questions or requirements from the interviewer. \
+        You condense an older span of a live coaching session's history into a briefing the coach will \
+        rely on for the rest of the session. Preserve durable context: the participants and goal; the \
+        active topic or task and its load-bearing details; the user's approach, progress, and decisions; \
+        advice the coach already gave so it is not repeated; and requirements, feedback, or unresolved \
+        questions from the interviewer or caller. Compress resolved topics to only facts likely to matter \
+        later and omit obsolete detail. Do not assume a coding interview or any single interview format. \
         Plain text, under 250 words. Output only the briefing.
         """
 

--- a/Sources/JarvisCore/Transcription/Transcript.swift
+++ b/Sources/JarvisCore/Transcription/Transcript.swift
@@ -68,7 +68,7 @@ public final class RollingTranscript: @unchecked Sendable {
     /// sockets (mic/"me", system audio/"them") append independently and a slow utterance can complete
     /// — and so be appended — after a later one, so insertion order isn't time order. We sort by `.at`
     /// (stable on ties via the original index) so the coach always sees the order things were said.
-    private static func render<S: Sequence>(_ lines: S) -> String where S.Element == TranscriptLine {
+    static func render<S: Sequence>(_ lines: S) -> String where S.Element == TranscriptLine {
         lines.enumerated()
             .sorted { $0.element.at != $1.element.at ? $0.element.at < $1.element.at : $0.offset < $1.offset }
             .map { "[\(stamp($0.element.at))] \($0.element.speaker.rawValue): \($0.element.text)" }

--- a/Sources/JarvisCore/Triggers/TurnSubstance.swift
+++ b/Sources/JarvisCore/Triggers/TurnSubstance.swift
@@ -35,6 +35,7 @@ public enum TurnSubstance {
         let lower = text.lowercased()
         if lower.contains("jarvis") { return true }
         if lower.contains("?") || lower.contains("？") { return true }
+        if containsAcronymLikeSound(text) { return true }
 
         let collapsed = normalized(lower)
 
@@ -68,6 +69,21 @@ public enum TurnSubstance {
     private static func isDiscardableSoundSequence(_ lower: String) -> Bool {
         let parts = normalizedSeparatorParts(lower)
         return parts.count > 1 && parts.allSatisfy(discardableSounds.contains)
+    }
+
+    /// Preserve an all-uppercase token whose lowercase spelling collides with a sound ("M", "ER",
+    /// "UM", "OH"). Capitalization is the only local evidence that it may be a variable or acronym;
+    /// ordinary ASR fillers such as "Um" and "Oh" remain discardable.
+    private static func containsAcronymLikeSound(_ text: String) -> Bool {
+        text.components(separatedBy: soundSeparators).contains { part in
+            guard discardableSounds.contains(normalized(part.lowercased())) else { return false }
+            let casedLetters = part.unicodeScalars.filter {
+                CharacterSet.uppercaseLetters.contains($0) || CharacterSet.lowercaseLetters.contains($0)
+            }
+            return !casedLetters.isEmpty && casedLetters.allSatisfy {
+                CharacterSet.uppercaseLetters.contains($0)
+            }
+        }
     }
 
     private static func normalizedSeparatorParts(_ lower: String) -> [String] {

--- a/Sources/JarvisCore/Triggers/TurnSubstance.swift
+++ b/Sources/JarvisCore/Triggers/TurnSubstance.swift
@@ -1,41 +1,33 @@
 import Foundation
 
-/// Decides whether a transcript line carries coaching-relevant substance or is pure back-channel
-/// filler ("Hmm", "嗯嗯", "ok"). The coach loop removes known filler from brain-facing context and
-/// skips a turn-end whose whole delta is filler — from either speaker — so it never buys a request.
+/// Decides whether a transcript line carries coaching-relevant substance or is only a clear
+/// hesitation sound ("Hmm", "Uh", "嗯嗯"). The coach loop removes those sounds from brain-facing
+/// context and skips a turn-end whose whole delta is discardable — from either speaker — so it never
+/// buys a request.
 /// The finalized transcript still remains in Activity for the user to audit.
 ///
-/// Why a list is enough: back-channels are a small CLOSED class per language (roughly a dozen forms);
-/// the apparent endless variety is elongation/repetition, which the repeat-collapsing normalization
-/// absorbs ("Hmmmm." → "hm", "嗯嗯" → "嗯"). Everything outside that closed class FAILS OPEN to
-/// the brain — including unknown short fragments. The model stays the judge of meaning; this is
-/// punctuation-level hygiene, not a wake-word gate.
+/// The list is deliberately conservative: lexical replies such as "Yes", "No", "Okay", "Right",
+/// "对", and "可以" can change the conversation, so they always fail open to the brain regardless of
+/// speaker. Elongation/repetition normalization absorbs spelling variants ("Hmmmm." → "hm", "嗯嗯" →
+/// "嗯"). The model stays the judge of meaning; this is punctuation-level hygiene, not a wake-word gate.
 public enum TurnSubstance {
-    /// A bare rejection from the interviewer is not a back-channel: it corrects the user's current
-    /// understanding and needs an immediate coaching turn. The same words from the user remain
-    /// filler ("no, no" while thinking aloud), so this override must see the speaker label.
-    private static let interviewerCorrections: Set<String> = ["no", "nope"]
-
-    /// Human-readable back-channel forms, kept in natural spelling. Each is run through `normalized`
-    /// when the set is built, so entries stay readable while being guaranteed to match normalized
-    /// input — an entry with a doubled letter ("cool", "i see") can't silently die to the collapse
-    /// step. To add a language, add its dozen closed-class forms in plain spelling.
-    private static let fillers: Set<String> = Set([
+    /// Human-readable non-semantic vocal sounds, kept in natural spelling. Each is run through
+    /// `normalized` when the set is built so it matches normalized input. Keep semantic
+    /// acknowledgements out of this set even when they are often used casually.
+    private static let discardableSounds: Set<String> = Set([
         // English
-        "hm", "m", "mhm", "uh", "um", "uhuh", "uhum", "ok", "okay",
-        "yes", "yeah", "yep", "no", "nope", "right", "sure", "wow", "oh", "ah", "so",
-        "cool", "got it", "i see", "alright",
+        "hm", "m", "uh", "um", "er", "erm", "oh", "ah",
         // Chinese
-        "嗯", "恩", "啊", "哦", "噢", "呃", "好", "好的", "好吧", "好了",
-        "对", "对的", "是", "是的", "明白", "可以", "行", "了解",
+        "嗯", "恩", "啊", "哦", "噢", "呃",
     ].map(normalized))
 
-    /// Separators that may join several independent filler acknowledgements in one transcription
-    /// result ("Uh. Okay. Hmm."). Whitespace is deliberately excluded because some closed-class
-    /// entries are phrases ("got it", "I see"); an unknown phrase continues to fail open.
-    private static let fillerSeparators = CharacterSet.punctuationCharacters
+    /// Separators that may join several independent hesitation sounds in one transcription result
+    /// ("Uh. Hmm. Oh."). Hyphens stay inside a form so affirmative sounds such as "Mm-hmm" fail
+    /// open instead of being mistaken for the separate noises "m" and "hm".
+    private static let soundSeparators = CharacterSet.punctuationCharacters
+        .subtracting(CharacterSet(charactersIn: "-"))
         .union(.symbols)
-        .union(.newlines)
+        .union(.whitespacesAndNewlines)
 
     /// True when the line should reach the brain. Order matters: overrides first (a question or an
     /// address is always substance, whoever said it), then normalize and consult the closed class.
@@ -46,25 +38,22 @@ public enum TurnSubstance {
 
         let collapsed = normalized(lower)
 
-        if collapsed.isEmpty { return false }                       // pure punctuation / noise
-        if fillers.contains(collapsed) { return false }             // one known back-channel
-        if isKnownFillerSequence(lower) { return false }            // several known back-channels
+        if collapsed.isEmpty { return false }                              // pure punctuation / noise
+        if discardableSounds.contains(collapsed) { return false }          // one clear sound
+        if isDiscardableSoundSequence(lower) { return false }              // several clear sounds
         return true
     }
 
-    /// Speaker-aware entry point used by the coach's delta gate. Most filler behavior stays neutral,
-    /// but a terse interviewer rejection is a correction, not conversational noise.
+    /// Speaker-labeled entry point used by the coach's delta gate. Classification stays neutral:
+    /// ambiguous short replies are preserved for both speakers.
     public static func isSubstantive(_ line: TranscriptLine) -> Bool {
-        if line.speaker == .them, containsInterviewerCorrection(line.text.lowercased()) {
-            return true
-        }
         return isSubstantive(line.text)
     }
 
     /// Keep only letters/digits (CJK ideographs are letters), dropping punctuation, whitespace, and
     /// symbols; then collapse consecutive repeats so elongations fold onto their base form
-    /// ("Hmmmm." → "hm", "嗯嗯" → "嗯"). Applied to both incoming lines and the `fillers` set so the
-    /// two are compared in the same shape.
+    /// ("Hmmmm." → "hm", "嗯嗯" → "嗯"). Applied to both incoming lines and `discardableSounds`
+    /// so the two are compared in the same shape.
     private static func normalized(_ lower: String) -> String {
         var collapsed = ""
         for scalar in lower.unicodeScalars where CharacterSet.alphanumerics.contains(scalar) {
@@ -74,21 +63,15 @@ public enum TurnSubstance {
         return collapsed
     }
 
-    /// True only when punctuation/newlines separate two or more known filler forms. Requiring every
-    /// part to be in the closed class keeps technical fragments such as "B.F.S." substantive.
-    private static func isKnownFillerSequence(_ lower: String) -> Bool {
+    /// True only when separators divide two or more clear hesitation sounds. Requiring every part
+    /// to be in the conservative set keeps technical fragments such as "B.F.S." substantive.
+    private static func isDiscardableSoundSequence(_ lower: String) -> Bool {
         let parts = normalizedSeparatorParts(lower)
-        return parts.count > 1 && parts.allSatisfy(fillers.contains)
-    }
-
-    /// A composite interviewer line such as "No. Okay." still carries an immediate correction even
-    /// though each component is otherwise in the filler class.
-    private static func containsInterviewerCorrection(_ lower: String) -> Bool {
-        normalizedSeparatorParts(lower).contains(where: interviewerCorrections.contains)
+        return parts.count > 1 && parts.allSatisfy(discardableSounds.contains)
     }
 
     private static func normalizedSeparatorParts(_ lower: String) -> [String] {
-        lower.components(separatedBy: fillerSeparators)
+        lower.components(separatedBy: soundSeparators)
             .map(normalized)
             .filter { !$0.isEmpty }
     }

--- a/Sources/JarvisCore/Triggers/TurnSubstance.swift
+++ b/Sources/JarvisCore/Triggers/TurnSubstance.swift
@@ -1,16 +1,15 @@
 import Foundation
 
 /// Decides whether a transcript line carries coaching-relevant substance or is pure back-channel
-/// filler ("Hmm", "嗯嗯", "ok"). The coach loop skips a turn-end whose whole delta is filler — from
-/// either speaker — so filler never buys a brain request; the lines still ride along as context on
-/// the next substantive turn, and silence checks fire regardless, so a wrong skip costs one turn of
-/// delay at most.
+/// filler ("Hmm", "嗯嗯", "ok"). The coach loop removes known filler from brain-facing context and
+/// skips a turn-end whose whole delta is filler — from either speaker — so it never buys a request.
+/// The finalized transcript still remains in Activity for the user to audit.
 ///
 /// Why a list is enough: back-channels are a small CLOSED class per language (roughly a dozen forms);
 /// the apparent endless variety is elongation/repetition, which the repeat-collapsing normalization
-/// absorbs ("Hmmmm." → "hm", "嗯嗯" → "嗯"). Unknown-language back-channels are caught by the
-/// short-fragment fallback. Everything else FAILS OPEN to the brain — the model stays the judge of
-/// meaning; this is punctuation-level hygiene, not a wake-word gate.
+/// absorbs ("Hmmmm." → "hm", "嗯嗯" → "嗯"). Everything outside that closed class FAILS OPEN to
+/// the brain — including unknown short fragments. The model stays the judge of meaning; this is
+/// punctuation-level hygiene, not a wake-word gate.
 public enum TurnSubstance {
     /// A bare rejection from the interviewer is not a back-channel: it corrects the user's current
     /// understanding and needs an immediate coaching turn. The same words from the user remain
@@ -31,9 +30,15 @@ public enum TurnSubstance {
         "对", "对的", "是", "是的", "明白", "可以", "行", "了解",
     ].map(normalized))
 
+    /// Separators that may join several independent filler acknowledgements in one transcription
+    /// result ("Uh. Okay. Hmm."). Whitespace is deliberately excluded because some closed-class
+    /// entries are phrases ("got it", "I see"); an unknown phrase continues to fail open.
+    private static let fillerSeparators = CharacterSet.punctuationCharacters
+        .union(.symbols)
+        .union(.newlines)
+
     /// True when the line should reach the brain. Order matters: overrides first (a question or an
-    /// address is always substance, whoever said it), then normalize, then the closed-class list and
-    /// the ≤2-character fallback.
+    /// address is always substance, whoever said it), then normalize and consult the closed class.
     public static func isSubstantive(_ text: String) -> Bool {
         let lower = text.lowercased()
         if lower.contains("jarvis") { return true }
@@ -41,9 +46,9 @@ public enum TurnSubstance {
 
         let collapsed = normalized(lower)
 
-        if collapsed.isEmpty { return false }              // pure punctuation / noise
-        if fillers.contains(collapsed) { return false }    // closed-class back-channel
-        if collapsed.count <= 2 { return false }           // short fragment in ANY language
+        if collapsed.isEmpty { return false }                       // pure punctuation / noise
+        if fillers.contains(collapsed) { return false }             // one known back-channel
+        if isKnownFillerSequence(lower) { return false }            // several known back-channels
         return true
     }
 
@@ -67,5 +72,14 @@ public enum TurnSubstance {
             if collapsed.last != ch { collapsed.append(ch) }
         }
         return collapsed
+    }
+
+    /// True only when punctuation/newlines separate two or more known filler forms. Requiring every
+    /// part to be in the closed class keeps technical fragments such as "B.F.S." substantive.
+    private static func isKnownFillerSequence(_ lower: String) -> Bool {
+        let parts = lower.components(separatedBy: fillerSeparators)
+            .map(normalized)
+            .filter { !$0.isEmpty }
+        return parts.count > 1 && parts.allSatisfy(fillers.contains)
     }
 }

--- a/Sources/JarvisCore/Triggers/TurnSubstance.swift
+++ b/Sources/JarvisCore/Triggers/TurnSubstance.swift
@@ -55,7 +55,7 @@ public enum TurnSubstance {
     /// Speaker-aware entry point used by the coach's delta gate. Most filler behavior stays neutral,
     /// but a terse interviewer rejection is a correction, not conversational noise.
     public static func isSubstantive(_ line: TranscriptLine) -> Bool {
-        if line.speaker == .them, interviewerCorrections.contains(normalized(line.text.lowercased())) {
+        if line.speaker == .them, containsInterviewerCorrection(line.text.lowercased()) {
             return true
         }
         return isSubstantive(line.text)
@@ -77,9 +77,19 @@ public enum TurnSubstance {
     /// True only when punctuation/newlines separate two or more known filler forms. Requiring every
     /// part to be in the closed class keeps technical fragments such as "B.F.S." substantive.
     private static func isKnownFillerSequence(_ lower: String) -> Bool {
-        let parts = lower.components(separatedBy: fillerSeparators)
+        let parts = normalizedSeparatorParts(lower)
+        return parts.count > 1 && parts.allSatisfy(fillers.contains)
+    }
+
+    /// A composite interviewer line such as "No. Okay." still carries an immediate correction even
+    /// though each component is otherwise in the filler class.
+    private static func containsInterviewerCorrection(_ lower: String) -> Bool {
+        normalizedSeparatorParts(lower).contains(where: interviewerCorrections.contains)
+    }
+
+    private static func normalizedSeparatorParts(_ lower: String) -> [String] {
+        lower.components(separatedBy: fillerSeparators)
             .map(normalized)
             .filter { !$0.isEmpty }
-        return parts.count > 1 && parts.allSatisfy(fillers.contains)
     }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -641,6 +641,19 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.isEmpty)
     }
 
+    /// Several known acknowledgements in one transcription completion are still one filler-only
+    /// turn and do not buy a request.
+    @Test func compositeFillerTurnEndSkipsTheBrain() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "quiet")]),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "Uh. OK. Okay, okay.", at: 1))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .skippedFillerOnly)
+        #expect(brain.calls.isEmpty)
+    }
+
     /// The gate is speaker-NEUTRAL: an interviewer question is substance and reaches the brain — the
     /// prompt lets the model offer the user a proactive tip for answering it.
     @Test func interviewerQuestionReachesTheBrain() async {
@@ -664,9 +677,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.isEmpty)
     }
 
-    /// Skipped filler is NOT lost: the sent-index doesn't advance on a skip, so it rides along with
-    /// the next substantive turn in one request.
-    @Test func skippedFillerRidesAlongOnTheNextTurn() async {
+    /// Activity has already retained finalized speech, so a locally skipped filler line is consumed
+    /// and does not inflate the next substantive request.
+    @Test func skippedFillerDoesNotRideAlongOnTheNextTurn() async {
         let clock = ManualClock(now: 0)
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")]),
@@ -676,9 +689,26 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .skippedFillerOnly)
         transcript.append(.init(speaker: .me, text: "I'd check both neighbors at that height", at: 5))
         await driver.handleTrigger(.turnEnd)
-        let userText = brain.calls[0].compactMap { $0.text }.joined(separator: " ")
-        #expect(userText.contains("嗯"))                                     // filler context arrived...
-        #expect(userText.contains("I'd check both neighbors at that height")) // ...with the real line
+        let userText = brain.calls[0].filter { $0.role == .user }.compactMap(\.text)
+            .joined(separator: " ")
+        #expect(!userText.contains("嗯"))
+        #expect(userText.contains("I'd check both neighbors at that height"))
+    }
+
+    /// Known filler beside real speech remains in Activity but is removed from brain-facing input.
+    @Test func mixedDeltaSendsOnlySubstantiveLines() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "quiet")]),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "Hmm.", at: 1))
+        transcript.append(.init(speaker: .them, text: "How would you test that?", at: 2))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
+        let userText = brain.calls[0].filter { $0.role == .user }.compactMap(\.text)
+            .joined(separator: " ")
+        #expect(!userText.contains("Hmm."))
+        #expect(userText.contains("How would you test that?"))
     }
 
     /// Silence wake-ups are NOT gated: with nothing new said, the model may still want to look at the

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -684,6 +684,24 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(userText.contains("Yes. Hmm."))
     }
 
+    /// Uppercase tokens that spell like hesitation sounds can be variables or acronyms. They must
+    /// reach the brain rather than being permanently consumed at the transcript boundary.
+    @Test func acronymLikeShortUtterancesReachTheBrain() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "quiet")]),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .them, text: "ER", at: 1))
+        transcript.append(.init(speaker: .me, text: "M", at: 2))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
+        #expect(brain.calls.count == 1)
+        let userText = brain.calls[0].filter { $0.role == .user }.compactMap(\.text)
+            .joined(separator: " ")
+        #expect(userText.contains("[00:01] them: ER"))
+        #expect(userText.contains("[00:02] me: M"))
+    }
+
     /// An empty-delta turn-end (fragments already sent last turn) is skipped the same way.
     @Test func emptyDeltaTurnEndSkipsTheBrain() async {
         let clock = ManualClock(now: 0)

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -625,10 +625,10 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(overlay.rendered.isEmpty)
     }
 
-    // MARK: - The substance gate: filler never buys a brain request
+    // MARK: - The substance gate: clear hesitation sounds never buy a brain request
 
-    /// A turn-end whose whole delta is back-channel filler — from EITHER speaker — is skipped without
-    /// a request: filler can't produce a tip, and the request would only re-bill the working set.
+    /// A turn-end whose whole delta is clear hesitation sounds — from EITHER speaker — is skipped
+    /// without a request: those sounds can't produce a tip, and the call would only re-bill context.
     @Test func fillerOnlyTurnEndSkipsTheBrain() async {
         let clock = ManualClock(now: 0)
         let brain = ScriptedBrain(script: [
@@ -641,14 +641,14 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.isEmpty)
     }
 
-    /// Several known acknowledgements in one transcription completion are still one filler-only
+    /// Several clear hesitation sounds in one transcription completion are still one filler-only
     /// turn and do not buy a request.
     @Test func compositeFillerTurnEndSkipsTheBrain() async {
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")]),
         ])
         let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
-        transcript.append(.init(speaker: .me, text: "Uh. OK. Okay, okay.", at: 1))
+        transcript.append(.init(speaker: .me, text: "Uh. Hmm. Oh, oh.", at: 1))
 
         #expect(await driver.handleTrigger(.turnEnd) == .skippedFillerOnly)
         #expect(brain.calls.isEmpty)
@@ -666,20 +666,22 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.count == 1)
     }
 
-    /// A correction remains substantive when the transcriber combines it with acknowledgements
-    /// that would otherwise form a composite filler line.
-    @Test func compositeInterviewerCorrectionReachesTheBrain() async {
+    /// Context-dependent short replies remain substantive for either speaker, including when the
+    /// transcriber combines one with a clear hesitation sound.
+    @Test func contextDependentTerseRepliesReachTheBrainForEitherSpeaker() async {
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")]),
         ])
         let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
         transcript.append(.init(speaker: .them, text: "No. Okay.", at: 1))
+        transcript.append(.init(speaker: .me, text: "Yes. Hmm.", at: 2))
 
         #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
         #expect(brain.calls.count == 1)
         let userText = brain.calls[0].filter { $0.role == .user }.compactMap(\.text)
             .joined(separator: " ")
         #expect(userText.contains("No. Okay."))
+        #expect(userText.contains("Yes. Hmm."))
     }
 
     /// An empty-delta turn-end (fragments already sent last turn) is skipped the same way.
@@ -711,7 +713,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(userText.contains("I'd check both neighbors at that height"))
     }
 
-    /// Known filler beside real speech remains in Activity but is removed from brain-facing input.
+    /// A clear hesitation sound beside real speech remains in Activity but is removed from input.
     @Test func mixedDeltaSendsOnlySubstantiveLines() async {
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")]),
@@ -739,7 +741,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.count == 1)
     }
 
-    @Test func fillerWakeCannotCancelFailedSilenceAttempt() async {
+    /// A filler wake after a failed silence attempt has no new value to send. It consumes the
+    /// transcript boundary instead of starting a fresh provider request with an empty user message.
+    @Test func fillerWakeAfterFailedSilenceSkipsEmptyFreshAttempt() async {
         let gate = AsyncGate()
         let brain = GatedFailureThenSpeakingBrain(gate: gate)
         let overlay = FakeOverlay()
@@ -754,9 +758,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .busy)
         await gate.release()
 
-        #expect(await outcome == .spoke)
-        #expect(brain.calls.count == 2)
-        #expect(overlay.rendered == [["recovered pending turn"]])
+        #expect(await outcome == .skippedFillerOnly)
+        #expect(brain.calls.count == 1)
+        #expect(overlay.rendered.isEmpty)
     }
 
     // MARK: - Client-managed session memory (CoachHistory)
@@ -1613,6 +1617,37 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(!fallbackRequest.contains { $0.toolCalls != nil })
     }
 
+    /// A completed screen observation is useful context for a fresh attempt even when the only new
+    /// speech is filler. Send the observation directly: do not recapture, replay raw tool state, or
+    /// manufacture an empty/synthetic speech message.
+    @Test func savedObservationStartsFreshAttemptWithoutEmptySpeech() async {
+        let gate = AsyncGate()
+        let brain = CaptureThenGatedFailureThenSpeakingBrain(gate: gate)
+        let screen = FakeScreen(recognizedText: "let answer = 42")
+        let (driver, transcript) = makeDriver(
+            brain: brain,
+            screen: screen,
+            clock: ManualClock())
+
+        async let outcome = driver.handleTrigger(.silence(secondsQuiet: 30))
+        await gate.waitUntilEntered()
+        transcript.append(.init(speaker: .them, text: "Hmm.", at: 1))
+        #expect(await driver.handleTrigger(.turnEnd) == .busy)
+        await gate.release()
+
+        #expect(await outcome == .spoke)
+        #expect(screen.captureCount == 1)
+        #expect(brain.calls.count == 3)
+        let freshRequest = brain.calls[2]
+        #expect(!freshRequest.contains { $0.role == .user && $0.text == "" })
+        #expect(!freshRequest.contains { ($0.text ?? "").contains("Hmm.") })
+        #expect(freshRequest.contains { $0.imageBase64JPEG == screen.payload })
+        #expect(freshRequest.contains { ($0.text ?? "").contains("let answer = 42") })
+        #expect(!freshRequest.contains { $0.role == .tool })
+        #expect(!freshRequest.contains { $0.rawItemsJSON != nil })
+        #expect(!freshRequest.contains { $0.toolCalls != nil })
+    }
+
     @Test func automaticPendingAttemptWaitsForBothSpeakersToStop() async {
         let gate = AsyncGate()
         let delayGate = AsyncGate()
@@ -2101,12 +2136,12 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         await gate.release()
 
         #expect(await first == .spoke)
-        let retryUserText = brain.calls[1]
+        let freshAttemptUserText = brain.calls[1]
             .filter { $0.role == .user }
             .compactMap(\.text)
             .joined(separator: "\n")
-        #expect(retryUserText.contains("new speech ended"))
-        #expect(!retryUserText.contains("no speech for"))
+        #expect(freshAttemptUserText.contains("new speech ended"))
+        #expect(!freshAttemptUserText.contains("no speech for"))
     }
 
     /// Audio-driven turns REQUIRE a tool call (never free text): the model picks which tool from the
@@ -2432,6 +2467,50 @@ final class GatedFailureThenSpeakingBrain: BrainClient, @unchecked Sendable {
                     id: "recovered", name: "speak",
                     argumentsJSON: #"{"lines":["recovered pending turn"]}"#),
             ])
+    }
+}
+
+/// Captures once, then parks and fails the continuation request. The next call belongs to a fresh
+/// attempt and lets tests inspect exactly which provider-neutral context survives.
+final class CaptureThenGatedFailureThenSpeakingBrain: BrainClient, @unchecked Sendable {
+    private let gate: AsyncGate
+    private let lock = NSLock()
+    private var recordedCalls: [[ChatMessage]] = []
+    var calls: [[ChatMessage]] { lock.withLock { recordedCalls } }
+
+    init(gate: AsyncGate) { self.gate = gate }
+
+    func respond(messages: [ChatMessage], tools: [ToolDef],
+                 toolChoice: ToolChoice) async throws -> BrainResponse {
+        let index = lock.withLock {
+            recordedCalls.append(messages)
+            return recordedCalls.count - 1
+        }
+        switch index {
+        case 0:
+            return BrainResponse(
+                toolCalls: [.captureScreen(callId: "capture")],
+                rawToolCalls: [
+                    RawToolCall(
+                        id: "capture",
+                        name: "capture_screen",
+                        argumentsJSON: "{}"),
+                ])
+        case 1:
+            await gate.enter()
+            throw NSError(
+                domain: "FutureProvider", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "temporary provider interruption"])
+        default:
+            return BrainResponse(
+                toolCalls: [.speak(callId: "recovered", lines: ["used saved observation"])],
+                rawToolCalls: [
+                    RawToolCall(
+                        id: "recovered",
+                        name: "speak",
+                        argumentsJSON: #"{"lines":["used saved observation"]}"#),
+                ])
+        }
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -666,6 +666,22 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls.count == 1)
     }
 
+    /// A correction remains substantive when the transcriber combines it with acknowledgements
+    /// that would otherwise form a composite filler line.
+    @Test func compositeInterviewerCorrectionReachesTheBrain() async {
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "quiet")]),
+        ])
+        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .them, text: "No. Okay.", at: 1))
+
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
+        #expect(brain.calls.count == 1)
+        let userText = brain.calls[0].filter { $0.role == .user }.compactMap(\.text)
+            .joined(separator: " ")
+        #expect(userText.contains("No. Okay."))
+    }
+
     /// An empty-delta turn-end (fragments already sent last turn) is skipped the same way.
     @Test func emptyDeltaTurnEndSkipsTheBrain() async {
         let clock = ManualClock(now: 0)

--- a/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
@@ -128,4 +128,16 @@ import Testing
         #expect(h.estimatedTokens > afterText)                    // the stub still counts…
         #expect(h.estimatedTokens < afterText + 100)              // …but nowhere near image cost
     }
+
+    /// The compaction trigger must not apply an English chars/4 estimate to Chinese text. Equal
+    /// character counts deliberately produce a more conservative estimate for non-ASCII scripts.
+    @Test func estimateTreatsNonASCIITextConservatively() {
+        let latin = CoachHistory()
+        latin.commit([.user(String(repeating: "a", count: 100))])
+        let chinese = CoachHistory()
+        chinese.commit([.user(String(repeating: "中", count: 100))])
+
+        #expect(latin.estimatedTokens == 25)
+        #expect(chinese.estimatedTokens == 100)
+    }
 }

--- a/Tests/JarvisCoreTests/Coach/HistorySummaryPromptTests.swift
+++ b/Tests/JarvisCoreTests/Coach/HistorySummaryPromptTests.swift
@@ -1,0 +1,17 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct HistorySummaryPromptTests {
+    /// Compaction serves every supported interview format and retires old topics instead of forcing
+    /// behavioral or project discussion into a coding-problem template.
+    @Test func summaryIsFormatNeutralAndRetiresResolvedTopics() {
+        let prompt = JarvisPrompts.HistorySummary.system.lowercased()
+
+        #expect(prompt.contains("live coaching session"))
+        #expect(prompt.contains("participants and goal"))
+        #expect(prompt.contains("resolved topics"))
+        #expect(prompt.contains("omit obsolete detail"))
+        #expect(prompt.contains("do not assume a coding interview"))
+        #expect(!prompt.contains("coding-interview coaching session"))
+    }
+}

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -93,6 +93,15 @@ import Testing
         #expect(!modelContext.lowercased().contains("leetcode"))
     }
 
+    /// Interviewer instructions are context for coaching the user, never an invitation for Jarvis
+    /// to impersonate the user or claim it performed an unavailable action.
+    @Test func coachPromptForbidsRolePlayingAndUnsupportedActionClaims() {
+        #expect(JarvisPrompts.Coach.system.contains("Never speak as if you are \"me\""))
+        #expect(JarvisPrompts.Coach.system.contains("coach \"me\" in the second person"))
+        #expect(JarvisPrompts.Coach.system.contains("it does not share it"))
+        #expect(JarvisPrompts.Coach.system.contains("Never claim you opened an app"))
+    }
+
     @Test func coachPromptHasOneConsistentFullSolutionRule() {
         #expect(JarvisPrompts.Coach.system.contains("Give a full solution only when \"me\" explicitly asks"))
         #expect(!JarvisPrompts.Coach.system.contains("never the whole answer"))

--- a/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
@@ -57,10 +57,10 @@ import Testing
         }
     }
 
-    /// A terse interviewer rejection changes the requirements immediately. It must not wait for the
-    /// next long utterance, while the same one-word response from the user remains a back-channel.
+    /// A terse interviewer rejection changes the requirements immediately, including when the
+    /// transcriber combines it with other acknowledgements. The same user response remains filler.
     @Test func interviewerRejectionIsImmediateSubstance() {
-        for text in ["No.", "nope"] {
+        for text in ["No.", "nope", "No. Okay.", "No. No.", "Nope. Hmm."] {
             #expect(TurnSubstance.isSubstantive(.init(speaker: .them, text: text, at: 1)))
             #expect(!TurnSubstance.isSubstantive(.init(speaker: .me, text: text, at: 1)))
         }

--- a/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
@@ -53,6 +53,17 @@ import Testing
         }
     }
 
+    /// Capitalization can distinguish a technical identifier from an otherwise identical vocal
+    /// sound. Ambiguous all-uppercase forms fail open; normal sentence-cased fillers stay filtered.
+    @Test func acronymLikeSoundSpellingsFailOpen() {
+        for text in ["M", "ER", "UM", "OH", "U.M.", "UM. Oh."] {
+            #expect(TurnSubstance.isSubstantive(text), "expected acronym-like substance: \(text)")
+        }
+        for text in ["m", "Er", "Um", "Oh"] {
+            #expect(!TurnSubstance.isSubstantive(text), "expected vocal sound: \(text)")
+        }
+    }
+
     /// Questions and addresses punch through, whoever said them — including interviewer questions
     /// that should draw a proactive tip, and even a bare "ok?" that would otherwise be filler.
     @Test func questionsAndAddressesAlwaysSubstantive() {

--- a/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
@@ -2,20 +2,10 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct TurnSubstanceTests {
-    /// The closed class: plain back-channels in both shipped languages are filler.
-    @Test func backChannelsAreFiller() {
-        for text in ["Hmm", "hm", "Mm-hmm.", "uh", "Um...", "ok", "OK.", "Okay",
-                     "yeah", "Yes.", "right", "Sure", "oh", "嗯", "啊", "哦", "好的",
-                     "对", "是的", "明白", "行", "了解"] {
-            #expect(!TurnSubstance.isSubstantive(text), "expected filler: \(text)")
-        }
-    }
-
-    /// Multi-letter back-channels whose spelling has a doubled letter ("cool", "I see") must still
-    /// match: the `fillers` set is normalized with the same collapse step as the input, so a doubled
-    /// letter can't silently drop an entry out of the set. Regression for the dead-entry bug.
-    @Test func doubledLetterBackChannelsAreFiller() {
-        for text in ["cool", "Cool.", "cooool", "I see", "I see.", "isee", "I  see"] {
+    /// Only clear vocal hesitation sounds in the shipped languages are discarded.
+    @Test func clearHesitationSoundsAreFiller() {
+        for text in ["Hmm", "hm", "uh", "Um...", "er", "erm", "oh", "Ah",
+                     "嗯", "啊", "哦", "噢", "呃"] {
             #expect(!TurnSubstance.isSubstantive(text), "expected filler: \(text)")
         }
     }
@@ -23,18 +13,32 @@ import Testing
     /// Elongation/repetition variants normalize onto their base form — the reason the closed-class
     /// list doesn't need to enumerate "hmmm", "mmmm", "嗯嗯", …
     @Test func elongationsCollapseOntoTheList() {
-        for text in ["Hmmmm.", "mmm", "uhhh", "ummmm", "嗯嗯", "好的好的" == "好的好的" ? "嗯嗯嗯" : "嗯嗯",
-                     "okaaay", "yeahhh"] {
+        for text in ["Hmmmm.", "mmm", "uhhh", "ummmm", "ohhh", "ahhh", "嗯嗯嗯"] {
             #expect(!TurnSubstance.isSubstantive(text), "expected filler: \(text)")
         }
     }
 
-    /// One transcription completion can contain several punctuation-separated acknowledgements.
-    /// They are still filler when every part is known explicitly.
-    @Test func compositeBackChannelsAreFiller() {
-        for text in ["Oh, so, so.", "Okay. Hmm.", "Uh. OK. Okay, okay.",
-                     "Hmm. Hmm. Hmm. 嗯，明白。", "Oh. Yeah. Okay."] {
+    /// One transcription completion can contain several separated hesitation sounds.
+    @Test func compositeHesitationSoundsAreFiller() {
+        for text in ["Oh. Hmm.", "Uh. Hmm. Oh, oh.", "uh um hmm", "Hmm. 嗯，呃。"] {
             #expect(!TurnSubstance.isSubstantive(text), "expected filler: \(text)")
+        }
+    }
+
+    /// Short replies can change the conversation. Preserve them for either speaker and let the
+    /// model interpret their meaning from context.
+    @Test func contextDependentTerseRepliesFailOpenForEitherSpeaker() {
+        let replies = [
+            "OK", "Okay", "Yes", "Yeah", "No", "Nope", "Right", "Sure", "So", "Wow",
+            "Cool", "Got it", "I see", "Alright", "Mhm", "Mm-hmm", "Uh-huh",
+            "好", "好的", "对", "对的", "是", "是的", "明白", "可以", "行", "了解",
+            "No. Okay.", "Yes. Hmm.", "对。嗯。",
+        ]
+        for speaker in [Speaker.me, .them] {
+            for text in replies {
+                let line = TranscriptLine(speaker: speaker, text: text, at: 1)
+                #expect(TurnSubstance.isSubstantive(line), "expected substance: \(text)")
+            }
         }
     }
 
@@ -54,15 +58,6 @@ import Testing
     @Test func questionsAndAddressesAlwaysSubstantive() {
         for text in ["那你是怎么做的?", "ok?", "嗯？", "Jarvis", "jarvis help me", "Hey Jarvis..."] {
             #expect(TurnSubstance.isSubstantive(text), "expected substance: \(text)")
-        }
-    }
-
-    /// A terse interviewer rejection changes the requirements immediately, including when the
-    /// transcriber combines it with other acknowledgements. The same user response remains filler.
-    @Test func interviewerRejectionIsImmediateSubstance() {
-        for text in ["No.", "nope", "No. Okay.", "No. No.", "Nope. Hmm."] {
-            #expect(TurnSubstance.isSubstantive(.init(speaker: .them, text: text, at: 1)))
-            #expect(!TurnSubstance.isSubstantive(.init(speaker: .me, text: text, at: 1)))
         }
     }
 

--- a/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
+++ b/Tests/JarvisCoreTests/Triggers/TurnSubstanceTests.swift
@@ -29,11 +29,23 @@ import Testing
         }
     }
 
-    /// Short fragments are filler in ANY language — the zero-maintenance fallback for back-channels
-    /// the list has never heard of.
-    @Test func shortFragmentsAreFillerInAnyLanguage() {
-        for text in ["m", "の", "え", "네", "ja", "!!", "…", ""] {
+    /// One transcription completion can contain several punctuation-separated acknowledgements.
+    /// They are still filler when every part is known explicitly.
+    @Test func compositeBackChannelsAreFiller() {
+        for text in ["Oh, so, so.", "Okay. Hmm.", "Uh. OK. Okay, okay.",
+                     "Hmm. Hmm. Hmm. 嗯，明白。", "Oh. Yeah. Okay."] {
             #expect(!TurnSubstance.isSubstantive(text), "expected filler: \(text)")
+        }
+    }
+
+    /// Unknown short fragments fail open. A length rule would discard technical terms and terse
+    /// answers merely because they are short; pure punctuation remains content-free.
+    @Test func unknownShortFragmentsFailOpen() {
+        for text in ["の", "え", "네", "ja", "R", "Go", "C++", "B.F.S."] {
+            #expect(TurnSubstance.isSubstantive(text), "expected substance: \(text)")
+        }
+        for text in ["!!", "…", ""] {
+            #expect(!TurnSubstance.isSubstantive(text), "expected noise: \(text)")
         }
     }
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -70,12 +70,11 @@ moments the model judges worthwhile.
    cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's
    Start/Stop and the **substance gate** (`TurnSubstance`): a turn-end whose delta is pure
-   known filler ("Hmm", "嗯", or a sequence such as "Uh. Okay. Hmm.") or empty is skipped without a
-   request. Known filler lines are also removed from a mixed brain-facing delta, while Activity keeps
-   the complete finalized transcription. Unknown short fragments fail open. Classification is
-   speaker-aware only where conversational meaning demands it: a short interviewer rejection such
-   as "No" is substantive, even though the same user-side response is known filler. Interviewer
-   questions remain first-class and may draw a proactive tip. Consumed filler never rides into a
+   clear hesitation sounds ("Hmm", "嗯", or a sequence such as "Uh. Hmm. Oh.") or empty is skipped
+   without a request. Those sounds are also removed from a mixed brain-facing delta, while Activity
+   keeps the complete finalized transcription. Context-dependent short replies such as "Yes", "No",
+   "Okay", "对", and "可以" fail open for either speaker, as do unknown short fragments. Interviewer
+   questions remain first-class and may draw a proactive tip. Consumed noise never rides into a
    later request; silence checks and the hint hotkey always go through.
 3. It calls the **selected brain model** with the coach system prompt, the session memory
    (`CoachHistory`), the
@@ -141,7 +140,7 @@ plugins ship only with full Xcode, and Jarvis builds **CLT-only** (see
 | **WebRTCEchoCanceller** | AEC3 echo canceller driven at 48 kHz on 10 ms frames inside the capture IOProc; far reference first, then the mic cleaned in place. | WebRTC **AEC3** (`webrtc-audio-processing`), vendored static + zero-dylib via `scripts/build-aec.sh`. |
 | **ErrorReporter** | The single funnel for user-facing failures. Severity on a Foundation-only `UserFacingError` decides the lifecycle consequence; an explicit startup/runtime context decides presentation. Startup failures may alert, but runtime failures never activate Jarvis or present UI even when they stop the session. `BrainFailure` feeds attempt outcomes into the finite provider route; only route exhaustion enters terminal reporting. Fixed, typed Activity outcomes carry stable on-disk identities while raw detail stays in `JarvisLog`. | AppKit (`NSAlert`) for startup only. |
 | **Transcriber** | Maintain a rolling, speaker-labeled, **spoken-time timestamped** transcript; emit speech-activity, turn-end, and backing-off silence events (with quiet duration). Two instances run in parallel — one per side — tagging lines `me`/`them` into one shared transcript through the provider-neutral `TranscriptionSession` port. The default OpenAI adapter keeps its per-`item_id` reconciliation, delta salvage, acknowledged readiness, ping/pong health, and transactional reconnect path. GPT-4o Transcribe remains its default model and uses tuned server VAD. GPT Transcribe and GPT Live Transcribe remain opt-in with local WebRTC VAD: a bounded pre-roll opens at confirmed speech onset, active speech and trailing silence enter the ordered audio FIFO, and indefinite idle silence stays off the wire. Endpoints commit only after that FIFO reaches their boundary, and the server's commit acknowledgement binds each boundary to its `item_id`. GPT Transcribe also reports detected completion languages to debug diagnostics. Both new models receive fixed context for the captured speaker role, and GPT Live additionally requests low transcription delay. The opt-in macOS 26+ Apple adapter prepares one selected-locale asset before capture, converts the existing 24 kHz PCM to `SpeechAnalyzer`'s preferred format, and commits final results only. Its content-free local activity tracker delays coaching but never gates transcription or retains PCM. Every path keeps unusable words diagnostic-only and records content-free boundary evidence. | OpenAI Realtime transcription (model-compatible server or local turn detection) or Apple `SpeechAnalyzer` / `SpeechTranscriber` (on-device). |
-| **CoachDriver** | Coordinate one single-flighted coaching attempt from a natural trigger or pending-work wake-up: snapshot one route target plus the latest conversation, route its tool calls, commit only a complete terminal action, and report one outcome to the scheduler. No speaking cooldown/rate cap — restraint is the model's; the only client-side content skip is the filler-only turn-end gate (`TurnSubstance`). | The selected OpenAI Responses API, Claude Code, or Codex route target; See [§4 Local CLI brain providers](#local-cli-brain-providers). Provider-specific summary tiers are defined in `BrainModelCatalog`. |
+| **CoachDriver** | Coordinate one single-flighted coaching attempt from a natural trigger or pending-work wake-up: snapshot one route target plus the latest conversation, route its tool calls, commit only a complete terminal action, and report one outcome to the scheduler. No speaking cooldown/rate cap — restraint is the model's; `TurnSubstance` removes only clear hesitation sounds from mixed deltas and skips a turn-end when no substantive text or saved observation remains. | The selected OpenAI Responses API, Claude Code, or Codex route target; See [§4 Local CLI brain providers](#local-cli-brain-providers). Provider-specific summary tiers are defined in `BrainModelCatalog`. |
 | **Local agent runtime** | Keep provider startup outside the coaching latency path while preserving the attempt boundary: a `BrainConversation` lease owns every model turn in one attempt, including a `capture_screen` continuation, then is explicitly finished. Claude leases one initialized safe-mode query; Codex prepares the first target-specific ephemeral thread at Session Start and opens a fresh thread for each later attempt on one session-scoped app-server. A runtime failure fails the attempt; it never switches to a one-shot transport. | Claude Code stream-json control protocol; Codex app-server JSON-RPC over stdio. |
 | **ScreenTool** | Fulfill `capture_screen`: silently shoot the **active window** (default scope) — the window-server frontmost, on whichever display, clean even when partially covered — and attach an **on-device OCR** of the shot to the tool result so the model reads exact text instead of pixels. Falls back to a full-display capture (no OCR) — the Settings-chosen display in Entire-display scope, the main display when no window is eligible; the overlay window is excluded either way. See [settings-window.md](./settings-window.md#capture-scope). | macOS `screencapture` CLI + Apple Vision (`VNRecognizeTextRequest`). |
 | **Overlay Caption** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. Switchable from Settings — **off by default**; when off, tips are suppressed. | AppKit NSPanel; `OverlayCaptionPanel`. |
@@ -295,9 +294,9 @@ The implementation keeps orchestration, route policy, and OS edges separate:
 - **Continuous (cheap):** audio → the selected transcription adapter → transcript. This runs the
   whole session; Apple Speech removes continuous audio egress and OpenAI transcription billing.
 - **Per-turn (cheap):** a selected-brain call on each substantive turn-end and each silence event,
-  with a bounded, mostly-cached working set. Known filler is removed before brain input, and
-  filler-only turn-ends (from either speaker) are skipped client-side — free. No image unless the
-  model asks.
+  with a bounded, mostly-cached working set. Clear non-semantic hesitation sounds are removed before
+  brain input, and turn-ends containing only those sounds (from either speaker) are skipped
+  client-side — free. No image unless the model asks.
 - **On-demand (expensive):** a screenshot + vision tokens, only when the model calls
   `capture_screen`. A coaching response, only when the model calls `speak`.
 
@@ -322,10 +321,10 @@ rather than a per-turn screenshot.
   and past a token threshold (see
   `Config.historyCompactionTokenThreshold`) the oldest span is **compacted** into a short,
   interview-format-neutral briefing written by a cheaper model (`gpt-5.4-mini`). Its size estimate
-  treats non-ASCII scripts conservatively; the briefing preserves durable goals, requirements,
-  progress, prior advice, and unresolved questions while retiring obsolete detail from resolved
-  topics. Compaction uses one Core-owned workload deadline across providers and fails soft: a slow or
-  failed summary leaves the full history intact for a later attempt. Requests are sent `store:true`
+  treats non-ASCII scripts conservatively; the exact retention and topic-retirement policy lives in
+  [`JarvisPrompts.HistorySummary.system`](../Sources/JarvisCore/Prompts/JarvisPrompts+HistorySummary.swift).
+  Compaction uses one Core-owned workload deadline across providers and fails soft: a slow or failed
+  summary leaves the full history intact for a later attempt. Requests are sent `store:true`
   so they stay inspectable in the OpenAI dashboard for debugging — the retention tradeoff is
   documented in [sandbox.md](./sandbox.md).
 - **Transcription has its own provider, model, and language settings.** OpenAI remains the provider
@@ -595,8 +594,8 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
   are sent `store:true`, so what the model saw does remain inspectable (and retained) server-side at
   OpenAI for debugging (see [sandbox.md](./sandbox.md)).
 - **Behavioral restraint (model-governed):** there is **no cooldown or rate cap** in code. Every
-  substantive utterance — from either speaker; only known filler is removed as pure cost — reaches
-  the brain, and the brain decides whether it has anything worth
+  substantive utterance — from either speaker; only clear non-semantic hesitation sounds are removed
+  as pure cost — reaches the brain, and the brain decides whether it has anything worth
   saying — that restraint lives in the system prompt (see
   [`JarvisPrompts.Coach.system`](../Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift)).
   This keeps

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -70,11 +70,13 @@ moments the model judges worthwhile.
    cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's
    Start/Stop and the **substance gate** (`TurnSubstance`): a turn-end whose delta is pure
-   back-channel filler ("Hmm", "嗯") or empty is skipped without a request. Classification is
+   known filler ("Hmm", "嗯", or a sequence such as "Uh. Okay. Hmm.") or empty is skipped without a
+   request. Known filler lines are also removed from a mixed brain-facing delta, while Activity keeps
+   the complete finalized transcription. Unknown short fragments fail open. Classification is
    speaker-aware only where conversational meaning demands it: a short interviewer rejection such
-   as "No" is substantive, even though the same user-side fragment is normally filler. Interviewer
-   questions remain first-class and may draw a proactive tip. Skipped lines ride along on the next
-   substantive turn; silence checks and the hint hotkey always go through.
+   as "No" is substantive, even though the same user-side response is known filler. Interviewer
+   questions remain first-class and may draw a proactive tip. Consumed filler never rides into a
+   later request; silence checks and the hint hotkey always go through.
 3. It calls the **selected brain model** with the coach system prompt, the session memory
    (`CoachHistory`), the
    new transcript delta, the timing context (seconds silent, session elapsed), and the tool set
@@ -292,9 +294,10 @@ The implementation keeps orchestration, route policy, and OS edges separate:
 
 - **Continuous (cheap):** audio → the selected transcription adapter → transcript. This runs the
   whole session; Apple Speech removes continuous audio egress and OpenAI transcription billing.
-- **Per-turn (cheap):** a selected-brain call on each substantive turn-end and each silence event, with a
-  bounded, mostly-cached working set. Filler-only turn-ends (from either speaker) are skipped
-  client-side — free. No image unless the model asks.
+- **Per-turn (cheap):** a selected-brain call on each substantive turn-end and each silence event,
+  with a bounded, mostly-cached working set. Known filler is removed before brain input, and
+  filler-only turn-ends (from either speaker) are skipped client-side — free. No image unless the
+  model asks.
 - **On-demand (expensive):** a screenshot + vision tokens, only when the model calls
   `capture_screen`. A coaching response, only when the model calls `speak`.
 
@@ -317,10 +320,12 @@ rather than a per-turn screenshot.
   items live only inside the turn that produced them — at commit, the pixels become a one-line stub
   and the capture's OCR text (in the tool result) is what persists, and reasoning items are dropped;
   and past a token threshold (see
-  `Config.historyCompactionTokenThreshold`) the oldest span is **compacted** into a short structured
-  summary written by a cheaper model (`gpt-5.4-mini`), so the problem statement never falls out of
-  context. Compaction uses one Core-owned workload deadline across providers and fails soft: a slow
-  or failed summary leaves the full history intact for a later attempt. Requests are sent `store:true`
+  `Config.historyCompactionTokenThreshold`) the oldest span is **compacted** into a short,
+  interview-format-neutral briefing written by a cheaper model (`gpt-5.4-mini`). Its size estimate
+  treats non-ASCII scripts conservatively; the briefing preserves durable goals, requirements,
+  progress, prior advice, and unresolved questions while retiring obsolete detail from resolved
+  topics. Compaction uses one Core-owned workload deadline across providers and fails soft: a slow or
+  failed summary leaves the full history intact for a later attempt. Requests are sent `store:true`
   so they stay inspectable in the OpenAI dashboard for debugging — the retention tradeoff is
   documented in [sandbox.md](./sandbox.md).
 - **Transcription has its own provider, model, and language settings.** OpenAI remains the provider
@@ -590,8 +595,8 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
   are sent `store:true`, so what the model saw does remain inspectable (and retained) server-side at
   OpenAI for debugging (see [sandbox.md](./sandbox.md)).
 - **Behavioral restraint (model-governed):** there is **no cooldown or rate cap** in code. Every
-  substantive utterance — from either speaker; only back-channel filler is skipped as pure cost —
-  reaches the brain, and the brain decides whether it has anything worth
+  substantive utterance — from either speaker; only known filler is removed as pure cost — reaches
+  the brain, and the brain decides whether it has anything worth
   saying — that restraint lives in the system prompt (see
   [`JarvisPrompts.Coach.system`](../Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift)).
   This keeps

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -269,8 +269,8 @@
 - **Rejected:** (a) A them-only speaker gate — cheaper, but it silences Jarvis exactly when the interviewer asks the user a question. (b) A longer client debounce window (adds reply latency, merges less). (c) A classifier model for filler (~$0.03/hr and latency; unwarranted while the closed class + fail-open holds).
 - **Detail:** `Sources/JarvisCore/Triggers/TurnSubstance.swift`, `CoachDriver.runTurn`.
 - **Superseded in part by:** 2026-08-07 — Known filler is consumed before brain context. The
-  speaker-neutral closed class stands; deferred filler and the arbitrary short-fragment fallback do
-  not.
+  speaker-neutral, fail-open shape stands; deferred filler, the arbitrary short-fragment fallback,
+  and the broad acknowledgement list do not.
 
 ### 2026-07-07 — Session memory moved client-side, with compaction
 
@@ -385,6 +385,9 @@
   actionable feedback, not a back-channel.
 - **Rejected:** Removing the filler gate — would restore the large steady-state cost from acknowledgments.
 - **Detail:** `Sources/JarvisCore/Triggers/TurnSubstance.swift`.
+- **Superseded by:** 2026-08-07 — Clear hesitation sounds are consumed before brain context. Terse
+  contextual replies now fail open for either speaker, so the interviewer-only exception is no
+  longer needed.
 
 ### 2026-07-17 — Audio continuity evidence is content-free, not a recording
 
@@ -1186,24 +1189,27 @@
   `Sources/JarvisCore/Transcription/RealtimeSession.swift`,
   `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`.
 
-### 2026-08-07 — Known filler is consumed before brain context
+### 2026-08-07 — Clear hesitation sounds are consumed before brain context
 
-- **Chose:** Keep the speaker-neutral closed-class substance gate, recognize punctuation-separated
-  sequences of known filler, and remove known filler lines from every brain-facing transcript delta.
-  A filler-only turn consumes its transcript boundary without a request, while Activity retains the
-  complete finalized transcription. Unknown short fragments fail open; direct questions, Jarvis
-  addresses, and terse interviewer corrections remain substantive.
-- **Why:** Session `2026-08-07_11-15-48_B24D` showed that isolated filler was already skipped, but
-  combinations such as “Uh. OK. Okay, okay.” escaped the exact-phrase check and bought a full-history
-  `stay_silent` request. Previously skipped filler also entered the next substantive request, turning
-  a saved call into recurring context cost.
+- **Chose:** Keep a speaker-neutral, conservative substance gate for clear non-semantic vocal sounds,
+  recognize separated sequences of those sounds, and remove them from every brain-facing transcript
+  delta. A turn with nothing else consumes its transcript boundary without a request, while Activity
+  retains the complete finalized transcription. Context-dependent short replies such as “Yes,” “No,”
+  “Okay,” “对,” and “可以” fail open for either speaker, as do unknown short fragments.
+- **Why:** Session `2026-08-07_11-15-48_B24D` showed that isolated hesitation sounds were already
+  skipped, but combined sounds could escape the exact-phrase check and buy a full-history
+  `stay_silent` request. Previously skipped noise also entered the next substantive request, turning
+  a saved call into recurring context cost. A narrow discard set saves those calls without silently
+  deleting short answers whose meaning depends on the conversation.
 - **Rejected:** (a) Asking the transcription model to delete filler — it is not a deterministic
-  omission boundary and would silently change the audit record. (b) Treating every unknown short
-  fragment as filler — it can discard terse answers and technical terms. (c) A classifier model —
-  extra latency and cost for a small explicit class.
+  omission boundary and would silently change the audit record. (b) Treating contextual replies or
+  every unknown short fragment as filler — either can carry an answer, correction, or technical term.
+  (c) A classifier model — extra latency and cost for a small explicit class. (d) Sending filler or an
+  artificial placeholder after a failed attempt — when no substantive text or saved observation
+  remains, there is no useful context for a fresh request.
 - **Supersedes in part:** 2026-07-07 — Filler-only turn-ends skip the brain. Its speaker-neutral gate
-  and explicit overrides stand; skipped lines no longer ride forward, and unknown short fragments
-  no longer disappear by length alone.
+  stands, but the broad acknowledgement list and explicit speaker overrides do not; skipped sounds
+  no longer ride forward, and unknown short fragments no longer disappear by length alone.
 - **Detail:** [architecture.md → The turn](./architecture.md#the-turn),
   `Sources/JarvisCore/Triggers/TurnSubstance.swift`,
   `Sources/JarvisCore/Coach/CoachDriver.swift`.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -268,6 +268,9 @@
 - **Why:** Roughly 40–45% of an interviewer-heavy session's turn-ends are back-channel ("Hmm", "嗯", "对") that can never produce a tip, yet each re-billed the whole working set. Normalization + a closed class scales where a raw allowlist wouldn't: back-channels are a small closed set per language and the apparent variety is elongation, which collapsing absorbs. Gating on *what* was said (not *who*) keeps interviewer questions first-class — they may draw a proactive tip for the user (prompt relaxed accordingly).
 - **Rejected:** (a) A them-only speaker gate — cheaper, but it silences Jarvis exactly when the interviewer asks the user a question. (b) A longer client debounce window (adds reply latency, merges less). (c) A classifier model for filler (~$0.03/hr and latency; unwarranted while the closed class + fail-open holds).
 - **Detail:** `Sources/JarvisCore/Triggers/TurnSubstance.swift`, `CoachDriver.runTurn`.
+- **Superseded in part by:** 2026-08-07 — Known filler is consumed before brain context. The
+  speaker-neutral closed class stands; deferred filler and the arbitrary short-fragment fallback do
+  not.
 
 ### 2026-07-07 — Session memory moved client-side, with compaction
 
@@ -276,6 +279,9 @@
 - **Rejected:** (a) Keeping conversations and rotating them with a summary seed — same summarization work, but retains the unbounded-growth window and the lock failure mode. (b) `store:false` for privacy — deferred by choice; debuggability wins while the harness is being tuned, and it's now a one-line flip.
 - **Detail:** `Sources/JarvisCore/Coach/CoachHistory.swift`, `CoachDriver.compactIfNeeded`, [sandbox.md](./sandbox.md) for the retention posture.
 - **Superseded (in part) by:** the 2026-07-16 entry — screenshots now never outlive their turn as pixels; the rest of this entry stands.
+- **Superseded in part by:** 2026-08-07 — History compaction is language- and interview-format
+  neutral. Client-owned memory and bounded summarization stand; the English-oriented size estimate
+  and coding-specific briefing do not.
 
 ### 2026-07-07 — `capture_screen` is window-scoped with an on-device OCR sidecar
 
@@ -1179,3 +1185,46 @@
   `Sources/JarvisCore/Transcription/OpenAITranscriptionModel.swift`,
   `Sources/JarvisCore/Transcription/RealtimeSession.swift`,
   `Sources/JarvisApp/Capture/RealtimeTranscriber.swift`.
+
+### 2026-08-07 — Known filler is consumed before brain context
+
+- **Chose:** Keep the speaker-neutral closed-class substance gate, recognize punctuation-separated
+  sequences of known filler, and remove known filler lines from every brain-facing transcript delta.
+  A filler-only turn consumes its transcript boundary without a request, while Activity retains the
+  complete finalized transcription. Unknown short fragments fail open; direct questions, Jarvis
+  addresses, and terse interviewer corrections remain substantive.
+- **Why:** Session `2026-08-07_11-15-48_B24D` showed that isolated filler was already skipped, but
+  combinations such as “Uh. OK. Okay, okay.” escaped the exact-phrase check and bought a full-history
+  `stay_silent` request. Previously skipped filler also entered the next substantive request, turning
+  a saved call into recurring context cost.
+- **Rejected:** (a) Asking the transcription model to delete filler — it is not a deterministic
+  omission boundary and would silently change the audit record. (b) Treating every unknown short
+  fragment as filler — it can discard terse answers and technical terms. (c) A classifier model —
+  extra latency and cost for a small explicit class.
+- **Supersedes in part:** 2026-07-07 — Filler-only turn-ends skip the brain. Its speaker-neutral gate
+  and explicit overrides stand; skipped lines no longer ride forward, and unknown short fragments
+  no longer disappear by length alone.
+- **Detail:** [architecture.md → The turn](./architecture.md#the-turn),
+  `Sources/JarvisCore/Triggers/TurnSubstance.swift`,
+  `Sources/JarvisCore/Coach/CoachDriver.swift`.
+
+### 2026-08-07 — History compaction is language- and interview-format neutral
+
+- **Chose:** Estimate non-ASCII session memory conservatively instead of applying the English
+  characters-per-token shortcut to every script. Summarize older history as a general live-coaching
+  briefing: preserve durable goals, requirements, progress, decisions, prior advice, feedback, and
+  unresolved questions; compress resolved topics and omit obsolete detail. Do not assume a coding
+  interview or add an explicit phase state machine.
+- **Why:** The Chinese-heavy audited session reached a large recurring request while the old estimate
+  still remained below the compaction threshold. Its older project and behavioral discussion would
+  also have been forced into a hard-coded coding-problem summary even if compaction had run.
+- **Rejected:** (a) Lowering the threshold globally — it does not fix the language bias and compacts
+  English sessions too early. (b) A hard-coded interview-phase detector — the general summarizer can
+  retire resolved topics first, without adding another brittle state machine. (c) Separate summary
+  schemas per interview type — they duplicate policy and can misclassify mixed sessions.
+- **Supersedes in part:** 2026-07-07 — Session memory moved client-side, with compaction. Client-owned
+  memory, the bounded briefing, and fail-soft behavior stand; the English-biased estimate and
+  coding-only summary do not.
+- **Detail:** [architecture.md → Models and APIs](./architecture.md#models-and-apis),
+  `Sources/JarvisCore/Coach/CoachHistory.swift`,
+  `Sources/JarvisCore/Prompts/JarvisPrompts+HistorySummary.swift`.


### PR DESCRIPTION
## Summary

- remove only clear hesitation sounds before brain context, including separated sequences such as `Uh. Hmm. Oh, oh.`
  - sound-only turns no longer spend a brain request or ride into later turns
  - clear sounds are removed from mixed brain-facing deltas
  - context-dependent short replies such as `Yes`, `No`, `Okay`, `Right`, `对`, and `可以` remain substantive for either speaker
  - acronym-like uppercase tokens such as `M`, `ER`, `UM`, and `OH` fail open instead of being consumed as sounds
  - the complete finalized transcript remains in Activity
- keep fresh attempts useful
  - if no meaningful speech or saved observation remains, consume the filler boundary without another provider call
  - if a saved screen observation remains, send it directly without an empty user message, artificial placeholder, recapture, or raw provider tool state
- clarify that Jarvis coaches `me` and cannot impersonate the user, open apps, share screens, click, type, send, or change anything
- make history compaction language- and interview-format neutral
  - estimate non-ASCII text conservatively so multilingual sessions compact at the intended boundary
  - preserve durable context while retiring resolved or obsolete topic detail
- keep evaluator improvements separate in #138; this PR changes no evaluator behavior

## Session evidence

Session `2026-08-07_11-15-48_B24D` contained many isolated hesitation sounds such as `Hmm.`, `Oh.`, and `Uh.`, as well as combined acknowledgements. Exact single-phrase filtering skipped some calls, but combined sounds could escape the gate and previously skipped noise was carried into later brain context.

The permanent-removal boundary is intentionally narrow. Short lexical replies may be load-bearing decisions, so the model still receives them and judges their meaning from conversation context.

The session also exposed two prompt problems: the coach could echo interviewer-directed actions as if Jarvis performed them, and the compaction briefing assumed a coding interview while its English-oriented size estimate delayed compaction in Chinese-heavy history.

## Validation

- `swift build && ./scripts/run-tests.sh` — 626 tests across 74 suites passed with default parallelism
- focused acronym/P1 regression — 9 tests across 2 suites passed
- ghost-mode and audio-capture guards passed
- one opt-in live ScreenCaptureKit test skipped as expected
- `git diff --check` passed

No live microphone session was started.

## Dependency

This PR is intentionally stacked on #134. The prompt catalog from merged #135 is already present on that base branch and supplies the prompt files changed here. Retarget this PR to `main` after #134 merges.