### PR TITLE
fix(release): align distributed app appearance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,9 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: macos-15
+    # AppKit selects the macOS 26 control design from the linked SDK. Pin the release runner instead
+    # of following macos-latest so distributed and local macOS 26 builds cannot silently diverge.
+    runs-on: macos-26
     # Notarization occasionally stalls on Apple's side; without a cap, a stalled run rides the
     # 6-hour default timeout at the 10x macOS minute multiplier. Normal publishes finish well
     # under this. The cap must clear package-app.sh's `notarytool --wait --timeout 30m` PLUS

--- a/Sources/JarvisOverlay/OverlayBoxPanel.swift
+++ b/Sources/JarvisOverlay/OverlayBoxPanel.swift
@@ -77,6 +77,10 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
         let scroll = NSScrollView(frame: box.bounds)
         scroll.autoresizingMask = [.width, .height]
         scroll.hasVerticalScroller = true
+        // Keep the history scrollable without reserving a persistent legacy-style gutter. AppKit's
+        // preferred style can differ by linked SDK and input device, so this must not be implicit.
+        scroll.scrollerStyle = .overlay
+        scroll.autohidesScrollers = true
         scroll.drawsBackground = false        // let the opaque box show through
         scroll.borderType = .noBorder
 
@@ -251,6 +255,16 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
 
     /// Whether the box can be resized by dragging its edges.
     var isResizable: Bool { panel.isResizable }
+
+    /// Scroller presentation used by the history box.
+    var currentScrollerStyle: NSScroller.Style {
+        textView.enclosingScrollView?.scrollerStyle ?? .legacy
+    }
+
+    /// Whether a non-scrollable history hides its vertical scroller.
+    var scrollersAutohide: Bool {
+        textView.enclosingScrollView?.autohidesScrollers ?? false
+    }
 
     /// Resize the box's content (used by tests; the user resizes by dragging the edges).
     func setContentSize(_ size: NSSize) { panel.setContentSize(size) }

--- a/Tests/JarvisOverlayTests/OverlayBoxPanelTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayBoxPanelTests.swift
@@ -74,6 +74,15 @@ import AppKit
     }
 
     @MainActor @Test
+    func usesAutoHidingOverlayScroller() {
+        let panel = OverlayBoxPanel()
+        #expect(panel.currentScrollerStyle == .overlay,
+                "the box must not inherit a persistent legacy scroller from the release SDK")
+        #expect(panel.scrollersAutohide,
+                "a short history must not leave an unnecessary scrollbar visible")
+    }
+
+    @MainActor @Test
     func appearanceSettersChangeOpacityAndFontSize() {
         let panel = OverlayBoxPanel()
         panel.setOpacity(0.5)

--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+workflow=".github/workflows/release.yml"
+package_script="scripts/package-app.sh"
+verify_script="scripts/verify-release.sh"
+sdk_guard="scripts/check-release-sdk.sh"
+package_guard_call="./scripts/check-release-sdk.sh \"\$BIN_PATH\""
+verify_guard_call="./scripts/check-release-sdk.sh \"\$EXTRACTED_BIN\""
+
+for path in "$workflow" "$package_script" "$verify_script" "$sdk_guard"; do
+  if [[ ! -f "$path" || -L "$path" ]]; then
+    echo "Release configuration guard: $path must be a regular file." >&2
+    exit 1
+  fi
+done
+
+if ! /usr/bin/grep -Eq '^[[:space:]]*runs-on:[[:space:]]*macos-26[[:space:]]*$' "$workflow"; then
+  echo "Release publish job must use the Apple-silicon macos-26 runner." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq "$package_guard_call" "$package_script"; then
+  echo "Release packaging must reject a pre-macOS-26 SDK before signing and notarization." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq "$verify_guard_call" "$verify_script"; then
+  echo "Final release verification must inspect the SDK linked into the extracted app." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'readonly MINIMUM_SDK_MAJOR=26' "$sdk_guard"; then
+  echo "Release SDK guard must require macOS SDK 26 or newer." >&2
+  exit 1
+fi
+
+echo "Release configuration guard passed."

--- a/scripts/check-release-sdk.sh
+++ b/scripts/check-release-sdk.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINARY="${1:-}"
+if [[ $# -ne 1 || -z "$BINARY" || ! -f "$BINARY" || -L "$BINARY" ]]; then
+  echo "usage: $0 /path/to/JarvisApp" >&2
+  exit 2
+fi
+
+readonly MINIMUM_SDK_MAJOR=26
+SDK_VERSION="$(
+  /usr/bin/otool -l "$BINARY" \
+    | /usr/bin/awk '
+        $1 == "cmd" { in_build_version = ($2 == "LC_BUILD_VERSION"); next }
+        in_build_version && $1 == "platform" { platform = $2; next }
+        in_build_version && platform == "1" && $1 == "sdk" && sdk == "" { sdk = $2 }
+        END { if (sdk != "") print sdk }
+      '
+)"
+
+if [[ ! "$SDK_VERSION" =~ ^([0-9]+)(\.[0-9]+){1,2}$ ]]; then
+  echo "error: couldn't read a macOS SDK version from $BINARY" >&2
+  exit 1
+fi
+SDK_MAJOR="${BASH_REMATCH[1]}"
+if (( SDK_MAJOR < MINIMUM_SDK_MAJOR )); then
+  echo "error: $BINARY was built with macOS SDK $SDK_VERSION; SDK $MINIMUM_SDK_MAJOR or newer is required" >&2
+  exit 1
+fi
+
+echo "Release SDK guard passed: macOS SDK $SDK_VERSION"

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -47,6 +47,7 @@ fi
 echo "▶ swift build -c release"
 swift build -c release
 BIN_PATH="$(swift build -c release --show-bin-path)/$BIN_NAME"
+./scripts/check-release-sdk.sh "$BIN_PATH"
 
 echo "▶ assembling $APP"
 rm -rf "$APP"

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -4,6 +4,7 @@ cd "$(dirname "$0")/.."
 
 ./scripts/check-ghost-mode.sh
 ./scripts/check-audio-capture-config.sh
+./scripts/check-release-config.sh
 
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -52,11 +52,13 @@ if [[ -n "$EXPECTED_RELEASE_TAG" && "$EXPECTED_RELEASE_TAG" != "v$VERSION" ]]; t
   echo "error: expected release tag $EXPECTED_RELEASE_TAG does not match bundled version $VERSION" >&2
   exit 1
 fi
-ARCHITECTURES="$(lipo -archs "$EXTRACTED_APP/Contents/MacOS/$BIN_NAME")"
+EXTRACTED_BIN="$EXTRACTED_APP/Contents/MacOS/$BIN_NAME"
+ARCHITECTURES="$(lipo -archs "$EXTRACTED_BIN")"
 if [[ "$ARCHITECTURES" != "arm64" ]]; then
   echo "error: archived app has unexpected architectures: $ARCHITECTURES" >&2
   exit 1
 fi
+./scripts/check-release-sdk.sh "$EXTRACTED_BIN"
 if [[ ! -f "$EXTRACTED_APP/Contents/Resources/LICENSE" \
       || ! -f "$EXTRACTED_APP/Contents/Resources/THIRD_PARTY_NOTICES.md" ]]; then
   echo "error: archived app is missing required license notices" >&2

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -55,20 +55,23 @@ so the archive is rebuilt after stapling). Hardened runtime denies microphone ca
 without the `audio-input` entitlement, so the script signs with `Resources/Jarvis.entitlements`.
 The script then passes that final zip to `scripts/verify-release.sh`, which extracts it into a fresh
 verification directory and checks the exact shipped app's bundle shape, version, arm64 architecture,
-notices, strict code signature, stapled ticket, and Gatekeeper policy result. The pre-compression app
-is not accepted as a proxy for the downloaded artifact.
+linked macOS 26-or-newer SDK, notices, strict code signature, stapled ticket, and Gatekeeper policy
+result. The same SDK guard runs immediately after the release build, before signing or notarization;
+the pre-compression app is not accepted as a proxy for the downloaded artifact.
 
 Releases are cut by `.github/workflows/release.yml`, not by hand: on every push to `main`,
 **release-please** maintains a standing Release PR from the conventional-commit history (bumping both
 version keys in `Resources/Info.plist` via `x-release-please-version` annotations, plus the
 CHANGELOG — config in `release-please-config.json`). Merging that PR creates the GitHub Release **as
-a draft**; a `macos-15` job then runs the test gate, signs/notarizes via repo secrets (the base64
-`.p12` certificate and an App Store Connect API key — names in the workflow), attaches the zip, and
-only then publishes the Release. The publish step also attaches `SHA256SUMS` and prepends the stable
-installation block in `.github/release-header.md` to release-please's generated changelog. A failed
-sign, notarization, or final-archive verification therefore never leaves a public Release without a
-validated app. The publish job lives in the same workflow because tags created with `GITHUB_TOKEN`
-never trigger other workflows.
+a draft**; an Apple-silicon `macos-26` job then runs the test gate, signs/notarizes via repo secrets
+(the base64 `.p12` certificate and an App Store Connect API key — names in the workflow), attaches
+the zip, and only then publishes the Release. The publish step also attaches `SHA256SUMS` and
+prepends the stable installation block in `.github/release-header.md` to release-please's generated
+changelog. A failed sign, notarization, or final-archive verification therefore never leaves a
+public Release without a validated app. The exact runner label and binary guard keep downloaded
+AppKit controls on the same macOS 26 design as local development builds instead of inheriting the
+compatibility appearance of an older linked SDK. The publish job lives in the same workflow because
+tags created with `GITHUB_TOKEN` never trigger other workflows.
 
 `package-app.sh` also runs locally (one-time `xcrun notarytool store-credentials jarvis-notary …`,
 then just run the script) for packaging without CI. Distributed builds require macOS 14.2 or later

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -453,6 +453,9 @@
 - **Chose:** Releases are fully automated in `.github/workflows/release.yml`: release-please (`simple` release type) maintains a Release PR from the conventional-commit history and keeps both `Resources/Info.plist` version keys in sync via `x-release-please-version` line annotations; merging it creates a **draft** GitHub Release, and a `macos-15` job runs the test gate, then `scripts/package-app.sh` — one Developer ID signing pass with hardened runtime, timestamp, and the `audio-input` entitlement (hardened runtime otherwise denies the mic), notarization via an App Store Connect API key, staple, **re-zip after stapling** — and publishes the Release only after `Jarvis-<version>.zip` is attached. `package-app.sh` is self-contained rather than layered on `build-app.sh`, whose self-signed-identity creation can prompt for keychain access and hang a headless runner.
 - **Why:** Friends install from the repo's Releases page with zero Gatekeeper friction, and version/CHANGELOG/tag/asset can't drift because no step is manual. Draft-until-attached means a failed sign/notarize run never leaves a public Release without its app.
 - **Rejected:** (a) Sharing the `Jarvis Dev`-signed zip — untrusted on every other Mac; macOS 15 removed the right-click-Open bypass, leaving the buried "Open Anyway" flow. (b) A separate tag-triggered build workflow — tags created with `GITHUB_TOKEN` never trigger other workflows, so it would silently never run; the build job is gated on `release_created` in the same workflow instead. (c) Apple ID + app-specific password for notarization — the API key is the recommended CI method (no 2FA/session coupling, revocable). (d) A DMG — a zip is standard for a small menu-bar app and `notarytool` takes it directly.
+- **Superseded in part by:** 2026-08-12 — Distributed AppKit appearance is pinned to the macOS 26
+  SDK. The release-please, signing, notarization, and publication flow stands; the `macos-15` runner
+  does not.
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci); `scripts/package-app.sh`, `release-please-config.json`.
 
 ### 2026-07-17 — Agentic session audit as a dev-side workflow; single-call path kept as fallback
@@ -1593,3 +1596,25 @@
 - **Supersedes in part:** 2026-08-10 — Public repositories keep hosted, owner-gated agent automation.
 - **Detail:** `.github/workflows/claude-code-review.yml`, `.github/workflows/claude.yml`,
   `.github/workflows/issue-opener.yml`, `.github/workflows/issue-worker.yml`.
+
+### 2026-08-12 — Distributed AppKit appearance is pinned to the macOS 26 SDK
+
+- **Chose:** Build the signed release on the Apple-silicon `macos-26` runner and require the actual
+  Jarvis Mach-O to link macOS SDK 26 or newer. Run that binary check before signing/notarization and
+  repeat it after extracting the final downloadable zip. Keep the Overlay Box scrollable, but set
+  its scroller to AppKit's overlay style with automatic hiding instead of accepting the runtime's
+  SDK-, preference-, or pointing-device-selected default.
+- **Why:** The notarized 0.1.2 app and a local source build contained the same Settings and overlay
+  source, but the downloaded binary linked SDK 15.5 while the local binary linked SDK 26.5. macOS 26
+  deliberately preserves the old control design for apps built with older SDKs, and the implicit
+  Overlay Box scroller became a persistent legacy gutter. Release UI parity is therefore an artifact
+  property, not something source review or a runner label alone proves.
+- **Rejected:** (a) Hand-styling Settings to imitate one SDK—duplicates AppKit and still leaves other
+  standard controls divergent. (b) Changing only the runner label—future image drift or local
+  packaging could silently produce another old-SDK artifact. (c) Removing vertical scrolling from
+  the Overlay Box—hides the symptom by losing access to older coaching tips.
+- **Supersedes in part:** 2026-07-17 — Distribution via release-please + notarized zip on GitHub
+  Releases. Its automation and trust chain stand; its release runner does not.
+- **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
+  `.github/workflows/release.yml`, `scripts/check-release-sdk.sh`,
+  `Sources/JarvisOverlay/OverlayBoxPanel.swift`.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -141,11 +141,12 @@ central workflow's existing author write-access check. Reusable agent workflows 
 repository's `main` branch; retained third-party Actions are SHA-pinned and Dependabot-managed.
 Public docs disclose the current unsandboxed boundary, contribution and private-reporting paths are
 present, and the latest GitHub Release carries a Developer ID-signed, notarized Apple silicon app.
-The release workflow requires macOS 14.2 or later, re-extracts and checks the final zip as the user
-receives it, and attaches a SHA-256 checksum; the app bundle carries the Apache license plus
-third-party notices. The existing Git/PR history is intentionally preserved after the full-history
-secret scan found no credential leak; current-tree machine-specific instructions were generalized
-instead of rewriting repository identity and provenance.
+The release workflow builds with the macOS 26 SDK while retaining a macOS 14.2 deployment target,
+then re-extracts and checks that linked SDK in the final zip as the user receives it and attaches a
+SHA-256 checksum; the app bundle carries the Apache license plus third-party notices. The existing
+Git/PR history is intentionally preserved after the full-history secret scan found no credential
+leak; current-tree machine-specific instructions were generalized instead of rewriting repository
+identity and provenance.
 
 ## Next action
 
@@ -231,7 +232,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the current non-persisted readiness badge, an exact selectable/copyable session ID, and one-click **Evaluate** / **Open report** agentic audit flow.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 + classic VAD native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
-- `.github/workflows/` + `scripts/package-app.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then release-please Release PR → Developer ID-signed, notarized, stapled, re-extracted, and Gatekeeper-checked `Jarvis-<version>.zip` with Apache and third-party notices plus `SHA256SUMS` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
+- `.github/workflows/` + `scripts/package-app.sh` + `scripts/check-release-sdk.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then a macOS-26-SDK release-please Release PR → Developer ID-signed, notarized, stapled, re-extracted, SDK/Gatekeeper-checked `Jarvis-<version>.zip` with Apache and third-party notices plus `SHA256SUMS` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
 - `AGENTS.md` + `.github/workflows/sync-shared-rules.yml` — project-specific agent guidance with a
   machine-managed shared-rules block that syncs weekly from `JINGBANZ/rules`; `CLAUDE.md` imports the
   same canonical file.


### PR DESCRIPTION
## Summary

- build release artifacts on the Apple-silicon `macos-26` runner and reject binaries linked against a pre-macOS-26 SDK before notarization and after extracting the final ZIP
- keep the Overlay Box scrollable while making its vertical scroller explicitly overlay-style and auto-hiding
- add Gate coverage for both invariants and record the release decision in the wiki

## Root cause

The installed 0.1.2 binary linked macOS SDK 15.5 while the local development binary linked SDK 26.5, even though their Settings and overlay source matched. AppKit therefore gave the distributed app the older compatibility appearance. The Overlay Box also inherited its scroller presentation from the runtime, which exposed a persistent legacy gutter.

## Validation

- `./scripts/run-tests.sh --filter OverlayBoxPanelTests` — 15 tests passed
- SDK guard accepted the local SDK 26.5 binary and rejected the installed SDK 15.5 binary
- `bash -n`, `shellcheck`, workflow YAML parsing, release configuration guard, and `git diff --check` passed
- `swift build && ./scripts/run-tests.sh` — 755 tests in 89 suites passed; the consent-gated live screen-capture test remained skipped

An earlier full run hit the unrelated one-second timeout in `timedOutCodexCompactionInterruptsOnlyItsThread` under parallel load; that test passed in isolation, followed by the clean exact full Gate above.

## Scope

No Settings redesign, preference migration, coaching/runtime behavior change, or live capture run.