### PR TITLE
docs(wiki): define lean coaching core architecture

### DIFF
--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -12,6 +12,10 @@
 > `Config/Config.swift`); this page is
 > the *why*, the code is the *what*.
 
+> The approved cross-cutting destination for isolating optional runtime work is documented in
+> [lean-coaching-core.md](./lean-coaching-core.md). That page distinguishes the built Phase 0 audit
+> foundation from the unbuilt Phase 1–5 roadmap; the current runtime remains as described here.
+
 ## 1. Vision
 
 Jarvis is a personal, always-on macOS assistant that **coaches you through technical interviews**:
@@ -671,6 +675,11 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
    egress are enforced today; do not claim filesystem isolation until App Sandbox is implemented.
 6. **Self-verifying.** Every build ships with tests and a smoke checklist the agent can run to prove it works.
 7. **One domain, done well.** Ship the technical-interview coach; expand later.
+
+The same principle applies to runtime structure: the
+[lean coaching core contract](./lean-coaching-core.md) keeps only outcome-affecting policy and ports
+on the critical lane, while one shared best-effort evidence stack serves the Activity window and
+detailed agent/evaluator investigation.
 
 How Jarvis is built, signed, tested, and run — and the activity viewer — is its own
 operational page: [build-and-run.md](./build-and-run.md).

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1674,3 +1674,41 @@
   `Sources/JarvisCore/Diagnostics/SessionEvidenceIndex.swift`,
   `Sources/JarvisCore/Diagnostics/SessionMetrics.swift`,
   `Sources/JarvisCore/Prompts/JarvisPrompts+Evaluation.swift`.
+
+### 2026-08-16 — Session evidence uses one shared stack and two projections
+
+- **Chose:** Make the issue #147 destination one `SessionEvidence` stack: one versioned
+  `SessionEvent` per occurrence, one count- and byte-bounded mailbox, one worker, one per-session
+  handle and lifecycle, and one completeness contract. An event carries typed detail plus an optional
+  closed, human-safe Activity presentation. The Activity window renders that high-level projection;
+  the owner-only session folder retains the detailed agent/evaluator projection. Audit, diagnostics,
+  Activity, and continuity evidence remain typed categories, not independent persistence stacks.
+- **Chose:** Give all persisted session evidence the same best-effort loss contract. Capacity or
+  persistence failure may lose any category and must leave the session visibly partial when possible;
+  coaching always continues. The shared evidence queue therefore has no priority classes, reserved
+  capacity, backpressure, or writer retries. Critical queues declare separate intentional policies
+  because transcript state, coaching history, route state, and enabled overlay delivery are not
+  optional evidence.
+- **Chose:** Rename capture liveness to **capture heartbeat** and keep it on the critical branch. The
+  existing content-free `AudioContinuityWitness` frame-progress observation directly feeds capture
+  health policy; only an optional diagnostic copy enters `SessionEvidence`. Evidence loss can never
+  change readiness, microphone-only degradation, or stop. Preserve one target per coaching attempt,
+  forward-only fresh-attempt recovery, the three-failure temporary/unknown budget, immediate proven
+  permanent exhaustion, and independent new sessions after Stop → Start.
+- **Why:** The actual workflow has one human consumer—the Activity window—and one detailed consumer—an
+  agent or evaluator inspecting the session folder. Parallel Activity, audit, diagnostic, and
+  telemetry queues would duplicate workers, health, lifecycle, and overload policy without buying a
+  stronger product guarantee. Typed projections keep human copy safe and detailed evidence rich while
+  sharing the simple failure boundary the owner approved.
+- **Rejected:** (a) Dedicated `ActivityEventSink`, `DiagnosticSink`, session-audit, and continuity
+  stacks. (b) A flat human log containing transport and raw-error detail. (c) Priority queues or
+  reserved Activity/audit capacity under a uniform best-effort contract. (d) Letting capture health
+  consume persisted telemetry. (e) Combining the whole migration, target extraction, maintenance,
+  and coordinator decomposition in one refactor.
+- **Supersedes in part:** 2026-08-10 — Session audit persistence is bounded and failure-contained.
+  Its bounded nonblocking transport and honest partial evidence stand; the audit-only scope and
+  separate Activity failure-domain assumption become the Phase 0 foundation of the shared stack.
+- **Extends:** 2026-08-11 — Session audits close once and never reopen. Its monotonic health,
+  independent Stop → Start, and Quit-never-waits semantics apply to the destination evidence stack.
+- **Detail:** [lean-coaching-core.md](./lean-coaching-core.md),
+  [session-audit.md](./session-audit.md).

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -19,7 +19,8 @@
 - **[landscape-survey.md](./landscape-survey.md)** — every tool and product we tried or evaluated, and how each measured up. ("What I tried.")
 - **[fork-evaluation.md](./fork-evaluation.md)** — code-level evaluation of open-source apps as a fork base for the PoC, and why they're all Electron/Tauri rather than native Swift.
 - **[settings-window.md](./settings-window.md)** — the unified Settings window: one menu item → `SettingsWindow` hosting `BrainSection`, `OverlaySection`, `DisplaySection`, and `ActivitySection`; the Brain tab configures the independent transcription provider/model/language or Apple locale, the ordered coaching route (OpenAI API or auto-detected local Claude Code / Codex CLI targets), shared reasoning effort, and the conditionally required OpenAI API key; the Overlay Caption and Overlay Box each have an on/off toggle + size/opacity, persisted via `OverlayAppearance`; the Screen tab picks what `capture_screen` shoots in one dropdown — the active window by default (with an on-device OCR sidecar) or an entire display.
-- **[session-audit.md](./session-audit.md)** — the diagnostics-only session audit: optional execution ports, bounded persistence, Start/Stop/Quit ownership, failure containment, completeness evidence, and the evaluator boundary.
+- **[lean-coaching-core.md](./lean-coaching-core.md)** — the approved issue #147 target architecture and phased roadmap: one critical coaching lane, one shared `SessionEvidence` stack with Activity and agent projections, capture heartbeat, preserved fresh-attempt routing, and the Phase 1 implementation contract.
+- **[session-audit.md](./session-audit.md)** — the built Phase 0 foundation: optional audit ports, bounded persistence, Start/Stop/Quit ownership, failure containment, completeness evidence, and the evaluator boundary.
 
 ## Decisions
 

--- a/wiki/lean-coaching-core.md
+++ b/wiki/lean-coaching-core.md
@@ -1,0 +1,272 @@
+# Lean Coaching Core
+
+> The approved target architecture and phased implementation contract for
+> [issue #147](https://github.com/JINGBANZ/jarvis/issues/147). Phase 0 is built. Phase 1 is the next
+> implementation slice; the later phases describe the reviewed destination, not shipped behavior.
+
+> **Owner review result:** This contract supersedes the issue body's proposed independent Activity,
+> audit, diagnostic, and continuity-telemetry stacks and its earlier phase ordering. The issue remains
+> the umbrella tracker; this wiki page and the matching [decision record](./decisions.md) are the
+> implementation authority.
+
+## Why This Exists
+
+The live coach currently records optional evidence through three paths: the human-facing
+`ActivityLog`, evaluator-focused session audit, and agent-facing `jlog`. Their content differs, but
+their persistence has the same product contract: evidence is useful after an incident, yet it must
+not decide whether Jarvis hears, reasons, captures, or delivers a tip.
+
+The approved design therefore has one session-evidence stack instead of separate Activity, audit,
+diagnostic, and continuity-telemetry stacks. Typed event categories preserve their different meaning;
+one bounded transport, lifecycle, and completeness record avoid parallel queue machinery. The
+Activity window remains the concise human view. The owner-only session folder remains the detailed
+source an agent or evaluator inspects.
+
+The current implementation remains described in [architecture.md](./architecture.md) and
+[session-audit.md](./session-audit.md). This page is the durable target contract and handoff for the
+phased migration.
+
+## Approved Architecture Contract
+
+| Concern | Contract |
+|---|---|
+| Coaching behavior | From finalized transcript admission through overlay delivery, coaching depends only on deterministic in-memory policy and explicitly injected critical ports. |
+| Optional evidence | Producers submit one typed `SessionEvent` through nonthrowing, nonbackpressuring admission. Evidence has no callback or state-transition edge into coaching. |
+| Failure behavior | Capacity pressure, serialization failure, file failure, or an unfinished close makes evidence visibly partial. Coaching continues. |
+| Accepted data loss | All persisted session evidence, including Activity and evaluator/audit records, may be incomplete. Transcript state, coaching history, route state, and enabled overlay delivery may not be lost under this policy. |
+| Human workflow | The Activity window shows the high-level session story. Detailed debugging is performed by pointing an agent at the owner-only session folder. |
+| Queue policy | Session evidence uses one mailbox bounded by event count and retained bytes. It has no priority classes or reserved capacity. Critical queues declare their own policy and may intentionally be no-drop. |
+| Lifecycle | One Start owns one session directory and one evidence handle. Stop seals that handle asynchronously. A new Start is independent of older optional work. Quit never waits for evidence. |
+| Privacy | The stack does not archive raw microphone audio or a separate live transcript. Human presentation cannot expose raw diagnostic detail. Existing owner-only session storage rules remain. |
+
+The single evidence queue is deliberate. Activity and audit records do not receive guaranteed
+capacity ahead of diagnostics because the owner approved one uniform best-effort loss contract. If
+that product contract changes, queue priority or separate failure domains require a new scope review;
+they are not speculative safeguards in this design.
+
+## Destination Architecture
+
+Solid arrows belong to the control and product-critical lanes. Dashed arrows are optional evidence
+or offline flow with no return edge into coaching. The highlighted nodes are the Phase 1
+implementation focus.
+
+```mermaid
+flowchart TB
+  subgraph CONTROL["Control plane"]
+    PREF["Preferences + secrets"] --> PLAN["Immutable plan revision<br/>frozen for one attempt"]
+    PLAN --> COMPOSE["Readiness + composition"]
+    COMPOSE --> RUNTIME["Session runtime ownership<br/>Start · Stop · teardown"]
+  end
+
+  subgraph CORE["Product-critical coaching kernel"]
+    CAPTURE["Capture + transcription ports"] --> TRANSCRIPT["Finalized transcript admission"]
+    TRANSCRIPT --> SCHEDULER["Attempt scheduler +<br/>forward-only route state"]
+    SCHEDULER --> ATTEMPT["Attempt runner +<br/>history commit"]
+    ATTEMPT --> BRAIN["BrainClient port"]
+    ATTEMPT --> SCREEN["ScreenSnapshot port"]
+    ATTEMPT --> OUTPUT["Enabled overlay output port"]
+    HEARTBEAT["Capture heartbeat<br/>content-free frame progress"] --> HEALTH["Capture health policy"]
+    HEALTH --> SCHEDULER
+  end
+
+  PLAN --> SCHEDULER
+  RUNTIME --> CAPTURE
+
+  subgraph EVIDENCE["One SessionEvidence stack"]
+    ADMIT["SessionEvent admission<br/>count + byte bounded"] -.-> WORKER["One worker · session handle<br/>lifecycle · completeness record"]
+    WORKER -.-> ACTIVITY["Activity window<br/>high-level projection · Phase 2"]
+    WORKER -.-> FOLDER["Owner-only session folder<br/>detailed agent/evaluator evidence"]
+  end
+
+  TRANSCRIPT -. "typed event" .-> ADMIT
+  SCHEDULER -. "typed event" .-> ADMIT
+  ATTEMPT -. "typed event" .-> ADMIT
+  HEARTBEAT -. "optional evidence copy" .-> ADMIT
+
+  subgraph OFFLINE["Sealed-session and maintenance work"]
+    FOLDER -.-> EVALUATION["Evaluation parser + metrics"]
+    EVALUATION -.-> CONSUMERS["EvalPrep + Activity Evaluate"]
+    MAINTENANCE["Preemptible compaction<br/>and session pruning"]
+  end
+
+  classDef current fill:#fff0c2,stroke:#b76e00,stroke-width:3px,color:#24211d;
+  class ADMIT,WORKER current;
+```
+
+The graph is a dependency rule, not a package diagram. A new SwiftPM target is justified only by a
+compiler-enforced boundary, an isolated test boundary, or a second executable consumer. File count
+and line count alone do not justify extraction.
+
+## One Event, Two Projections
+
+`SessionEvent` is the one versioned envelope for an occurrence. It carries a stable kind, session and
+attempt attribution where applicable, occurrence/record timing, typed detail, and an optional
+human-safe Activity presentation. The persisted layout may keep multiple files and attachments; file
+partitioning is a projection detail, not a reason for another admission stack.
+
+Producer code may retain narrow typed protocol views, such as the existing brain-traffic and
+coaching-attempt observer ports. Those views converge on the same session handle; they are not
+separate queues, workers, health records, or lifecycles. One shared stack also does not grant every
+producer a generic path to author human-facing copy.
+
+“Activity event” and “diagnostic event” describe projections, not transports:
+
+| Event shape | Activity window | Session folder |
+|---|---|---|
+| Finalized utterance, manual hint, brain action, or fixed lifecycle/degradation notice | Friendly high-level row from the event's Activity presentation | Full typed event and attribution |
+| Provider timing, transport error, retry scheduling, lifecycle detail, or raw error | Nothing; the event has no Activity presentation | Full typed diagnostic detail |
+| Route advance or failed coaching attempt | Fixed, non-sensitive Activity summary | Same event's provider, attempt, timing, and failure detail |
+| Capture heartbeat or continuity anomaly | No raw counter stream; readiness remains current UI state | Optional content-free evidence copy |
+
+One occurrence produces one event. Producers do not mirror it through an `ActivityEventSink`, a
+`DiagnosticSink`, a session-audit queue, and a continuity-telemetry queue. The closed set of Activity
+presentations preserves the existing rule that transport, retry, timing, lifecycle, and raw-error
+details never leak into the human view or model transcript.
+
+After consolidation, “session audit” means the evaluator-relevant event categories and persisted
+projection. It is not a second worker or lifecycle. “Continuity telemetry” likewise becomes typed
+detail within `SessionEvidence`, except for the critical heartbeat decision described below.
+
+## Capture Heartbeat
+
+Capture heartbeat is content-free audio-frame progress from the existing authoritative
+`AudioContinuityWitness`. It is not a timer ping, network liveness probe, audio recording, or second
+counter.
+
+The same source observation has two one-way consumers:
+
+1. The critical in-memory branch feeds `CaptureReadinessMonitor`. Missing first frames or a sustained
+   missing heartbeat can keep readiness pending, degrade system audio to microphone-only, or stop an
+   unusable microphone session.
+2. An optional copy may enter `SessionEvidence` so an agent can diagnose what happened later.
+
+The critical branch never reads the evidence queue or persisted files. Losing the optional copy may
+make evidence partial, but it cannot change the readiness, degrade, or stop decision. This is why
+capture heartbeat remains outside `SessionEvidence` as policy input even though its diagnostic copy
+shares the evidence stack.
+
+## Fresh-Attempt Recovery and Routing
+
+“Routing and retries” means the existing fresh-attempt recovery contract:
+
+1. A coaching attempt snapshots exactly one user-authorized provider/model target.
+2. That target owns the complete attempt, including any `capture_screen` continuation. Jarvis never
+   replays a failed brain request or switches providers inside the attempt.
+3. Failure ends the attempt without committing a partial outcome. The conversation remains pending,
+   and a new attempt can include newer finalized speech.
+4. A temporary or unknown failure exhausts the active target after three failed attempts. A proven
+   permanent provider-boundary failure may exhaust it immediately.
+5. Only a later fresh attempt advances to the next configured target. The route moves forward, never
+   revisits an exhausted target, never races providers, and never rewrites saved preferences.
+
+This roadmap does not add evidence-write retries, provider probes, cooldown recovery, or same-attempt
+failover. Transcription transport reconnect remains its separate adapter-level recovery contract.
+
+## A New Session After Stop → Start
+
+The earlier phrase “replacement session” means a new Jarvis session after the user performs Stop and
+then Start. It does not mean provider failover, a replacement brain inside an attempt, or a
+replacement transcription socket.
+
+Session A may still be completing its bounded evidence close after Stop. Session B starts with an
+independent directory, evidence handle, runtime objects, and route cursor and does not wait for A.
+Every persisted event carries its originating session handle so late work from A cannot be attributed
+to B. Unaccepted or unfinished evidence from A may be lost and its completeness state remains honest.
+
+## Phased Roadmap
+
+Each phase leaves Jarvis working end to end. The destination is approved, but each later implementation
+slice still freezes its own behavior, failure, degradation, non-goals, and verification contract before
+editing.
+
+| Phase | State | Outcome | Explicit boundary |
+|---|---|---|---|
+| 0 — Audit baseline | **Built** in [#146](https://github.com/JINGBANZ/jarvis/issues/146) / [PR #149](https://github.com/JINGBANZ/jarvis/pull/149) | One process-level count/byte-bounded audit worker, per-session handle, monotonic health, and independent Stop/Start lifecycle | Evaluator audit only; Activity and `jlog` remain separate today |
+| 1 — Evidence foundation | **Next slice** | Generalize the settled audit transport into `SessionEvidence` and route diagnostics through it without another worker | Activity remains on its existing path until Phase 2 |
+| 2 — Activity projection | Approved destination | Render and persist Activity through `SessionEvent`, show incomplete evidence in the Activity window, and remove Activity's independent persistence path | Human copy remains a closed safe projection; no debug detail enters Activity |
+| 3 — Offline work | Approved destination | Give evaluation a shared compiler boundary when justified by the app and `EvalPrep`; make history compaction preemptible and move pruning off Start | Failure keeps full history and surviving session evidence |
+| 4 — Plans and adapters | Approved destination | Use immutable plan revisions at explicit between-attempt boundaries and move provider, process, screen, and file adapters outward | Live setting changes and fresh-attempt routing semantics remain intact |
+| 5 — Decomposition | Approved destination | Split the `CoachDriver` facade and `AppDelegate` only after ports and state ownership settle | Structure changes; observable coaching and lifecycle behavior do not |
+
+## Phase 1 Implementation Contract
+
+Phase 1 is the diagnostics-only slice. It expands the proven Phase 0 mechanism; it does not create a
+new `DiagnosticSink` service beside it.
+
+### Expected behavior
+
+- Existing coaching, routing, capture, overlay, Activity, session-folder, and evaluator behavior stays
+  unchanged.
+- The Phase 0 audit event schemas and provenance continue to be available to the evaluator.
+- Agent-facing diagnostics use the shared bounded worker. Formatting, Console emission, file opening,
+  seeking, serialization, and writing no longer run synchronously on the live coaching path.
+- A persisted diagnostic is attributed through its immutable session handle. Unbound diagnostics may
+  go to an asynchronous process log or be omitted, but they must never be guessed into the newest
+  session.
+- Existing artifact filenames may remain during the migration. Renaming or combining files is not a
+  completion requirement.
+
+### Failure and accepted degradation
+
+- Enabled, disabled, full, blocked, and failing evidence paths produce the same provider calls, route
+  transitions, coaching terminal outcomes, and overlay output events.
+- Admission is nonthrowing and does not wait for the worker. The retained mailbox stays within both
+  its count and byte limits.
+- Capacity, oversize, formatting, Console, open, serialization, write, late-event, or unfinished-close
+  loss marks the affected session evidence partial when possible. Later events still receive an
+  independent admission attempt.
+- No evidence kind receives priority in Phase 1. A blocked diagnostics-heavy session may lose audit
+  records too; that is the approved degradation.
+- Stop seals old evidence asynchronously. A new Start and Application Quit never wait for it.
+
+### Non-goals
+
+- Moving Activity onto `SessionEvidence`; that is Phase 2.
+- Changing brain routing, failure budgets, attempt boundaries, transcription reconnects, capture
+  readiness, heartbeat consequences, history semantics, or overlay queue policy.
+- Extracting SwiftPM targets, moving provider adapters, preempting compaction, moving pruning, or
+  decomposing `CoachDriver` / `AppDelegate`.
+- Adding evidence priority, reserved capacity, writer retries, backpressure, raw-audio retention, a
+  live-transcript archive, settings, or compatibility migrations.
+
+### Completion criteria
+
+- There is one shared evidence mailbox, worker, per-session handle, close lifecycle, and completeness
+  contract for audit and diagnostics; there is no dedicated diagnostic worker.
+- No diagnostic persistence or Console operation executes synchronously from the live coaching path.
+- Tests use deterministic blocked, full, oversize, failing, and session-rotation fakes rather than
+  wall-clock latency assertions.
+- An architecture check prevents the critical kernel from importing or directly invoking concrete
+  evidence persistence.
+- The repository Gate passes: `swift build && ./scripts/run-tests.sh`.
+- Live microphone or network-interruption validation is not required for this diagnostics-only slice;
+  do not run it without explicit owner consent.
+
+## Source Handoff
+
+The implementation agent should begin with these current boundaries:
+
+- Phase 0 transport:
+  [`FileSessionAudit.swift`](../Sources/JarvisCore/Diagnostics/FileSessionAudit.swift),
+  [`SessionAuditWorker.swift`](../Sources/JarvisCore/Diagnostics/SessionAuditWorker.swift), and
+  [`SessionAuditFileWriter.swift`](../Sources/JarvisCore/Diagnostics/SessionAuditFileWriter.swift).
+- Current synchronous diagnostics:
+  [`Log.swift`](../Sources/JarvisCore/Diagnostics/Log.swift).
+- Current Activity stack:
+  [`ActivityLog.swift`](../Sources/JarvisCore/Diagnostics/ActivityLog.swift) and
+  [`ActivityViewer.swift`](../Sources/JarvisApp/Viewer/ActivityViewer.swift).
+- Current sealed-session analysis:
+  [`SessionEvidenceIndex.swift`](../Sources/JarvisCore/Diagnostics/SessionEvidenceIndex.swift) is the
+  evaluator's descriptive index over persisted files. It is an offline consumer, not the future live
+  `SessionEvidence` admission stack.
+- Capture-heartbeat source and critical policy:
+  [`AudioContinuityWitness.swift`](../Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift),
+  [`RealtimeContinuityReporter.swift`](../Sources/JarvisApp/Capture/RealtimeContinuityReporter.swift),
+  and [`CaptureReadinessMonitor.swift`](../Sources/JarvisCore/Diagnostics/CaptureReadinessMonitor.swift).
+- Composition and attempt boundaries:
+  [`AppDelegate.swift`](../Sources/JarvisApp/App/AppDelegate.swift) and
+  [`CoachDriver.swift`](../Sources/JarvisCore/Coach/CoachDriver.swift).
+
+The first question during review remains: **Can this dependency change or delay a coaching outcome?**
+If not, the critical kernel may emit a typed observation, but it may neither await nor depend on the
+concrete evidence implementation.

--- a/wiki/session-audit.md
+++ b/wiki/session-audit.md
@@ -1,7 +1,10 @@
 # Session Audit
 
-> A diagnostics component that records coaching-attempt provenance and provider traffic without
-> making persistence part of coaching behavior or latency.
+> The built Phase 0 foundation for the approved
+> [lean coaching core](./lean-coaching-core.md): a diagnostics component that records
+> coaching-attempt provenance and provider traffic without making persistence part of coaching
+> behavior or latency. Activity and `jlog` still use separate paths in the current implementation;
+> Phases 1 and 2 consolidate them onto this transport without creating parallel workers.
 
 ## Why It Exists
 
@@ -43,7 +46,7 @@ unavailable. Historical sessions without versioned audit evidence keep their leg
 ## Lifecycle
 
 One Start creates one audit and one owner-only session directory. Regular Stop cancels that session's
-producer tasks, waits for them in a background task, then closes the old audit. A replacement Start
+producer tasks, waits for them in a background task, then closes the old audit. A new Start after Stop
 uses a new directory immediately; it does not wait for the old audit. Activity protects and does not
 evaluate only the session that is still closing.
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -106,8 +106,8 @@ ephemerality and a message/reasoning event allowlist that aborts a turn on any o
 Saving an API key while running also preserves those live objects: existing Realtime sockets take
 the key on their next reconnect, and an OpenAI brain update remains transactional. Audio
 route rebuilds likewise retry before declaring capture unavailable, and stale capture callbacks
-cannot stop a replacement session; repeated route notifications cannot reset one incident's bounded
-budget. Activity persists stable event kinds and flushes at Stop. The sole evaluator is agentic: it
+cannot stop a new session after Stop → Start; repeated route notifications cannot reset one
+incident's bounded budget. Activity persists stable event kinds and flushes at Stop. The sole evaluator is agentic: it
 receives the complete session directory and reads the full, unfiltered `jarvis-activity.jsonl`
 whenever it needs the user-visible sequence, alongside first-class coaching-attempt provenance, raw
 brain traffic, screenshots, and live source code. A neutral evidence index reports artifact health,
@@ -153,7 +153,20 @@ existing Git/PR history is intentionally preserved after the full-history secret
 credential leak; current-tree machine-specific instructions were generalized instead of rewriting
 repository identity and provenance.
 
+The [lean coaching core architecture](./lean-coaching-core.md) is approved for issue #147. Its
+Phase 0 audit foundation is built; the unified `SessionEvidence` stack, diagnostic migration,
+Activity projection, offline-maintenance changes, adapter direction, and coordinator decomposition
+are not yet implemented. The approved next slice is diagnostics-only and preserves the current
+coaching, routing, Activity, evaluator, and artifact behavior.
+
 ## Next action
+
+For issue #147, implement **Phase 1 — Evidence foundation** from
+[lean-coaching-core.md](./lean-coaching-core.md#phase-1-implementation-contract): generalize the
+settled session-audit transport into one `SessionEvidence` stack and move synchronous `jlog`
+Console/file work behind that same bounded worker. Do not add a dedicated diagnostic worker or move
+Activity yet. All persisted evidence is best effort and may be visibly partial; coaching always
+continues. Preserve the current forward-only fresh-attempt route and capture-heartbeat behavior.
 
 Re-enable the four agent workflows. Their hosted definitions and existing source-level gates are
 ready on `main`; they were disabled during rollout so the old base-branch copies could not target the
@@ -244,5 +257,9 @@ thin OS shell, verified by the smoke run.
 
 ## Not yet built
 
+- **Lean coaching core Phases 1–5** — the approved destination and slice contracts are in
+  [lean-coaching-core.md](./lean-coaching-core.md). Phase 0 audit isolation is built; unified
+  diagnostics, the Activity projection, offline maintenance, plan/adapter direction, and final
+  coordinator decomposition remain future work.
 - **Universal binary** — `Sources/CJarvisAEC/lib/libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 slice if Intel is ever needed.
 - **Neural double-talk canceller** (DTLN / Muesli-style on the same aligned streams) — the escalation if AEC3 over-attenuates the user under loud far audio in practice.


### PR DESCRIPTION
## Summary

- add the canonical lean-coaching-core wiki architecture and Mermaid graph for issue #147
- replace the issue body's proposed parallel Activity/audit/diagnostic/continuity stacks with one owner-approved `SessionEvidence` stack and two projections: the Activity window for people and the owner-only session folder for agents/evaluation
- define the uniform best-effort/visibly-partial evidence contract, explicit critical/evidence queue policies, and the separate critical capture-heartbeat branch
- preserve and explain fresh-attempt routing, forward-only target exhaustion, and a new session after Stop → Start
- record the Phase 0–5 roadmap and a complete Phase 1 diagnostics-only handoff contract
- update the wiki index, current status, architecture cross-links, Phase 0 session-audit page, and decision log

## Scope

This PR is documentation only. It deliberately does not implement Phase 1 or change runtime behavior.

The wiki explicitly supersedes the issue body's earlier independent-sink design. Phase 0 (PR #149) is built; Phase 1 generalizes that transport and moves synchronous `jlog` work behind the same bounded worker. Activity remains separate until Phase 2.

The approved degradation is uniform: any persisted session evidence may be partial and must be marked honestly; coaching always continues. No evidence priority, reserved capacity, backpressure, writer retries, routing changes, capture changes, target extraction, or coordinator decomposition are included.

The handoff also distinguishes the newly landed offline `SessionEvidenceIndex` from the future live `SessionEvidence` admission stack.

## Validation

- `swift build && ./scripts/run-tests.sh`
- build and all static guards passed
- 754 tests in 89 suites passed
- opt-in live capture test skipped as expected
- relative wiki file links resolve
- `git diff --check origin/main...HEAD`

Related to #147.