### PR TITLE
fix: clarify coaching retry warning

### DIFF
--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -51,8 +51,8 @@ public final class ActivityLog: @unchecked Sendable {
         /// The single terminal lifecycle event for a live coaching session. The reason is a closed,
         /// sanitized set so raw errors cannot leak into Activity.
         case sessionEnded(reason: SessionEndReason)
-        /// One coaching turn failed temporarily while capture and transcription remain live. The
-        /// provider identity is enough for fixed recovery copy; raw error detail stays in debug.
+        /// One coaching response failed temporarily and a fresh attempt will retry while capture and
+        /// transcription remain live. Provider identity is enough; raw error detail stays in debug.
         case coachingTurnFailed(provider: BrainProvider)
         /// The secondary system-audio transcription stopped while microphone coaching continued.
         case systemAudioStopped
@@ -92,7 +92,7 @@ public final class ActivityLog: @unchecked Sendable {
             case .coachingTurnFailed(let provider):
                 return (
                     .coachingTurnFailed,
-                    "⚠️ \(provider.displayName) couldn't respond this turn — listening continues",
+                    "⚠️ \(provider.displayName) couldn't finish the response — retrying while listening continues",
                     nil
                 )
             case .systemAudioStopped:
@@ -345,8 +345,9 @@ public final class ActivityLog: @unchecked Sendable {
             || m.hasPrefix("👁 looking at your screen") || m.hasPrefix("👁 couldn't view your screen")
             || m.hasPrefix("💬") || m.hasPrefix("🤫 stayed silent")
             || m.hasPrefix("⏹ session ended")
-            || (m.hasPrefix("⚠️") && m.contains("couldn't respond this turn")
-                && m.hasSuffix("listening continues"))
+            || (m.hasPrefix("⚠️") && m.hasSuffix("listening continues")
+                && (m.contains("couldn't respond this turn")
+                    || m.contains("couldn't finish the response — retrying while")))
             || m.hasPrefix("⚠️ system audio stopped")
             || m.hasPrefix("⚠️ settings change wasn't applied")
             || m.hasPrefix("🧠 brain switch applied")

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -439,9 +439,11 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 
         let snapshot = ActivityLog.shared.attach { _ in }
         #expect(snapshot.rows.count == 3)
-        #expect(snapshot.rows[0].contains("couldn't respond this turn"))
+        #expect(snapshot.rows[0].contains("couldn't finish the response"))
+        #expect(snapshot.rows[0].contains("retrying"))
         #expect(snapshot.rows[0].contains("listening continues"))
-        #expect(snapshot.rows[1].contains("couldn't respond this turn"))
+        #expect(snapshot.rows[1].contains("couldn't finish the response"))
+        #expect(snapshot.rows[1].contains("retrying"))
         #expect(snapshot.rows[1].contains("listening continues"))
         #expect(snapshot.rows[2].contains("recovered coaching"))
         #expect(!snapshot.rows.joined().contains("test"))

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -159,16 +159,21 @@ import Foundation
         ))
     }
 
-    @Test func temporaryBrainFailureSaysListeningContinuesWithoutDiagnosticDetail() throws {
+    @Test func temporaryBrainFailureSaysRetryingWithoutDiagnosticDetail() throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
         let log = ActivityLog(); log.enable(directory: dir)
         log.record(.coachingTurnFailed(provider: .codexCLI))
         let snapshot = log.attach { _ in }
 
         let row = try #require(snapshot.rows.first)
-        #expect(row.contains("Codex CLI couldn't respond this turn"))
+        #expect(row.contains("Codex CLI couldn't finish the response"))
+        #expect(row.contains("retrying"))
         #expect(row.contains("listening continues"))
         #expect(!row.contains("timed out"))
+        #expect(ActivityLog.isHumanFacing(
+            message: "⚠️ Codex CLI couldn't finish the response — retrying while listening continues",
+            imageFile: nil
+        ))
         #expect(ActivityLog.isHumanFacing(
             message: "⚠️ Codex CLI couldn't respond this turn — listening continues",
             imageFile: nil


### PR DESCRIPTION
## Summary

- clarify the temporary coaching-failure notice by saying Jarvis is retrying while listening continues
- preserve the stable `coachingTurnFailed` event kind and compatibility with older Activity rows
- update Activity and recovery-pipeline assertions for the new copy

## Why

The previous notice said the provider “couldn't respond this turn,” which sounded terminal even though Jarvis had already scheduled a fresh attempt for the same pending work. The new copy reflects the actual recovery behavior without exposing raw diagnostics.

This is a copy-only behavior clarification: the 15-second live-coaching deadline and retry/routing policy are unchanged.

## Validation

- `./scripts/run-tests.sh --filter 'ActivityLogTests|CoachDriverPipelineTests'` — 91 tests passed
- `swift build && ./scripts/run-tests.sh` — build and guards passed; 677 tests in 78 suites passed, with the expected opt-in live capture test skipped