### PR TITLE
feat(release): distribute jarvis as a dmg

### DIFF
--- a/.github/release-header.md
+++ b/.github/release-header.md
@@ -3,9 +3,12 @@
 
 **Requires an Apple silicon Mac running macOS 14.2 or later.**
 
-1. Under **Assets**, download `Jarvis-<version>.zip` and double-click it to extract the app.
-2. Move `Jarvis.app` to **Applications**, then open it from there. Jarvis appears in the menu bar.
-3. Grant the permissions its selected features need, then configure transcription and brain providers
+[**Download Jarvis for Apple silicon (macOS 14.2+)**](@JARVIS_DOWNLOAD_URL@)
+
+1. Open `Jarvis.dmg`.
+2. In the Finder window, drag `Jarvis.app` onto the **Applications** shortcut.
+3. Eject the Jarvis disk image, then open Jarvis from **Applications**. It appears in the menu bar.
+4. Grant the permissions its selected features need, then configure transcription and brain providers
    in **Settings**.
 
 Jarvis is signed with Developer ID and notarized by Apple. Before using it in a meeting, review the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  # Build, sign, notarize, and attach Jarvis-<version>.zip to the Release just created. Gate
+  # Build, sign, notarize, and attach Jarvis.dmg to the Release just created. Gate
   # (tests) and publish share one job — macOS minutes bill at 10x, and re-running the Swift build
   # in a second job would double the cost for no extra safety: any failing step here still aborts
   # before the upload. This deliberately lives in the same workflow rather than a tag-triggered
@@ -113,12 +113,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
         run: |
-          archives=(Jarvis-*.zip)
-          if [[ ${#archives[@]} -ne 1 || ! -f "${archives[0]}" ]]; then
-            echo "error: expected exactly one Jarvis release archive" >&2
+          ASSET="Jarvis.dmg"
+          ASSET_LABEL="Jarvis for Apple silicon (macOS 14.2+)"
+          if [[ ! -f "$ASSET" || -L "$ASSET" ]]; then
+            echo "error: expected one regular $ASSET release artifact" >&2
             exit 1
           fi
-          shasum -a 256 "${archives[0]}" > SHA256SUMS
 
           CURRENT_NOTES="$RUNNER_TEMP/current-release-notes.md"
           RELEASE_NOTES="$RUNNER_TEMP/release-notes.md"
@@ -126,7 +126,11 @@ jobs:
           if grep -Fq '<!-- jarvis-release-install -->' "$CURRENT_NOTES"; then
             cp "$CURRENT_NOTES" "$RELEASE_NOTES"
           else
-            cat .github/release-header.md "$CURRENT_NOTES" > "$RELEASE_NOTES"
+            INSTALL_HEADER="$RUNNER_TEMP/release-header.md"
+            DOWNLOAD_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/download/${TAG}/${ASSET}"
+            sed "s|@JARVIS_DOWNLOAD_URL@|$DOWNLOAD_URL|g" \
+              .github/release-header.md > "$INSTALL_HEADER"
+            cat "$INSTALL_HEADER" "$CURRENT_NOTES" > "$RELEASE_NOTES"
           fi
 
           ASSET_NAMES="$RUNNER_TEMP/existing-release-assets.txt"
@@ -138,22 +142,28 @@ jobs:
             exit 1
           fi
           gh release view "$TAG" --json assets --jq '.assets[].name' > "$ASSET_NAMES"
+          UNEXPECTED_ASSETS="$(awk -v expected="$ASSET" '$0 != expected { print }' "$ASSET_NAMES")"
+          if [[ -n "$UNEXPECTED_ASSETS" ]]; then
+            echo "error: refusing to publish with unexpected app assets:" >&2
+            printf '%s\n' "$UNEXPECTED_ASSETS" >&2
+            exit 1
+          fi
           # A retry may encounter either a partial draft or a public Release whose publish response
           # was lost. Draft assets are safe to replace; public assets must never be deleted here.
-          for asset in "${archives[0]}" SHA256SUMS; do
+          for asset in "$ASSET"; do
             if grep -Fxq "$asset" "$ASSET_NAMES"; then
               gh release download "$TAG" --pattern "$asset" --dir "$ASSET_DIR"
               if cmp -s "$asset" "$ASSET_DIR/$asset"; then
                 echo "existing release asset is identical: $asset"
               elif [[ "$RELEASE_IS_DRAFT" == "true" ]]; then
                 echo "replacing different draft release asset: $asset"
-                gh release upload "$TAG" "$asset" --clobber
+                gh release upload "$TAG" "$asset#$ASSET_LABEL" --clobber
               else
                 echo "error: release already has a different $asset; preserving it" >&2
                 exit 1
               fi
             else
-              gh release upload "$TAG" "$asset"
+              gh release upload "$TAG" "$asset#$ASSET_LABEL"
             fi
           done
           gh release edit "$TAG" --notes-file "$RELEASE_NOTES" --draft=false --latest

--- a/README.md
+++ b/README.md
@@ -20,14 +20,11 @@ session for an immediate, screen-aware hint.
 
 [**Download Jarvis for Apple silicon (macOS 14.2+)**](https://github.com/JINGBANZ/jarvis/releases/latest/download/Jarvis.dmg)
 
-1. Open `Jarvis.dmg`.
-2. In the Finder window, drag `Jarvis.app` onto the **Applications** shortcut.
-3. Eject the Jarvis disk image, then open Jarvis from **Applications**. Jarvis appears in the menu
-   bar rather than the Dock.
-4. Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts.
-5. From the menu-bar icon, open **Settings**, choose transcription and brain providers, add any
-   credential those providers require, then select **Start Jarvis**. Allow System Audio Recording
-   when Start requests it so Jarvis can hear the other side.
+After installing, open Jarvis from **Applications**. It appears in the menu bar rather than the Dock.
+Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts. From the
+menu-bar icon, open **Settings**, choose transcription and brain providers, add any credential those
+providers require, then select **Start Jarvis**. Allow System Audio Recording when Start requests it
+so Jarvis can hear the other side.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ session for an immediate, screen-aware hint.
 
 **Requirements:** an Apple silicon Mac running macOS 14.2 or later. No developer tools are needed.
 
-[**Download the latest signed and notarized release**](https://github.com/JINGBANZ/jarvis/releases/latest)
+[**Download Jarvis for Apple silicon (macOS 14.2+)**](https://github.com/JINGBANZ/jarvis/releases/latest/download/Jarvis.dmg)
 
-1. Under **Assets**, download `Jarvis-<version>.zip` and double-click it to extract the app.
-2. Move `Jarvis.app` to **Applications**, then open it. Jarvis appears in the menu bar rather than
-   the Dock.
-3. Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts.
-4. From the menu-bar icon, open **Settings**, choose transcription and brain providers, add any
+1. Open `Jarvis.dmg`.
+2. In the Finder window, drag `Jarvis.app` onto the **Applications** shortcut.
+3. Eject the Jarvis disk image, then open Jarvis from **Applications**. Jarvis appears in the menu
+   bar rather than the Dock.
+4. Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts.
+5. From the menu-bar icon, open **Settings**, choose transcription and brain providers, add any
    credential those providers require, then select **Start Jarvis**. Allow System Audio Recording
    when Start requests it so Jarvis can hear the other side.
 

--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 workflow=".github/workflows/release.yml"
+release_header=".github/release-header.md"
 package_script="scripts/package-app.sh"
 verify_script="scripts/verify-release.sh"
 sdk_guard="scripts/check-release-sdk.sh"
 package_guard_call="./scripts/check-release-sdk.sh \"\$BIN_PATH\""
 verify_guard_call="./scripts/check-release-sdk.sh \"\$EXTRACTED_BIN\""
 
-for path in "$workflow" "$package_script" "$verify_script" "$sdk_guard"; do
+for path in "$workflow" "$release_header" "$package_script" "$verify_script" "$sdk_guard"; do
   if [[ ! -f "$path" || -L "$path" ]]; then
     echo "Release configuration guard: $path must be a regular file." >&2
     exit 1
@@ -30,6 +31,45 @@ if ! /usr/bin/grep -Fq "$verify_guard_call" "$verify_script"; then
 fi
 if ! /usr/bin/grep -Fq 'readonly MINIMUM_SDK_MAJOR=26' "$sdk_guard"; then
   echo "Release SDK guard must require macOS SDK 26 or newer." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'DMG="Jarvis.dmg"' "$package_script" \
+    || ! /usr/bin/grep -Fq 'DMG_IDENTIFIER="com.jarvis.coach.dmg"' "$package_script" \
+    || ! /usr/bin/grep -Fq 'codesign --force --timestamp --identifier "$DMG_IDENTIFIER" --sign "$IDENTITY" "$DMG"' \
+      "$package_script" \
+    || ! /usr/bin/grep -Fq 'ln -s /Applications "$DMG_STAGE/Applications"' "$package_script"; then
+  echo "Release packaging must create an identified Jarvis.dmg with an Applications shortcut." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'xcrun notarytool submit "$DMG"' "$package_script" \
+    || ! /usr/bin/grep -Fq 'xcrun stapler staple "$DMG"' "$package_script"; then
+  echo "Release packaging must notarize and staple the final disk image." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$MOUNT_POINT"' \
+      "$verify_script" \
+    || ! /usr/bin/grep -Fq '"$(readlink "$APPLICATIONS_LINK")" != "/Applications"' \
+      "$verify_script" \
+    || ! /usr/bin/grep -Fq 'syspolicy_check distribution "$EXTRACTED_APP" --verbose' \
+      "$verify_script"; then
+  echo "Final release verification must inspect the mounted layout and modern system policy." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'ASSET="Jarvis.dmg"' "$workflow" \
+    || ! /usr/bin/grep -Fq 'UNEXPECTED_ASSETS="$(awk -v expected="$ASSET"' \
+      "$workflow" \
+    || ! /usr/bin/grep -Fq 'for asset in "$ASSET"; do' "$workflow"; then
+  echo "Release publication must upload only the stable Jarvis.dmg app artifact." >&2
+  exit 1
+fi
+if /usr/bin/grep -Fq 'SHA256SUMS' "$workflow" \
+    || /usr/bin/grep -Fq 'Jarvis-*.zip' "$workflow"; then
+  echo "Release publication must not add legacy zip or checksum assets." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq '@JARVIS_DOWNLOAD_URL@' "$release_header" \
+    || ! /usr/bin/grep -Fq 'drag `Jarvis.app` onto the **Applications** shortcut' "$release_header"; then
+  echo "Release install notes must link directly to the disk image and explain the drag install." >&2
   exit 1
 fi
 

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Package Jarvis.app for distribution: Developer ID signing + notarization + stapling.
-# Produces Jarvis-<version>.zip, which opens on any Apple silicon Mac (macOS 14.2+) with no
-# Gatekeeper friction. Driven locally or by CI (.github/workflows/release.yml).
+# Produces Jarvis.dmg, which presents the app beside an Applications shortcut on any Apple silicon
+# Mac (macOS 14.2+) with no Gatekeeper friction. Driven locally or by CI
+# (.github/workflows/release.yml).
 #
 # Deliberately self-contained rather than layered on build-app.sh: the dev script's self-signed
 # "Jarvis Dev" identity exists only so local TCC grants persist, and creating it can prompt for
@@ -64,14 +65,59 @@ codesign --force --options runtime --timestamp \
   --sign "$IDENTITY" "$APP"
 codesign --verify --strict --verbose=2 "$APP"
 
-VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$APP/Contents/Info.plist")"
-ZIP="Jarvis-$VERSION.zip"
+DMG="Jarvis.dmg"
+DMG_IDENTIFIER="com.jarvis.coach.dmg"
+DMG_ROOT="$PWD/.build"
+if [[ -L "$DMG_ROOT" ]]; then
+  echo "error: disk-image staging root must not be a symbolic link" >&2
+  exit 1
+fi
+mkdir -p "$DMG_ROOT"
+DMG_STAGE_PREFIX="$DMG_ROOT/jarvis-dmg-stage."
+DMG_STAGE="$(mktemp -d "${DMG_STAGE_PREFIX}XXXXXX")"
+if [[ -z "$DMG_STAGE" || "$DMG_STAGE" != "$DMG_STAGE_PREFIX"* \
+      || ! -d "$DMG_STAGE" || -L "$DMG_STAGE" ]]; then
+  echo "error: couldn't create a safe disk-image staging directory" >&2
+  exit 1
+fi
+cleanup_dmg_stage() {
+  local exit_code=$?
+  local cleanup_safe=true
+  trap - EXIT
+  if [[ -n "${DMG_STAGE:-}" && -n "${DMG_STAGE_PREFIX:-}" \
+        && "$DMG_STAGE" == "$DMG_STAGE_PREFIX"* && -d "$DMG_STAGE" \
+        && ! -L "$DMG_STAGE" ]]; then
+    if [[ -L "$DMG_STAGE/Applications" \
+          && "$(readlink "$DMG_STAGE/Applications")" == "/Applications" ]]; then
+      unlink "$DMG_STAGE/Applications"
+    elif [[ -e "$DMG_STAGE/Applications" || -L "$DMG_STAGE/Applications" ]]; then
+      echo "error: refusing to clean an unexpected Applications staging entry" >&2
+      exit_code=1
+      cleanup_safe=false
+    fi
+    if find "$DMG_STAGE" -type l -print -quit | grep -q .; then
+      echo "error: refusing to clean disk-image staging with an unexpected symbolic link" >&2
+      exit_code=1
+      cleanup_safe=false
+    elif [[ "$cleanup_safe" == "true" ]]; then
+      rm -rf -- "$DMG_STAGE"
+    fi
+  fi
+  exit "$exit_code"
+}
+trap cleanup_dmg_stage EXIT
 
-# ditto (not zip/Finder) preserves the extended attributes the signature lives alongside.
+echo "▶ creating drag-install disk image"
+ditto "$APP" "$DMG_STAGE/$APP"
+ln -s /Applications "$DMG_STAGE/Applications"
+rm -f "$DMG"
+hdiutil create -volname Jarvis -srcfolder "$DMG_STAGE" -fs HFS+ -format UDZO -ov "$DMG"
+codesign --force --timestamp --identifier "$DMG_IDENTIFIER" --sign "$IDENTITY" "$DMG"
+codesign --verify --strict --verbose=2 "$DMG"
+
+# Submit the outermost container so Apple's ticket covers the exact disk image users download.
 echo "▶ submitting to Apple's notary service (usually 1-5 min)"
-rm -f "$ZIP"
-ditto -c -k --keepParent "$APP" "$ZIP"
-submit_json="$(xcrun notarytool submit "$ZIP" "${notary[@]}" --wait --timeout 30m --output-format json)" || true
+submit_json="$(xcrun notarytool submit "$DMG" "${notary[@]}" --wait --timeout 30m --output-format json)" || true
 echo "$submit_json"
 status="$(plutil -extract status raw -o - - <<<"$submit_json" 2>/dev/null || true)"
 if [[ "$status" != "Accepted" ]]; then
@@ -82,18 +128,15 @@ if [[ "$status" != "Accepted" ]]; then
   exit 1
 fi
 
-# Staple the ticket to the .app so Gatekeeper trusts it offline, then RE-zip: a zip itself cannot
-# be stapled, so the shipped archive must be rebuilt from the stapled bundle.
+# A disk image can carry its ticket, so the exact notarized file remains the final artifact.
 echo "▶ stapling"
-xcrun stapler staple "$APP"
-rm -f "$ZIP"
-ditto -c -k --keepParent "$APP" "$ZIP"
+xcrun stapler staple "$DMG"
 
-# Verify the exact archive users receive, not only the pre-compression bundle. A packaging mistake
+# Verify the exact disk image users receive, not only the pre-container bundle. A packaging mistake
 # must leave the draft Release unpublished even if signing and notarization already succeeded.
-verify_args=("$ZIP")
+verify_args=("$DMG")
 if [[ -n "${EXPECTED_RELEASE_TAG:-}" ]]; then
   verify_args+=("$EXPECTED_RELEASE_TAG")
 fi
 ./scripts/verify-release.sh "${verify_args[@]}"
-echo "✅ $ZIP is notarized and ready to distribute (Apple silicon, macOS 14.2+)"
+echo "✅ $DMG is notarized and ready to distribute (Apple silicon, macOS 14.2+)"

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
-# Verify the exact Jarvis release archive users download after it has been signed and notarized.
+# Verify the exact Jarvis disk image users download after it has been signed and notarized.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-ZIP="${1:-}"
+DMG="${1:-}"
 EXPECTED_RELEASE_TAG="${2:-}"
-if [[ $# -gt 2 || -z "$ZIP" || ! -f "$ZIP" || -L "$ZIP" ]]; then
-  echo "usage: $0 Jarvis-<version>.zip [v<version>]" >&2
+if [[ $# -gt 2 || -z "$DMG" || ! -f "$DMG" || -L "$DMG" ]]; then
+  echo "usage: $0 Jarvis.dmg [v<version>]" >&2
   exit 2
 fi
-ZIP="$(cd "$(dirname "$ZIP")" && pwd)/$(basename "$ZIP")"
+DMG="$(cd "$(dirname "$DMG")" && pwd)/$(basename "$DMG")"
+if [[ "$(basename "$DMG")" != "Jarvis.dmg" ]]; then
+  echo "error: release disk image must be named Jarvis.dmg" >&2
+  exit 1
+fi
 
 APP="Jarvis.app"
 BIN_NAME="JarvisApp"
@@ -25,29 +29,51 @@ if [[ -z "$VERIFY_DIR" || "$VERIFY_DIR" != "$VERIFY_PREFIX"* || ! -d "$VERIFY_DI
   echo "error: couldn't create a safe release-verification directory" >&2
   exit 1
 fi
+MOUNT_POINT="$VERIFY_DIR/mount"
+mkdir "$MOUNT_POINT"
+MOUNTED=false
 cleanup_verify_dir() {
-  if [[ -n "${VERIFY_DIR:-}" && -n "${VERIFY_PREFIX:-}" \
-        && "$VERIFY_DIR" == "$VERIFY_PREFIX"* && -d "$VERIFY_DIR" && ! -L "$VERIFY_DIR" ]]; then
+  local status=$?
+  trap - EXIT
+  if [[ "${MOUNTED:-false}" == "true" ]]; then
+    if hdiutil detach "$MOUNT_POINT"; then
+      MOUNTED=false
+    else
+      echo "error: couldn't detach release-verification disk image; leaving it mounted" >&2
+      status=1
+    fi
+  fi
+  if [[ "${MOUNTED:-false}" == "false" && -n "${VERIFY_DIR:-}" \
+        && -n "${VERIFY_PREFIX:-}" && "$VERIFY_DIR" == "$VERIFY_PREFIX"* \
+        && -d "$VERIFY_DIR" && ! -L "$VERIFY_DIR" ]]; then
     rm -rf -- "$VERIFY_DIR"
   fi
+  exit "$status"
 }
 trap cleanup_verify_dir EXIT
 
-echo "▶ verifying final archive: $(basename "$ZIP")"
-ditto -x -k "$ZIP" "$VERIFY_DIR"
-EXTRACTED_APP="$VERIFY_DIR/$APP"
-ENTRY_COUNT="$(find "$VERIFY_DIR" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')"
-if [[ "$ENTRY_COUNT" != "1" || ! -d "$EXTRACTED_APP" || -L "$EXTRACTED_APP" ]]; then
-  echo "error: final archive must contain exactly one regular $APP bundle" >&2
+echo "▶ verifying final disk image: $(basename "$DMG")"
+hdiutil verify "$DMG"
+codesign --verify --strict --verbose=2 "$DMG"
+xcrun stapler validate "$DMG"
+spctl --assess --type open --context context:primary-signature --verbose "$DMG"
+hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$MOUNT_POINT"
+MOUNTED=true
+
+EXTRACTED_APP="$MOUNT_POINT/$APP"
+APPLICATIONS_LINK="$MOUNT_POINT/Applications"
+ENTRY_COUNT="$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')"
+if [[ "$ENTRY_COUNT" != "2" || ! -d "$EXTRACTED_APP" || -L "$EXTRACTED_APP" ]]; then
+  echo "error: final disk image must contain one regular $APP bundle and one Applications shortcut" >&2
+  exit 1
+fi
+if [[ ! -L "$APPLICATIONS_LINK" || "$(readlink "$APPLICATIONS_LINK")" != "/Applications" ]]; then
+  echo "error: final disk image must contain an Applications shortcut targeting /Applications" >&2
   exit 1
 fi
 
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
   "$EXTRACTED_APP/Contents/Info.plist")"
-if [[ "$(basename "$ZIP")" != "Jarvis-$VERSION.zip" ]]; then
-  echo "error: archive filename does not match bundled version $VERSION" >&2
-  exit 1
-fi
 if [[ -n "$EXPECTED_RELEASE_TAG" && "$EXPECTED_RELEASE_TAG" != "v$VERSION" ]]; then
   echo "error: expected release tag $EXPECTED_RELEASE_TAG does not match bundled version $VERSION" >&2
   exit 1
@@ -55,18 +81,19 @@ fi
 EXTRACTED_BIN="$EXTRACTED_APP/Contents/MacOS/$BIN_NAME"
 ARCHITECTURES="$(lipo -archs "$EXTRACTED_BIN")"
 if [[ "$ARCHITECTURES" != "arm64" ]]; then
-  echo "error: archived app has unexpected architectures: $ARCHITECTURES" >&2
+  echo "error: disk-image app has unexpected architectures: $ARCHITECTURES" >&2
   exit 1
 fi
 ./scripts/check-release-sdk.sh "$EXTRACTED_BIN"
 if [[ ! -f "$EXTRACTED_APP/Contents/Resources/LICENSE" \
       || ! -f "$EXTRACTED_APP/Contents/Resources/THIRD_PARTY_NOTICES.md" ]]; then
-  echo "error: archived app is missing required license notices" >&2
+  echo "error: disk-image app is missing required license notices" >&2
   exit 1
 fi
 
 codesign --verify --strict --verbose=2 "$EXTRACTED_APP"
-xcrun stapler validate "$EXTRACTED_APP"
-# Final policy check, the way Gatekeeper will assess the downloaded app.
+# syspolicy_check runs the modern macOS distribution checks; keep spctl as the direct Gatekeeper
+# policy assertion already used by the release contract.
+syspolicy_check distribution "$EXTRACTED_APP" --verbose
 spctl --assess --type execute --verbose "$EXTRACTED_APP"
-echo "✅ $(basename "$ZIP") passed final release verification"
+echo "✅ $(basename "$DMG") passed final release verification"

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -62,15 +62,17 @@ that checkout-local bundle to the Trash so it cannot be launched accidentally; l
 The `Jarvis Dev` identity above is a **local-dev** device: on any other Mac it's untrusted and
 Gatekeeper blocks the app. Distributable builds go through `scripts/package-app.sh`, which builds and
 signs the bundle once with a **Developer ID Application** certificate — hardened runtime + secure
-timestamp (both notarization requirements) — submits it to Apple's notary service, staples the
-ticket, and re-zips the stapled bundle into `Jarvis-<version>.zip` (a zip itself can't be stapled,
-so the archive is rebuilt after stapling). Hardened runtime denies microphone capture outright
-without the `audio-input` entitlement, so the script signs with `Resources/Jarvis.entitlements`.
-The script then passes that final zip to `scripts/verify-release.sh`, which extracts it into a fresh
-verification directory and checks the exact shipped app's bundle shape, version, arm64 architecture,
-linked macOS 26-or-newer SDK, notices, strict code signature, stapled ticket, and Gatekeeper policy
-result. The same SDK guard runs immediately after the release build, before signing or notarization;
-the pre-compression app is not accepted as a proxy for the downloaded artifact.
+timestamp (both notarization requirements) — with the `audio-input` entitlement that hardened runtime
+requires for microphone capture. It places the signed app beside an `Applications` shortcut in
+`Jarvis.dmg`, signs and notarizes that outer disk image, then staples the ticket to the exact file
+users download.
+
+The script passes that final DMG to `scripts/verify-release.sh`, which verifies the disk image and its
+ticket, mounts it read-only, and requires exactly one regular `Jarvis.app` plus one symbolic link to
+`/Applications`. It checks the mounted app's version, arm64 architecture, linked macOS 26-or-newer
+SDK, notices, strict code signature, and Gatekeeper policy result before detaching the image. The same
+SDK guard runs immediately after the release build, before signing or notarization; the pre-container
+app is not accepted as a proxy for the downloaded artifact.
 
 Releases are cut by `.github/workflows/release.yml`, not by hand: on every push to `main`,
 **release-please** maintains a standing Release PR from the conventional-commit history (bumping both
@@ -78,10 +80,11 @@ version keys in `Resources/Info.plist` via `x-release-please-version` annotation
 CHANGELOG — config in `release-please-config.json`). Merging that PR creates the GitHub Release **as
 a draft**; an Apple-silicon `macos-26` job then runs the test gate, signs/notarizes via repo secrets
 (the base64 `.p12` certificate and an App Store Connect API key — names in the workflow), attaches
-the zip, and only then publishes the Release. The publish step also attaches `SHA256SUMS` and
-prepends the stable installation block in `.github/release-header.md` to release-please's generated
-changelog. A failed sign, notarization, or final-archive verification therefore never leaves a
-public Release without a validated app. The exact runner label and binary guard keep downloaded
+only `Jarvis.dmg`, and then publishes the Release. The stable installation block in
+`.github/release-header.md` links directly to that tag's DMG and explains the in-window drag to
+Applications; GitHub still supplies its automatic source archives. A failed sign, notarization, or
+final-image verification therefore never leaves a public Release without a validated app. The exact
+runner label and binary guard keep downloaded
 AppKit controls on the same macOS 26 design as local development builds instead of inheriting the
 compatibility appearance of an older linked SDK. The publish job lives in the same workflow because
 tags created with `GITHUB_TOKEN` never trigger other workflows.

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -456,6 +456,9 @@
 - **Superseded in part by:** 2026-08-12 — Distributed AppKit appearance is pinned to the macOS 26
   SDK. The release-please, signing, notarization, and publication flow stands; the `macos-15` runner
   does not.
+- **Superseded in part by:** 2026-08-16 — Distribution uses one drag-install DMG. The automated
+  release, signing, notarization, and draft-until-validated trust chain stands; the zip container,
+  separate checksum asset, and manual move instructions do not.
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci); `scripts/package-app.sh`, `release-please-config.json`.
 
 ### 2026-07-17 — Agentic session audit as a dev-side workflow; single-call path kept as fallback
@@ -1712,3 +1715,31 @@
   independent Stop → Start, and Quit-never-waits semantics apply to the destination evidence stack.
 - **Detail:** [lean-coaching-core.md](./lean-coaching-core.md),
   [session-audit.md](./session-audit.md).
+
+### 2026-08-16 — Distribution uses one drag-install DMG
+
+- **Chose:** Publish one stable `Jarvis.dmg` app artifact per GitHub Release. Its mounted root
+  contains exactly the signed `Jarvis.app` and an `Applications` shortcut targeting
+  `/Applications`; the release notes and README link directly to the DMG and tell the user to drag
+  the app onto that shortcut in the Finder window. The pipeline signs and notarizes the outer disk
+  image, staples it, mounts the final file read-only, and verifies both the container layout and the
+  app trust chain before publication. GitHub's automatic source archives remain outside this
+  project-controlled asset count.
+- **Why:** A single clearly labelled binary removes the choice between an app archive and a checksum
+  file, while the familiar app-to-Applications gesture keeps installation visible and owner-driven.
+  A stable filename supports one direct latest-release URL; the release tag and bundled Info.plist
+  remain the version authorities.
+- **Rejected:** (a) Keeping the zip plus `SHA256SUMS`—it leaves installation and asset selection to
+  the user, while GitHub already records the uploaded asset digest. (b) Moving the running app into
+  `/Applications` on first launch—downloaded apps can run from a translocated read-only location,
+  and an app should not silently relocate itself. (c) A signed installer package—it adds an
+  installer and elevated installation semantics that a single app bundle does not need. (d) A
+  third-party DMG-layout dependency or CI-driven Finder automation for cosmetic positioning—the
+  native two-entry image provides the required drag target without another release dependency or a
+  GUI session on the hosted runner.
+- **Supersedes in part:** 2026-07-17 — Distribution via release-please + notarized zip on GitHub
+  Releases. Its release-please flow, Developer ID identity, notarization credentials, and
+  draft-until-validated publication semantics stand.
+- **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
+  `scripts/package-app.sh`, `scripts/verify-release.sh`, `.github/workflows/release.yml`,
+  `.github/release-header.md`.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -145,8 +145,10 @@ repository's `main` branch; retained third-party Actions are SHA-pinned and Depe
 Public docs disclose the current unsandboxed boundary, contribution and private-reporting paths are
 present, and the latest GitHub Release carries a Developer ID-signed, notarized Apple silicon app.
 The release workflow builds with the macOS 26 SDK while retaining a macOS 14.2 deployment target,
-then re-extracts and checks that linked SDK in the final zip as the user receives it and attaches a
-SHA-256 checksum; the app bundle carries the Apache license plus third-party notices. Local builds
+then signs and notarizes one stable `Jarvis.dmg`, mounts that final image, and checks its two-item
+drag-install layout, Applications target, linked SDK, signature, ticket, and Gatekeeper result. The
+next release uploads that DMG as its only Jarvis-built asset and links to it directly; GitHub's
+automatic source archives remain. The app bundle carries the Apache license plus third-party notices. Local builds
 use the independent `Jarvis Dev.app` / `com.jarvis.coach.dev` identity while releases retain
 `Jarvis.app` / `com.jarvis.coach`, so their TCC grants and preferences can coexist on one Mac. The
 existing Git/PR history is intentionally preserved after the full-history secret scan found no
@@ -250,7 +252,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 + classic VAD native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
 - `scripts/build-app.sh` — the local self-signed `Jarvis Dev.app` build with an independent bundle id and TCC identity; its production plist source remains unchanged.
-- `.github/workflows/` + `scripts/package-app.sh` + `scripts/check-release-sdk.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then a macOS-26-SDK release-please Release PR → Developer ID-signed, notarized, stapled, re-extracted, SDK/Gatekeeper-checked `Jarvis-<version>.zip` with Apache and third-party notices plus `SHA256SUMS` attached to a GitHub Release ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
+- `.github/workflows/` + `scripts/package-app.sh` + `scripts/check-release-sdk.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then a macOS-26-SDK release-please Release PR → Developer ID-signed, notarized, stapled, mounted, layout/SDK/Gatekeeper-checked `Jarvis.dmg` with an Applications shortcut and bundled Apache and third-party notices; that DMG is the Release's only Jarvis-built asset ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
 - `AGENTS.md` + `.github/workflows/sync-shared-rules.yml` — project-specific agent guidance with a
   machine-managed shared-rules block that syncs weekly from `JINGBANZ/rules`; `CLAUDE.md` imports the
   same canonical file.


### PR DESCRIPTION
## Summary

- replace the ZIP and separate checksum uploads with one stable, labelled `Jarvis.dmg` app asset
- place `Jarvis.app` beside an `/Applications` shortcut so installation is an in-window Finder drag
- sign, notarize, staple, mount, and inspect the final DMG before a draft release can be published
- link directly to the latest DMG from the README and add tag-specific install guidance to releases
- record the distribution decision and keep the release configuration guarded by the normal test gate

## User experience

The user opens `Jarvis.dmg`, drags `Jarvis.app` onto the **Applications** shortcut in that Finder
window, ejects the Jarvis disk image, and opens Jarvis from Applications. GitHub continues to add its
automatic source archives, but the project publishes only one app artifact and the primary download
link bypasses the Assets list.

This changes future releases; it does not mutate the already-public v0.1.3 assets.

## Verification

- `swift build && ./scripts/run-tests.sh` — passed; 754 tests in 89 suites
- native DMG smoke — created, verified, mounted read-only, found exactly two root entries, confirmed
  `Applications -> /Applications`, and detached successfully
- release shell syntax, release configuration guard, app identity guard, workflow YAML parsing, and
  `git diff --check` — passed

The actual Developer ID signature and Apple notarization require the protected release credentials,
so they were not invoked locally. The release job performs those steps and now refuses publication
unless the final DMG passes its signature, notarization-ticket, mounted-layout, SDK, architecture,
license, `syspolicy_check`, and Gatekeeper checks.
