### PR TITLE
fix(build): separate development app identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ cd jarvis
 ./scripts/build-app.sh --run
 ```
 
-On the first local build, macOS asks whether `codesign` can use the `Jarvis Dev` key; choose
-**Always Allow**. The downloaded release does not use this local development identity.
+The script creates and opens `Jarvis Dev.app`, whose name, bundle id, preferences, and macOS privacy
+grants are independent from an installed `Jarvis.app` release. On the first local build, macOS asks
+whether `codesign` can use the `Jarvis Dev` key; choose **Always Allow**. macOS then asks once for the
+development app's own capture permissions. The downloaded release does not use this local identity.
 
 For signing details, permission recovery, and other commands, see
 [Build and run](./wiki/build-and-run.md). Always launch the app through the build script or `open`,

--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -1266,7 +1266,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// The agentic evaluator must inspect the live source checkout, not a baked description. Prefer
     /// an explicit launch argument, then the workspace-local `.jarvis/` parent used by build-app.sh,
-    /// then the directory containing a locally built Jarvis.app. A redistributed bundle without a
+    /// then the directory containing a locally built app bundle. A redistributed bundle without a
     /// checkout simply reports evaluation unavailable instead of running a weaker evaluator.
     private func evaluationRepositoryDirectory() -> URL? {
         let args = CommandLine.arguments

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Build, bundle, and sign Jarvis.app.
+# Build, bundle, and sign Jarvis Dev.app.
 #
 # Signing uses a stable, self-signed identity ("Jarvis Dev") so that macOS TCC permission grants
 # (Microphone, Screen Recording) persist across rebuilds — macOS keys a grant to the code signature,
 # and an identity that changed every build (ad-hoc) would make it re-prompt each time. The identity
 # is created automatically on the first build; there is no separate setup step and no ad-hoc signing.
+# The development bundle also has its own name and bundle id, so it cannot collide with an installed,
+# Developer ID-signed Jarvis release in TCC or Launch Services.
 #
 # Usage:
 #   ./scripts/build-app.sh                build + sign (release)
@@ -23,7 +25,9 @@ for arg in "$@"; do
   esac
 done
 
-APP="Jarvis.app"
+APP_NAME="Jarvis Dev"
+APP="$APP_NAME.app"
+BUNDLE_ID="com.jarvis.coach.dev"
 BIN_NAME="JarvisApp"
 IDENTITY="Jarvis Dev"
 
@@ -72,6 +76,12 @@ mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
 cp "$BIN_PATH" "$APP/Contents/MacOS/$BIN_NAME"
 cp Resources/Info.plist "$APP/Contents/Info.plist"
 cp Resources/Jarvis.icns "$APP/Contents/Resources/Jarvis.icns"
+# Resources/Info.plist remains the production source of truth. Override only the identity fields in
+# the assembled development bundle so release packaging stays independent and the two variants never
+# share TCC grants or Launch Services registration.
+/usr/bin/plutil -replace CFBundleName -string "$APP_NAME" "$APP/Contents/Info.plist"
+/usr/bin/plutil -replace CFBundleDisplayName -string "$APP_NAME" "$APP/Contents/Info.plist"
+/usr/bin/plutil -replace CFBundleIdentifier -string "$BUNDLE_ID" "$APP/Contents/Info.plist"
 
 echo "▶ signing with '$IDENTITY'"
 codesign --force --deep --sign "$IDENTITY" "$APP"
@@ -81,7 +91,9 @@ echo "✅ built $APP"
 # Always launch via `open`, never the bare binary — launching the executable from a terminal makes
 # macOS attribute the Mic/Screen-Recording grants to the shell, so they look "denied".
 launch() {
-  pkill -f "$APP/Contents/MacOS/$BIN_NAME" 2>/dev/null || true   # replace any running instance
+  # Replace only a development build. The installed production app has a different bundle path and
+  # identity and must be allowed to keep running alongside it.
+  /usr/bin/pkill -f "/${APP_NAME}[.]app/Contents/MacOS/$BIN_NAME" 2>/dev/null || true
   sleep 1
 }
 
@@ -95,7 +107,7 @@ case "$LAUNCH" in
     LOGDIR="$PWD/.jarvis"
     mkdir -p "$LOGDIR"
     chmod 700 "$LOGDIR"
-    echo "▶ launching Jarvis — open Settings → Activity to watch the log; per-session logs in $LOGDIR/<session>"
+    echo "▶ launching $APP_NAME — open Settings → Activity to watch the log; per-session logs in $LOGDIR/<session>"
     open ./"$APP" --args --log-dir "$LOGDIR"
     ;;
   "")

--- a/scripts/check-app-identities.sh
+++ b/scripts/check-app-identities.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail() {
+  echo "App identity guard: $1" >&2
+  exit 1
+}
+
+plist_value() {
+  /usr/libexec/PlistBuddy -c "Print :$1" Resources/Info.plist 2>/dev/null
+}
+
+[[ "$(plist_value CFBundleName)" == "Jarvis" ]] \
+  || fail "Resources/Info.plist must keep the production name Jarvis."
+[[ "$(plist_value CFBundleDisplayName)" == "Jarvis" ]] \
+  || fail "Resources/Info.plist must keep the production display name Jarvis."
+[[ "$(plist_value CFBundleIdentifier)" == "com.jarvis.coach" ]] \
+  || fail "Resources/Info.plist must keep the production bundle id com.jarvis.coach."
+
+dev_script="scripts/build-app.sh"
+for required in \
+  'APP_NAME="Jarvis Dev"' \
+  'APP="$APP_NAME.app"' \
+  'BUNDLE_ID="com.jarvis.coach.dev"' \
+  '/usr/bin/plutil -replace CFBundleName -string "$APP_NAME" "$APP/Contents/Info.plist"' \
+  '/usr/bin/plutil -replace CFBundleDisplayName -string "$APP_NAME" "$APP/Contents/Info.plist"' \
+  '/usr/bin/plutil -replace CFBundleIdentifier -string "$BUNDLE_ID" "$APP/Contents/Info.plist"'
+do
+  /usr/bin/grep -Fqx "$required" "$dev_script" \
+    || fail "$dev_script must assemble Jarvis Dev.app with its independent bundle identity."
+done
+/usr/bin/grep -Fqx '    open ./"$APP" --args --log-dir "$LOGDIR"' "$dev_script" \
+  || fail "$dev_script must launch the assembled development bundle."
+
+/usr/bin/grep -Fqx 'APP="Jarvis.app"' scripts/package-app.sh \
+  || fail "release packaging must continue to assemble Jarvis.app."
+/usr/bin/grep -Fqx 'APP="Jarvis.app"' scripts/verify-release.sh \
+  || fail "release verification must continue to require Jarvis.app."
+/usr/bin/grep -Fqx 'APP="Jarvis Dev.app"' scripts/transcription-benchmark.sh \
+  || fail "the developer transcription benchmark must launch Jarvis Dev.app."
+/usr/bin/grep -Fqx 'open -W -n "./$APP" --args "${COMMON_ARGS[@]}" &' \
+  scripts/transcription-benchmark.sh \
+  || fail "the developer transcription benchmark must open its declared development bundle."
+
+echo "App identity guard passed."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,6 +4,7 @@ cd "$(dirname "$0")/.."
 
 ./scripts/check-ghost-mode.sh
 ./scripts/check-audio-capture-config.sh
+./scripts/check-app-identities.sh
 
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's

--- a/scripts/transcription-benchmark.sh
+++ b/scripts/transcription-benchmark.sh
@@ -40,6 +40,7 @@ if ! [[ "$REPETITIONS" =~ ^[0-9]+$ ]] || (( REPETITIONS < 3 )); then
 fi
 
 BASE="$PWD/.jarvis/transcription-benchmarks"
+APP="Jarvis Dev.app"
 RUN_ID="$(date '+%Y-%m-%d_%H-%M-%S')-$$"
 RUN_DIR="$BASE/$RUN_ID"
 if [[ -L "$PWD/.jarvis" || -L "$BASE" ]]; then
@@ -97,7 +98,7 @@ trap abort_run INT TERM
 
 # `open -W` keeps a waitable launcher alive until the hidden app exits. Both modes observe the abort
 # marker; the signal trap then reaps this waiter so capture cannot outlive the command.
-open -W -n ./Jarvis.app --args "${COMMON_ARGS[@]}" &
+open -W -n "./$APP" --args "${COMMON_ARGS[@]}" &
 APP_WAITER_PID=$!
 wait "$APP_WAITER_PID"
 APP_WAITER_PID=""

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -26,20 +26,33 @@ needs — so a SwiftUI + ScreenCaptureKit binary builds with plain `swift build`
 
 ## Packaging & signing — why permission grants persist
 
-`scripts/build-app.sh` assembles the executable into a hand-built `.app` bundle (the bundle layout
-and the stable bundle id live in the script and `Resources/Info.plist`).
+`scripts/build-app.sh` assembles the executable into a hand-built `Jarvis Dev.app`. The production
+identity remains the source in `Resources/Info.plist`; the development script overrides only the
+assembled bundle's name and bundle id.
 
 **Permission persistence is a signing problem.** macOS TCC keys Screen-Recording, Microphone, and
 System Audio Recording grants to **code signature + bundle id + bundle path**. An ad-hoc signature
 changes every build, so macOS
 forgets the grant and re-prompts on each rebuild. So `build-app.sh` always signs with a **stable
 self-signed identity (`Jarvis Dev`**, created automatically on first build) — there is **no ad-hoc
-fallback**. With the identity, bundle id, and path all fixed, grants persist across rebuilds and
-relaunches. On the first build macOS prompts once to let `codesign` use the new key — click
-**"Always Allow"**.
+fallback**. It produces `Jarvis Dev.app` with bundle id `com.jarvis.coach.dev`; the downloaded
+`Jarvis.app` keeps `com.jarvis.coach` and its Developer ID signature. These intentionally incompatible
+identities give each variant its own TCC grants, Launch Services registration, and bundle-id-backed
+preferences, so both can be installed and run on one Mac without one variant impersonating the
+other. With the development identity, bundle id, and checkout path fixed, its grants persist across
+rebuilds and relaunches. On the first build macOS prompts once to let `codesign` use the new key —
+click **"Always Allow"** — and the first launch requests the development app's own capture grants.
+
+The identity split is not a second data sandbox. Both variants intentionally keep the established
+owner-only API-key and direct-open session storage under `Application Support/Jarvis`; launching the
+development app through `build-app.sh --run` continues to put its sessions in that checkout's
+`.jarvis/`. If a checkout still contains a generated `Jarvis.app` from before the split, move only
+that checkout-local bundle to the Trash so it cannot be launched accidentally; leave
+`/Applications/Jarvis.app` in place.
 
 - Recover a stale *denied* state (which macOS won't re-prompt for) with
-  `tccutil reset Microphone com.jarvis.coach` (or `ScreenCapture`), then relaunch and Allow.
+  `tccutil reset Microphone com.jarvis.coach.dev` (or `ScreenCapture`), then relaunch `Jarvis Dev`
+  and Allow. Use `com.jarvis.coach` only when intentionally resetting the production release.
 - Screen Recording + Microphone are granted by **TCC prompts at first launch**, not an App-Sandbox
   entitlement file. `Permissions.primeAll()` requests them at launch and is idempotent. Core Audio
   requests System Audio Recording when Jarvis first builds its process tap after Start.
@@ -80,13 +93,16 @@ installation steps; provider credentials remain user-supplied in Settings.
 | Command | What it does |
 |---|---|
 | `./scripts/run-tests.sh` | Build + run the unit/offline-pipeline tests (no key, no permissions). |
-| `./scripts/build-app.sh [release\|debug]` | Build, bundle, sign `Jarvis.app` (default `release`). Creates `Jarvis Dev` on first run. |
-| `./scripts/build-app.sh --run` | Same build, then launch. Per-session logs land in the workspace `.jarvis/` (see below). |
+| `./scripts/build-app.sh [release\|debug]` | Build, bundle, sign `Jarvis Dev.app` (default `release`). Creates the `Jarvis Dev` signing identity on first run. |
+| `./scripts/build-app.sh --run` | Same development build, then launch it. Per-session logs land in the workspace `.jarvis/` (see below). |
 
-- **Always launch with `open ./Jarvis.app`**, never the bare binary — running it from a shell makes
+- **Always launch with `open "./Jarvis Dev.app"`**, never the bare binary — running it from a shell makes
   TCC attribute the grant to the *terminal*, so the app reports Microphone, System Audio Recording,
   or Screen Recording as "denied" even when granted. Pass flags with
-  `open ./Jarvis.app --args …`.
+  `open "./Jarvis Dev.app" --args …`.
+- Production and development can stay open together, but the fixed global ⌥⌘J shortcut can belong
+  to only one running process. The second app logs that the shortcut is unavailable; use its menu-bar
+  controls directly or quit the other variant when testing the shortcut.
 - Jarvis does **not** auto-start: choose transcription and Primary brain providers in Settings, meet
   their credential or local sign-in requirements, then **Start / Stop** from the menu. OpenAI keys
   are saved to an owner-only file; `OPENAI_API_KEY` is a headless fallback. The icon shows two states
@@ -143,7 +159,7 @@ runtime). It also sidesteps the `file://` `fetch()` restriction that forced the 
   rendered page. A saved session shows **Open report** instead, avoiding another agent run. The local
   app locates its checkout from the
   workspace `.jarvis/`, a `--repo-dir` launch argument, or the directory containing a locally built
-  `Jarvis.app`; without live source it refuses to run a weaker audit. `./scripts/eval-session.sh
+  app bundle; without live source it refuses to run a weaker audit. `./scripts/eval-session.sh
   [session-dir]` is the terminal launcher for the same Core evaluator.
 
 ## System-audio transcription benchmark

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1593,3 +1593,25 @@
 - **Supersedes in part:** 2026-08-10 — Public repositories keep hosted, owner-gated agent automation.
 - **Detail:** `.github/workflows/claude-code-review.yml`, `.github/workflows/claude.yml`,
   `.github/workflows/issue-opener.yml`, `.github/workflows/issue-worker.yml`.
+
+### 2026-08-12 — Development and release builds have independent macOS identities
+
+- **Chose:** Make `scripts/build-app.sh` assemble `Jarvis Dev.app` with display name `Jarvis Dev`
+  and bundle id `com.jarvis.coach.dev`, while release packaging continues to ship `Jarvis.app` as
+  `com.jarvis.coach`. Derive the development plist from the production source at assembly time and
+  override only those identity fields. The signed-app transcription benchmark uses the development
+  bundle. Existing owner-only credential and session storage paths remain unchanged.
+- **Why:** TCC records privacy decisions against signed code identity, not the display label alone.
+  The self-signed development build and Developer ID release previously had incompatible designated
+  requirements but the same name and bundle id, leaving an ambiguous enabled “Jarvis” row while the
+  other variant could still be prompted on every launch. Separate identities make permission state,
+  Launch Services registration, and preferences unambiguous and let both variants coexist on one Mac.
+- **Rejected:** (a) Renaming only the `.app` directory—the signed bundle id would still collide.
+  (b) Giving both signatures mutually compatible designated requirements—that would deliberately
+  share the privacy grant instead of making the variants independent. (c) Maintaining a complete
+  second Info.plist—usage descriptions and release versions would drift. (d) Resetting TCC whenever
+  switching variants—destructive ceremony around an identity problem rather than a durable fix.
+- **Extends:** 2026-06-13 — Toolchain: SwiftPM + Command Line Tools. The stable local signing
+  identity remains; the development bundle now also has a distinct application identity.
+- **Detail:** [build-and-run.md → Packaging and signing](./build-and-run.md#packaging--signing--why-permission-grants-persist),
+  `scripts/build-app.sh`, `scripts/check-app-identities.sh`.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -143,7 +143,9 @@ Public docs disclose the current unsandboxed boundary, contribution and private-
 present, and the latest GitHub Release carries a Developer ID-signed, notarized Apple silicon app.
 The release workflow requires macOS 14.2 or later, re-extracts and checks the final zip as the user
 receives it, and attaches a SHA-256 checksum; the app bundle carries the Apache license plus
-third-party notices. The existing Git/PR history is intentionally preserved after the full-history
+third-party notices. Local builds use the independent `Jarvis Dev.app` / `com.jarvis.coach.dev`
+identity while releases retain `Jarvis.app` / `com.jarvis.coach`, so their TCC grants and preferences
+can coexist on one Mac. The existing Git/PR history is intentionally preserved after the full-history
 secret scan found no credential leak; current-tree machine-specific instructions were generalized
 instead of rewriting repository identity and provenance.
 
@@ -231,6 +233,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the current non-persisted readiness badge, an exact selectable/copyable session ID, and one-click **Evaluate** / **Open report** agentic audit flow.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 + classic VAD native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
+- `scripts/build-app.sh` — the local self-signed `Jarvis Dev.app` build with an independent bundle id and TCC identity; its production plist source remains unchanged.
 - `.github/workflows/` + `scripts/package-app.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then release-please Release PR → Developer ID-signed, notarized, stapled, re-extracted, and Gatekeeper-checked `Jarvis-<version>.zip` with Apache and third-party notices plus `SHA256SUMS` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
 - `AGENTS.md` + `.github/workflows/sync-shared-rules.yml` — project-specific agent guidance with a
   machine-managed shared-rules block that syncs weekly from `JINGBANZ/rules`; `CLAUDE.md` imports the

--- a/wiki/transcription-benchmark.md
+++ b/wiki/transcription-benchmark.md
@@ -8,8 +8,8 @@
 
 The benchmark answers a narrow question: **given known audio, does each production transcription
 path receive it continuously and return the expected result with a healthy lifecycle?** It uses the
-real signed `Jarvis.app`, process-scoped system-audio capture, provider sessions, reconnect code, and
-replay buffer. It does not start a coaching session or evaluate what the coach did.
+real signed `Jarvis Dev.app`, process-scoped system-audio capture, provider sessions, reconnect code,
+and replay buffer. It does not start a coaching session or evaluate what the coach did.
 
 The runner and scorer have different jobs:
 
@@ -17,7 +17,7 @@ The runner and scorer have different jobs:
 fixed synthetic speech
         │
         ▼
-hidden signed Jarvis.app ── lifecycle + capture observations ──► deterministic scorer
+hidden signed Jarvis Dev.app ─ lifecycle + capture observations ─► deterministic scorer
         │                                                           │
         └──────── real transcription provider path ─────────────────┘
                                                                     ▼


### PR DESCRIPTION
## Summary

- build local development bundles as `Jarvis Dev.app` with bundle id `com.jarvis.coach.dev`
- keep production packaging unchanged as `Jarvis.app` / `com.jarvis.coach`
- make the transcription benchmark target the development bundle
- add a Gate guard and document independent TCC, preferences, migration, and coexistence behavior

## Why

The self-signed development build and Developer ID release previously used the same app name and bundle id but had incompatible designated requirements. macOS could therefore show an enabled “Jarvis” privacy row for one identity while repeatedly prompting the other. Giving development and production distinct application identities makes their TCC records and Launch Services registrations unambiguous and durable.

## Validation

- `swift build && ./scripts/run-tests.sh` — passed; 755 tests in 89 suites
- `./scripts/build-app.sh debug` — built and signed `Jarvis Dev.app`
- built development plist — `Jarvis Dev` / `com.jarvis.coach.dev`
- installed production plist — `Jarvis` / `com.jarvis.coach`
- host `codesign --verify --deep --strict` and designated-requirement checks passed for both bundles
- XcodeBuildMCP Swift package debug build passed

Live launch/capture was intentionally not performed, so the first `Jarvis Dev` TCC prompt still needs manual confirmation on the target Mac.