### PR TITLE
build(release): harden downloadable app delivery

### DIFF
--- a/.github/release-header.md
+++ b/.github/release-header.md
@@ -8,7 +8,5 @@
 3. Grant the permissions its selected features need, then configure transcription and brain providers
    in **Settings**.
 
-Jarvis is signed with Developer ID and notarized by Apple. To verify the download, place the archive
-and `SHA256SUMS` in the same folder and run `shasum -a 256 -c SHA256SUMS`. Before using it in a
-meeting, review the
+Jarvis is signed with Developer ID and notarized by Apple. Before using it in a meeting, review the
 [privacy and consent requirements](https://github.com/JINGBANZ/jarvis#privacy).

--- a/.github/release-header.md
+++ b/.github/release-header.md
@@ -1,0 +1,14 @@
+<!-- jarvis-release-install -->
+## Install Jarvis
+
+**Requires an Apple silicon Mac running macOS 14.2 or later.**
+
+1. Under **Assets**, download `Jarvis-<version>.zip` and double-click it to extract the app.
+2. Move `Jarvis.app` to **Applications**, then open it from there. Jarvis appears in the menu bar.
+3. Grant the permissions its selected features need, then configure transcription and brain providers
+   in **Settings**.
+
+Jarvis is signed with Developer ID and notarized by Apple. To verify the download, place the archive
+and `SHA256SUMS` in the same folder and run `shasum -a 256 -c SHA256SUMS`. Before using it in a
+meeting, review the
+[privacy and consent requirements](https://github.com/JINGBANZ/jarvis#privacy).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,10 +84,15 @@ jobs:
 
       - name: Build, sign, notarize, package
         env:
+          EXPECTED_RELEASE_TAG: ${{ needs.release-please.outputs.tag_name }}
           NOTARY_KEY_BASE64: ${{ secrets.NOTARY_KEY_BASE64 }}
           NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
           NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
         run: |
+          if [[ -z "$EXPECTED_RELEASE_TAG" ]]; then
+            echo "error: release-please did not provide the expected release tag" >&2
+            exit 1
+          fi
           NOTARY_KEY_PATH="$RUNNER_TEMP/AuthKey.p8"
           echo -n "$NOTARY_KEY_BASE64" | base64 --decode -o "$NOTARY_KEY_PATH"
           export NOTARY_KEY_PATH
@@ -120,7 +125,24 @@ jobs:
             cat .github/release-header.md "$CURRENT_NOTES" > "$RELEASE_NOTES"
           fi
 
-          gh release upload "$TAG" "${archives[0]}" SHA256SUMS --clobber
+          ASSET_NAMES="$RUNNER_TEMP/existing-release-assets.txt"
+          ASSET_DIR="$RUNNER_TEMP/existing-release-assets"
+          mkdir -p "$ASSET_DIR"
+          gh release view "$TAG" --json assets --jq '.assets[].name' > "$ASSET_NAMES"
+          # A lost publish response can leave a public Release behind for the retry. Preserve its
+          # assets: reuse byte-identical files and fail closed if an existing name differs.
+          for asset in "${archives[0]}" SHA256SUMS; do
+            if grep -Fxq "$asset" "$ASSET_NAMES"; then
+              gh release download "$TAG" --pattern "$asset" --dir "$ASSET_DIR"
+              if ! cmp -s "$asset" "$ASSET_DIR/$asset"; then
+                echo "error: release already has a different $asset; preserving it" >&2
+                exit 1
+              fi
+              echo "existing release asset is identical: $asset"
+            else
+              gh release upload "$TAG" "$asset"
+            fi
+          done
           gh release edit "$TAG" --notes-file "$RELEASE_NOTES" --draft=false --latest
 
       # Hosted runners are ephemeral, but scrubbing the signing key is cheap insurance (and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,17 +94,34 @@ jobs:
           ./scripts/package-app.sh
 
       # The Release is created as a draft (release-please-config.json), so a failed build/sign/
-      # notarize run never leaves a public Release without its app — publishing happens only after
-      # the asset is attached. force-tag-creation makes release-please create the git tag
-      # immediately (GitHub otherwise defers tagging drafts until publish, and a lingering untagged
-      # draft would make later release-please runs miss the previous release and garble changelogs).
+      # notarize/verify run never leaves a public Release without its app — publishing happens only
+      # after the assets and user-facing install notes are ready. force-tag-creation makes
+      # release-please create the git tag immediately (GitHub otherwise defers tagging drafts until
+      # publish, and a lingering untagged draft would make later release-please runs miss the previous
+      # release and garble changelogs).
       - name: Attach the app and publish the Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          gh release upload "$TAG" Jarvis-*.zip
-          gh release edit "$TAG" --draft=false --latest
+          archives=(Jarvis-*.zip)
+          if [[ ${#archives[@]} -ne 1 || ! -f "${archives[0]}" ]]; then
+            echo "error: expected exactly one Jarvis release archive" >&2
+            exit 1
+          fi
+          shasum -a 256 "${archives[0]}" > SHA256SUMS
+
+          CURRENT_NOTES="$RUNNER_TEMP/current-release-notes.md"
+          RELEASE_NOTES="$RUNNER_TEMP/release-notes.md"
+          gh release view "$TAG" --json body --jq .body > "$CURRENT_NOTES"
+          if grep -Fq '<!-- jarvis-release-install -->' "$CURRENT_NOTES"; then
+            cp "$CURRENT_NOTES" "$RELEASE_NOTES"
+          else
+            cat .github/release-header.md "$CURRENT_NOTES" > "$RELEASE_NOTES"
+          fi
+
+          gh release upload "$TAG" "${archives[0]}" SHA256SUMS --clobber
+          gh release edit "$TAG" --notes-file "$RELEASE_NOTES" --draft=false --latest
 
       # Hosted runners are ephemeral, but scrubbing the signing key is cheap insurance (and
       # required hygiene if this ever moves to a self-hosted runner).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,17 +128,26 @@ jobs:
           ASSET_NAMES="$RUNNER_TEMP/existing-release-assets.txt"
           ASSET_DIR="$RUNNER_TEMP/existing-release-assets"
           mkdir -p "$ASSET_DIR"
+          RELEASE_IS_DRAFT="$(gh release view "$TAG" --json isDraft --jq .isDraft)"
+          if [[ "$RELEASE_IS_DRAFT" != "true" && "$RELEASE_IS_DRAFT" != "false" ]]; then
+            echo "error: couldn't determine whether release $TAG is a draft" >&2
+            exit 1
+          fi
           gh release view "$TAG" --json assets --jq '.assets[].name' > "$ASSET_NAMES"
-          # A lost publish response can leave a public Release behind for the retry. Preserve its
-          # assets: reuse byte-identical files and fail closed if an existing name differs.
+          # A retry may encounter either a partial draft or a public Release whose publish response
+          # was lost. Draft assets are safe to replace; public assets must never be deleted here.
           for asset in "${archives[0]}" SHA256SUMS; do
             if grep -Fxq "$asset" "$ASSET_NAMES"; then
               gh release download "$TAG" --pattern "$asset" --dir "$ASSET_DIR"
-              if ! cmp -s "$asset" "$ASSET_DIR/$asset"; then
+              if cmp -s "$asset" "$ASSET_DIR/$asset"; then
+                echo "existing release asset is identical: $asset"
+              elif [[ "$RELEASE_IS_DRAFT" == "true" ]]; then
+                echo "replacing different draft release asset: $asset"
+                gh release upload "$TAG" "$asset" --clobber
+              else
                 echo "error: release already has a different $asset; preserving it" >&2
                 exit 1
               fi
-              echo "existing release asset is identical: $asset"
             else
               gh release upload "$TAG" "$asset"
             fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ local-process boundaries. Small, testable changes are preferred.
 
 ## Before opening a pull request
 
-1. Use an Apple silicon Mac with macOS 14+, Swift 6, and the Command Line Tools.
+1. Use an Apple silicon Mac with macOS 14.2+, Swift 6, and the Command Line Tools.
 2. Create a branch or isolated worktree; never commit directly to `main`.
 3. Put Foundation-only logic in `JarvisCore` and keep OS-bound code thin in `JarvisApp` or
    `JarvisOverlay`. Read [`CLAUDE.md`](./CLAUDE.md) and the relevant page under [`wiki/`](./wiki/).

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let jarvisAppSwiftSettings: [SwiftSetting] = forceAppleSpeechFallback
 
 let package = Package(
     name: "Jarvis",
-    platforms: [.macOS(.v14)],
+    platforms: [.macOS("14.2")],
     targets: [
         .target(name: "JarvisCore"),
         // The AppKit overlay lives in its own library target (not the executable) so it can be

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ flowchart TD
 The detailed loop and its design rationale live in the
 [architecture guide](./wiki/architecture.md).
 
-## Build from source
+## Developer quick start
 
 Building locally additionally requires Swift 6 and the macOS Command Line Tools.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ session for an immediate, screen-aware hint.
 > with all required consent and where law, workplace policy, and platform terms allow. Read the full
 > [privacy and security model](./wiki/sandbox.md).
 
+## Install Jarvis
+
+**Requirements:** an Apple silicon Mac running macOS 14.2 or later. No developer tools are needed.
+
+[**Download the latest signed and notarized release**](https://github.com/JINGBANZ/jarvis/releases/latest)
+
+1. Under **Assets**, download `Jarvis-<version>.zip` and double-click it to extract the app.
+2. Move `Jarvis.app` to **Applications**, then open it. Jarvis appears in the menu bar rather than
+   the Dock.
+3. Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts.
+4. From the menu-bar icon, open **Settings**, choose transcription and brain providers, add any
+   credential those providers require, then select **Start Jarvis**. Allow System Audio Recording
+   when Start requests it so Jarvis can hear the other side.
+
 ## How it works
 
 ```mermaid
@@ -30,10 +44,9 @@ flowchart TD
 The detailed loop and its design rationale live in the
 [architecture guide](./wiki/architecture.md).
 
-## Run Jarvis
+## Build from source
 
-**Requirements:** an Apple silicon Mac running macOS 14.2 or later, Swift 6, and the macOS Command
-Line Tools. An OpenAI API key is needed only when OpenAI provides transcription or coaching.
+Building locally additionally requires Swift 6 and the macOS Command Line Tools.
 
 ```bash
 git clone https://github.com/JINGBANZ/jarvis.git
@@ -41,12 +54,8 @@ cd jarvis
 ./scripts/build-app.sh --run
 ```
 
-On the first run:
-
-1. When macOS asks whether `codesign` can use the `Jarvis Dev` key, choose **Always Allow**.
-2. Allow Microphone access to start. Allow System Audio Recording to hear the other side and Screen
-   Recording for screen-aware hints.
-3. Open **Settings**, choose your transcription and coaching providers, then select **Start Jarvis**.
+On the first local build, macOS asks whether `codesign` can use the `Jarvis Dev` key; choose
+**Always Allow**. The downloaded release does not use this local development identity.
 
 For signing details, permission recovery, and other commands, see
 [Build and run](./wiki/build-and-run.md). Always launch the app through the build script or `open`,

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -12,7 +12,7 @@
   <key>CFBundlePackageType</key><string>APPL</string>
   <key>CFBundleExecutable</key><string>JarvisApp</string>
   <key>CFBundleIconFile</key><string>Jarvis.icns</string>
-  <key>LSMinimumSystemVersion</key><string>14.0</string>
+  <key>LSMinimumSystemVersion</key><string>14.2</string>
   <key>LSUIElement</key><true/>
   <key>NSMicrophoneUsageDescription</key>
   <string>Jarvis listens to you think aloud to offer coaching tips.</string>

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Package Jarvis.app for distribution: Developer ID signing + notarization + stapling.
-# Produces Jarvis-<version>.zip, which opens on any Apple Silicon Mac (macOS 14+) with no
+# Produces Jarvis-<version>.zip, which opens on any Apple silicon Mac (macOS 14.2+) with no
 # Gatekeeper friction. Driven locally or by CI (.github/workflows/release.yml).
 #
 # Deliberately self-contained rather than layered on build-app.sh: the dev script's self-signed
@@ -88,6 +88,7 @@ xcrun stapler staple "$APP"
 rm -f "$ZIP"
 ditto -c -k --keepParent "$APP" "$ZIP"
 
-# Final check, the way Gatekeeper will assess it ("source=Notarized Developer ID").
-spctl --assess --type execute --verbose "$APP"
-echo "✅ $ZIP is notarized and ready to distribute (Apple Silicon, macOS 14+)"
+# Verify the exact archive users receive, not only the pre-compression bundle. A packaging mistake
+# must leave the draft Release unpublished even if signing and notarization already succeeded.
+./scripts/verify-release.sh "$ZIP"
+echo "✅ $ZIP is notarized and ready to distribute (Apple silicon, macOS 14.2+)"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -90,5 +90,9 @@ ditto -c -k --keepParent "$APP" "$ZIP"
 
 # Verify the exact archive users receive, not only the pre-compression bundle. A packaging mistake
 # must leave the draft Release unpublished even if signing and notarization already succeeded.
-./scripts/verify-release.sh "$ZIP"
+verify_args=("$ZIP")
+if [[ -n "${EXPECTED_RELEASE_TAG:-}" ]]; then
+  verify_args+=("$EXPECTED_RELEASE_TAG")
+fi
+./scripts/verify-release.sh "${verify_args[@]}"
 echo "✅ $ZIP is notarized and ready to distribute (Apple silicon, macOS 14.2+)"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Verify the exact Jarvis release archive users download after it has been signed and notarized.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+ZIP="${1:-}"
+if [[ -z "$ZIP" || ! -f "$ZIP" || -L "$ZIP" ]]; then
+  echo "usage: $0 Jarvis-<version>.zip" >&2
+  exit 2
+fi
+ZIP="$(cd "$(dirname "$ZIP")" && pwd)/$(basename "$ZIP")"
+
+APP="Jarvis.app"
+BIN_NAME="JarvisApp"
+VERIFY_ROOT="$PWD/.build"
+if [[ -L "$VERIFY_ROOT" ]]; then
+  echo "error: release-verification root must not be a symbolic link" >&2
+  exit 1
+fi
+mkdir -p "$VERIFY_ROOT"
+VERIFY_PREFIX="$VERIFY_ROOT/jarvis-release-verify."
+VERIFY_DIR="$(mktemp -d "${VERIFY_PREFIX}XXXXXX")"
+if [[ -z "$VERIFY_DIR" || "$VERIFY_DIR" != "$VERIFY_PREFIX"* || ! -d "$VERIFY_DIR" || -L "$VERIFY_DIR" ]]; then
+  echo "error: couldn't create a safe release-verification directory" >&2
+  exit 1
+fi
+cleanup_verify_dir() {
+  if [[ -n "${VERIFY_DIR:-}" && -n "${VERIFY_PREFIX:-}" \
+        && "$VERIFY_DIR" == "$VERIFY_PREFIX"* && -d "$VERIFY_DIR" && ! -L "$VERIFY_DIR" ]]; then
+    rm -rf -- "$VERIFY_DIR"
+  fi
+}
+trap cleanup_verify_dir EXIT
+
+echo "▶ verifying final archive: $(basename "$ZIP")"
+ditto -x -k "$ZIP" "$VERIFY_DIR"
+EXTRACTED_APP="$VERIFY_DIR/$APP"
+ENTRY_COUNT="$(find "$VERIFY_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')"
+if [[ "$ENTRY_COUNT" != "1" || ! -d "$EXTRACTED_APP" || -L "$EXTRACTED_APP" ]]; then
+  echo "error: final archive must contain exactly one regular $APP bundle" >&2
+  exit 1
+fi
+
+VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+  "$EXTRACTED_APP/Contents/Info.plist")"
+if [[ "$(basename "$ZIP")" != "Jarvis-$VERSION.zip" ]]; then
+  echo "error: archive filename does not match bundled version $VERSION" >&2
+  exit 1
+fi
+ARCHITECTURES="$(lipo -archs "$EXTRACTED_APP/Contents/MacOS/$BIN_NAME")"
+if [[ "$ARCHITECTURES" != "arm64" ]]; then
+  echo "error: archived app has unexpected architectures: $ARCHITECTURES" >&2
+  exit 1
+fi
+if [[ ! -f "$EXTRACTED_APP/Contents/Resources/LICENSE" \
+      || ! -f "$EXTRACTED_APP/Contents/Resources/THIRD_PARTY_NOTICES.md" ]]; then
+  echo "error: archived app is missing required license notices" >&2
+  exit 1
+fi
+
+codesign --verify --strict --verbose=2 "$EXTRACTED_APP"
+xcrun stapler validate "$EXTRACTED_APP"
+# Final policy check, the way Gatekeeper will assess the downloaded app.
+spctl --assess --type execute --verbose "$EXTRACTED_APP"
+echo "✅ $(basename "$ZIP") passed final release verification"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 ZIP="${1:-}"
-if [[ -z "$ZIP" || ! -f "$ZIP" || -L "$ZIP" ]]; then
-  echo "usage: $0 Jarvis-<version>.zip" >&2
+EXPECTED_RELEASE_TAG="${2:-}"
+if [[ $# -gt 2 || -z "$ZIP" || ! -f "$ZIP" || -L "$ZIP" ]]; then
+  echo "usage: $0 Jarvis-<version>.zip [v<version>]" >&2
   exit 2
 fi
 ZIP="$(cd "$(dirname "$ZIP")" && pwd)/$(basename "$ZIP")"
@@ -45,6 +46,10 @@ VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
   "$EXTRACTED_APP/Contents/Info.plist")"
 if [[ "$(basename "$ZIP")" != "Jarvis-$VERSION.zip" ]]; then
   echo "error: archive filename does not match bundled version $VERSION" >&2
+  exit 1
+fi
+if [[ -n "$EXPECTED_RELEASE_TAG" && "$EXPECTED_RELEASE_TAG" != "v$VERSION" ]]; then
+  echo "error: expected release tag $EXPECTED_RELEASE_TAG does not match bundled version $VERSION" >&2
   exit 1
 fi
 ARCHITECTURES="$(lipo -archs "$EXTRACTED_APP/Contents/MacOS/$BIN_NAME")"

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -53,6 +53,10 @@ timestamp (both notarization requirements) — submits it to Apple's notary serv
 ticket, and re-zips the stapled bundle into `Jarvis-<version>.zip` (a zip itself can't be stapled,
 so the archive is rebuilt after stapling). Hardened runtime denies microphone capture outright
 without the `audio-input` entitlement, so the script signs with `Resources/Jarvis.entitlements`.
+The script then passes that final zip to `scripts/verify-release.sh`, which extracts it into a fresh
+verification directory and checks the exact shipped app's bundle shape, version, arm64 architecture,
+notices, strict code signature, stapled ticket, and Gatekeeper policy result. The pre-compression app
+is not accepted as a proxy for the downloaded artifact.
 
 Releases are cut by `.github/workflows/release.yml`, not by hand: on every push to `main`,
 **release-please** maintains a standing Release PR from the conventional-commit history (bumping both
@@ -60,13 +64,16 @@ version keys in `Resources/Info.plist` via `x-release-please-version` annotation
 CHANGELOG — config in `release-please-config.json`). Merging that PR creates the GitHub Release **as
 a draft**; a `macos-15` job then runs the test gate, signs/notarizes via repo secrets (the base64
 `.p12` certificate and an App Store Connect API key — names in the workflow), attaches the zip, and
-only then publishes the Release. A failed sign/notarize run therefore never leaves a public Release
-without its app. The publish job lives in the same workflow because tags created with
-`GITHUB_TOKEN` never trigger other workflows.
+only then publishes the Release. The publish step also attaches `SHA256SUMS` and prepends the stable
+installation block in `.github/release-header.md` to release-please's generated changelog. A failed
+sign, notarization, or final-archive verification therefore never leaves a public Release without a
+validated app. The publish job lives in the same workflow because tags created with `GITHUB_TOKEN`
+never trigger other workflows.
 
 `package-app.sh` also runs locally (one-time `xcrun notarytool store-credentials jarvis-notary …`,
-then just run the script) for packaging without CI. Distributed builds run on Apple Silicon only —
-`libjarvis-aec.a` is arm64-only — and users supply their own OpenAI key at first run.
+then just run the script) for packaging without CI. Distributed builds require macOS 14.2 or later
+and run on Apple silicon only because `libjarvis-aec.a` is arm64-only. The README owns the user
+installation steps; provider credentials remain user-supplied in Settings.
 
 ## Running
 
@@ -80,9 +87,10 @@ then just run the script) for packaging without CI. Distributed builds run on Ap
   TCC attribute the grant to the *terminal*, so the app reports Microphone, System Audio Recording,
   or Screen Recording as "denied" even when granted. Pass flags with
   `open ./Jarvis.app --args …`.
-- Jarvis does **not** auto-start: set the OpenAI key once (Settings → Brain, saved to an owner-only
-  file; `OPENAI_API_KEY` is a headless fallback), then **Start / Stop** from the menu. The icon shows
-  two states only: ⚪️ stopped, 🟢 running.
+- Jarvis does **not** auto-start: choose transcription and Primary brain providers in Settings, meet
+  their credential or local sign-in requirements, then **Start / Stop** from the menu. OpenAI keys
+  are saved to an owner-only file; `OPENAI_API_KEY` is a headless fallback. The icon shows two states
+  only: ⚪️ stopped, 🟢 running.
 
 ## The live activity viewer
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -30,7 +30,7 @@ reconnect mode interrupts only Jarvis's transcription WebSocket, fills the real 
 the replacement is held, then exercises the ordinary replacement path without changing host network
 state. The normal app supplies no benchmark instrumentation: its session contract and `AppDelegate`
 wiring expose no benchmark capability, event construction is skipped, and its direct reconnect path
-is unchanged. On macOS 14–25, Apple Speech arms remain reported as platform-unavailable without
+is unchanged. On macOS 14.2–25, Apple Speech arms remain reported as platform-unavailable without
 failing the runnable matrix. Neither mode changes defaults or runs in the gate. The first complete standard run finished
 35 of 36 repetitions; one GPT Live Transcribe bilingual repetition timed out waiting for its finalized
 stream while capture and delivery continuity remained intact. The automated reconnect run passes all
@@ -133,31 +133,32 @@ and opens its saved report; the standalone script calls the same Core implementa
 covers microphone transcription, audio-route loss, in-place CLI preflight, and Activity-audit
 completion: no runtime error autonomously activates Jarvis, opens a browser, or presents a modal;
 fixed notices remain available in Activity. The gate statically rejects unreviewed presentation APIs.
-The source tree is prepared for a public launch without giving public input a direct privileged-agent
-path. CI, release, and agent automation use hosted runners; no self-hosted runner remains registered.
+The public source tree gives no public input a direct privileged-agent path. CI, release, and agent
+automation use hosted runners; no self-hosted runner remains registered.
 Automatic agent review is limited to same-repository PR branches, `@claude` is owner-invoked, issue
 discovery keeps its scheduled/manual triggers, and automatic issue implementation relies on the
 central workflow's existing author write-access check. Reusable agent workflows track the shared
 repository's `main` branch; retained third-party Actions are SHA-pinned and Dependabot-managed.
-Public docs
-disclose the current unsandboxed boundary, contribution and private-reporting paths are present, and
-release app bundles carry the Apache license plus third-party notices. The existing Git/PR history is
-intentionally preserved after the full-history secret scan found no credential leak; current-tree
-machine-specific instructions were generalized instead of rewriting repository identity and provenance.
+Public docs disclose the current unsandboxed boundary, contribution and private-reporting paths are
+present, and the latest GitHub Release carries a Developer ID-signed, notarized Apple silicon app.
+The release workflow requires macOS 14.2 or later, re-extracts and checks the final zip as the user
+receives it, and attaches a SHA-256 checksum; the app bundle carries the Apache license plus
+third-party notices. The existing Git/PR history is intentionally preserved after the full-history
+secret scan found no credential leak; current-tree machine-specific instructions were generalized
+instead of rewriting repository identity and provenance.
 
 ## Next action
 
 Re-enable the four agent workflows. Their hosted definitions and existing source-level gates are
 ready on `main`; they were disabled during rollout so the old base-branch copies could not target the
 removed self-hosted runner.
-Before changing repository visibility, delete the historical self-hosted runs and artifacts after
-owner approval: the audit found no credential leak, but those logs expose runner, account, and
-installed-tool paths.
+Delete the historical self-hosted runs and artifacts after owner approval: the audit found no
+credential leak, but those logs expose runner, account, and installed-tool paths.
 Replace release-please's `GITHUB_TOKEN` with a GitHub App token
 before making CI a required check, because token-authored Release PRs do not trigger `pull_request`
-workflows. At visibility change, enable private vulnerability reporting, secret scanning and push
-protection, Dependabot security updates, fork-workflow approval, and a `main` ruleset requiring pull
-requests and the CI check. Keep self-hosted runners unavailable to public forks.
+workflows. Confirm private vulnerability reporting, secret scanning and push protection, Dependabot
+security updates, fork-workflow approval, and a `main` ruleset requiring pull requests and the CI
+check for the public repository. Keep self-hosted runners unavailable to public forks.
 
 
 Run a live chronology smoke on a fresh session: let one speaker finish a longer question while the
@@ -230,14 +231,12 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the current non-persisted readiness badge, an exact selectable/copyable session ID, and one-click **Evaluate** / **Open report** agentic audit flow.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 + classic VAD native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
-- `.github/workflows/` + `scripts/package-app.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then release-please Release PR → Developer ID-signed, notarized, stapled `Jarvis-<version>.zip` with Apache and third-party notices attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
+- `.github/workflows/` + `scripts/package-app.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then release-please Release PR → Developer ID-signed, notarized, stapled, re-extracted, and Gatekeeper-checked `Jarvis-<version>.zip` with Apache and third-party notices plus `SHA256SUMS` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
 - `AGENTS.md` + `.github/workflows/sync-shared-rules.yml` — project-specific agent guidance with a
   machine-managed shared-rules block that syncs weekly from `JINGBANZ/rules`; `CLAUDE.md` imports the
   same canonical file.
 
 ## Not yet built
 
-- **First notarized release** — the release workflow needs its five repo secrets (Developer ID `.p12` + App Store Connect API key; names in `.github/workflows/release.yml`) set before the first Release PR is merged; the first run is the pipeline's live test.
 - **Universal binary** — `Sources/CJarvisAEC/lib/libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 slice if Intel is ever needed.
 - **Neural double-talk canceller** (DTLN / Muesli-style on the same aligned streams) — the escalation if AEC3 over-attenuates the user under loud far audio in practice.
-- **Minimum macOS version confirmed** — currently targeting macOS 14+; confirm against the APIs actually used (ScreenCaptureKit needs 13+).

--- a/wiki/transcription-benchmark.md
+++ b/wiki/transcription-benchmark.md
@@ -161,7 +161,7 @@ PCM is never persisted. A fixture-cleanup failure is a run failure and prevents 
 publishing a success marker.
 
 The command exits nonzero when a platform-supported arm is unavailable or incomplete, capture
-continuity fails, or the strict reconnect acceptance criteria fail. On macOS 14–25, Apple Speech arms
+continuity fails, or the strict reconnect acceptance criteria fail. On macOS 14.2–25, Apple Speech arms
 remain visible in `summary.json` as unavailable because that provider requires macOS 26, but they do
 not fail the runnable matrix. Inspect the summary to distinguish provider recognition/finalization
 behavior from capture or replay failure. Current live evidence and the next requested rerun belong in


### PR DESCRIPTION
## Summary

- make the signed GitHub Release the primary install path and separate it from source builds
- align the Swift package, app bundle, and docs on an Apple silicon / macOS 14.2 minimum
- verify the exact final ZIP after stapling, then publish it with checksums and install-first release notes
- make release publication retry-safe while keeping failed builds as drafts

## Why

The existing signed and notarized release proved distribution works, but the repository still led users through a source build and the workflow only assessed the app before its final archive was created. This closes those download and publication gaps without adding a DMG, updater, Intel build, or package-manager channel.

## User impact

Users can download Jarvis without Swift or Command Line Tools, follow one first-run path, and optionally verify the archive checksum. A future release remains a draft unless the exact shipped ZIP has the expected version, arm64 executable, license notices, valid signature, stapled notarization ticket, and Gatekeeper acceptance.

## Validation

- `swift build && ./scripts/run-tests.sh` — passed; 754 tests in 89 suites
- XcodeBuildMCP Swift package debug build — passed
- compiled `JarvisApp` reports deployment target `macOS 14.2`
- `scripts/verify-release.sh Jarvis-0.1.2.zip` — passed against the current public notarized artifact (`codesign`, `stapler`, and `spctl`)
- workflow YAML parse and embedded shell ShellCheck — passed
- `bash -n scripts/package-app.sh scripts/verify-release.sh` — passed
- `shellcheck scripts/package-app.sh scripts/verify-release.sh` — passed
- `plutil -lint Resources/Info.plist` and `git diff --check` — passed
