### PR TITLE
fix(release): staple app before packaging dmg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,11 @@ jobs:
     environment: release
     # Notarization occasionally stalls on Apple's side; without a cap, a stalled run rides the
     # 6-hour default timeout at the 10x macOS minute multiplier. Normal publishes finish well
-    # under this. The cap must clear package-app.sh's `notarytool --wait --timeout 30m` PLUS
-    # the checkout/test/build/sign work ahead of it — at 30m the job could be killed mid-wait,
-    # leaving a draft release without its asset. 45m keeps the backstop while giving notary its
-    # full 30m window.
-    timeout-minutes: 45
+    # under this. The cap must clear package-app.sh's two sequential
+    # `notarytool --wait --timeout 30m` calls PLUS checkout/test/build/sign work — otherwise the job
+    # could be killed during the outer-container wait, leaving a draft release without its asset.
+    # 75m keeps the backstop while giving both submissions their full bounded windows.
+    timeout-minutes: 75
     permissions:
       contents: write # upload the release asset
     steps:

--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 workflow=".github/workflows/release.yml"
+ci_workflow=".github/workflows/ci.yml"
 release_header=".github/release-header.md"
 package_script="scripts/package-app.sh"
 verify_script="scripts/verify-release.sh"
@@ -10,7 +11,7 @@ sdk_guard="scripts/check-release-sdk.sh"
 package_guard_call="./scripts/check-release-sdk.sh \"\$BIN_PATH\""
 verify_guard_call="./scripts/check-release-sdk.sh \"\$EXTRACTED_BIN\""
 
-for path in "$workflow" "$release_header" "$package_script" "$verify_script" "$sdk_guard"; do
+for path in "$workflow" "$ci_workflow" "$release_header" "$package_script" "$verify_script" "$sdk_guard"; do
   if [[ ! -f "$path" || -L "$path" ]]; then
     echo "Release configuration guard: $path must be a regular file." >&2
     exit 1
@@ -19,6 +20,18 @@ done
 
 if ! /usr/bin/grep -Eq '^[[:space:]]*runs-on:[[:space:]]*macos-26[[:space:]]*$' "$workflow"; then
   echo "Release publish job must use the Apple-silicon macos-26 runner." >&2
+  exit 1
+fi
+for checkout_workflow in "$workflow" "$ci_workflow"; do
+  if ! /usr/bin/grep -Eq \
+      '^[[:space:]]*-[[:space:]]*uses:[[:space:]]*actions/checkout@[0-9a-f]{40}[[:space:]]*#[[:space:]]*v([5-9]|[1-9][0-9]+)\.' \
+      "$checkout_workflow"; then
+    echo "$checkout_workflow must pin a Node 24-based actions/checkout release (v5+)." >&2
+    exit 1
+  fi
+done
+if ! /usr/bin/grep -Eq '^[[:space:]]*timeout-minutes:[[:space:]]*75[[:space:]]*$' "$workflow"; then
+  echo "Release publish timeout must cover both bounded notarization waits." >&2
   exit 1
 fi
 if ! /usr/bin/grep -Fq "$package_guard_call" "$package_script"; then
@@ -41,11 +54,32 @@ if ! /usr/bin/grep -Fq 'DMG="Jarvis.dmg"' "$package_script" \
   echo "Release packaging must create an identified Jarvis.dmg with an Applications shortcut." >&2
   exit 1
 fi
-if ! /usr/bin/grep -Fq 'xcrun notarytool submit "$DMG"' "$package_script" \
-    || ! /usr/bin/grep -Fq 'xcrun stapler staple "$DMG"' "$package_script"; then
-  echo "Release packaging must notarize and staple the final disk image." >&2
+if ! /usr/bin/grep -Fq 'xcrun notarytool submit "$artifact"' "$package_script"; then
+  echo "Release packaging must submit each distribution layer through the shared notarization path." >&2
   exit 1
 fi
+package_flow=(
+  'ditto -c -k --keepParent "$APP" "$APP_NOTARY_ARCHIVE"'
+  'notarize_artifact "$APP_NOTARY_ARCHIVE" "application"'
+  'xcrun stapler staple "$APP"'
+  'ditto "$APP" "$DMG_STAGE/$APP"'
+  'notarize_artifact "$DMG" "disk image"'
+  'xcrun stapler staple "$DMG"'
+  './scripts/verify-release.sh "${verify_args[@]}"'
+)
+previous_flow_line=0
+for flow_step in "${package_flow[@]}"; do
+  if ! flow_match="$(/usr/bin/grep -nF -m 1 -- "$flow_step" "$package_script")"; then
+    echo "Release packaging is missing required step: $flow_step" >&2
+    exit 1
+  fi
+  flow_line="${flow_match%%:*}"
+  if (( flow_line <= previous_flow_line )); then
+    echo "Release packaging step is out of order: $flow_step" >&2
+    exit 1
+  fi
+  previous_flow_line="$flow_line"
+done
 if ! /usr/bin/grep -Fq 'hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$MOUNT_POINT"' \
       "$verify_script" \
     || ! /usr/bin/grep -Fq '"$(readlink "$APPLICATIONS_LINK")" != "/Applications"' \

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -45,6 +45,27 @@ else
   notary=(--keychain-profile "${NOTARY_PROFILE:-jarvis-notary}")
 fi
 
+notarize_artifact() {
+  local artifact="$1"
+  local description="$2"
+  local submit_json
+  local notary_status
+  local submission_id
+
+  echo "▶ submitting $description to Apple's notary service (usually 1-5 min)"
+  submit_json="$(xcrun notarytool submit "$artifact" "${notary[@]}" \
+    --wait --timeout 30m --output-format json)" || true
+  echo "$submit_json"
+  notary_status="$(plutil -extract status raw -o - - <<<"$submit_json" 2>/dev/null || true)"
+  if [[ "$notary_status" != "Accepted" ]]; then
+    # The submission log names the exact offending file and reason — fetch it before failing.
+    submission_id="$(plutil -extract id raw -o - - <<<"$submit_json" 2>/dev/null || true)"
+    [[ -n "$submission_id" ]] && xcrun notarytool log "$submission_id" "${notary[@]}" || true
+    echo "error: $description notarization did not complete (status: ${notary_status:-unknown})" >&2
+    return 1
+  fi
+}
+
 echo "▶ swift build -c release"
 swift build -c release
 BIN_PATH="$(swift build -c release --show-bin-path)/$BIN_NAME"
@@ -107,6 +128,18 @@ cleanup_dmg_stage() {
 }
 trap cleanup_dmg_stage EXIT
 
+APP_NOTARY_ARCHIVE="$DMG_STAGE/Jarvis-app.zip"
+echo "▶ preparing application for notarization"
+ditto -c -k --keepParent "$APP" "$APP_NOTARY_ARCHIVE"
+notarize_artifact "$APP_NOTARY_ARCHIVE" "application"
+rm -f "$APP_NOTARY_ARCHIVE"
+
+# The app must carry its own ticket before it is sealed inside the final disk image. Otherwise the
+# mounted artifact fails the same offline distribution policy that users rely on after copying it.
+echo "▶ stapling application"
+xcrun stapler staple "$APP"
+xcrun stapler validate "$APP"
+
 echo "▶ creating drag-install disk image"
 ditto "$APP" "$DMG_STAGE/$APP"
 ln -s /Applications "$DMG_STAGE/Applications"
@@ -115,21 +148,11 @@ hdiutil create -volname Jarvis -srcfolder "$DMG_STAGE" -fs HFS+ -format UDZO -ov
 codesign --force --timestamp --identifier "$DMG_IDENTIFIER" --sign "$IDENTITY" "$DMG"
 codesign --verify --strict --verbose=2 "$DMG"
 
-# Submit the outermost container so Apple's ticket covers the exact disk image users download.
-echo "▶ submitting to Apple's notary service (usually 1-5 min)"
-submit_json="$(xcrun notarytool submit "$DMG" "${notary[@]}" --wait --timeout 30m --output-format json)" || true
-echo "$submit_json"
-status="$(plutil -extract status raw -o - - <<<"$submit_json" 2>/dev/null || true)"
-if [[ "$status" != "Accepted" ]]; then
-  # The submission log names the exact offending file and reason — fetch it before failing.
-  id="$(plutil -extract id raw -o - - <<<"$submit_json" 2>/dev/null || true)"
-  [[ -n "$id" ]] && xcrun notarytool log "$id" "${notary[@]}" || true
-  echo "error: notarization did not complete (status: ${status:-unknown})" >&2
-  exit 1
-fi
+notarize_artifact "$DMG" "disk image"
 
-# A disk image can carry its ticket, so the exact notarized file remains the final artifact.
-echo "▶ stapling"
+# The outer ticket covers the exact container users download as well as the app ticket already
+# embedded inside it.
+echo "▶ stapling disk image"
 xcrun stapler staple "$DMG"
 
 # Verify the exact disk image users receive, not only the pre-container bundle. A packaging mistake

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -63,9 +63,10 @@ The `Jarvis Dev` identity above is a **local-dev** device: on any other Mac it's
 Gatekeeper blocks the app. Distributable builds go through `scripts/package-app.sh`, which builds and
 signs the bundle once with a **Developer ID Application** certificate — hardened runtime + secure
 timestamp (both notarization requirements) — with the `audio-input` entitlement that hardened runtime
-requires for microphone capture. It places the signed app beside an `Applications` shortcut in
-`Jarvis.dmg`, signs and notarizes that outer disk image, then staples the ticket to the exact file
-users download.
+requires for microphone capture. It submits a temporary zip of that app to Apple's notary service,
+staples and validates the app's ticket, then places the stapled app beside an `Applications` shortcut
+in `Jarvis.dmg`. It signs and notarizes that outer disk image separately, then staples the container's
+ticket to the exact file users download. Both layers therefore remain verifiable offline.
 
 The script passes that final DMG to `scripts/verify-release.sh`, which verifies the disk image and its
 ticket, mounts it read-only, and requires exactly one regular `Jarvis.app` plus one symbolic link to


### PR DESCRIPTION
## Summary

- notarize, staple, and validate `Jarvis.app` before copying it into the release disk image
- separately notarize and staple the final `Jarvis.dmg`
- extend the publish timeout for the two bounded notarization submissions
- preserve the Node 24-based `actions/checkout@v7.0.1` pin from current `main` and add a release guard that rejects pre-v5 checkout pins in CI or Release

## Root cause

The failed release successfully notarized and stapled the outer DMG, but the mounted `Jarvis.app` had no stapled ticket. The final offline distribution check therefore failed with `Notary Ticket Missing` and exited before asset upload.

The Node.js deprecation warning was independent of that failure: the failed run used an older checkout action. Current `main` already carries checkout v7.0.1 (Node 24); this change adds a regression guard around that requirement.

## Behavior

The publish job now follows Apple's nested-distribution flow:

1. sign the app
2. submit a temporary app ZIP
3. staple and validate the app
4. package the stapled app into the DMG
5. submit and staple the DMG
6. verify the exact downloadable DMG and its mounted app

Any failed submission or staple still stops publication. Signing, Gatekeeper, offline ticket, and package-layout checks remain enforced.

## Validation

- `bash -n scripts/package-app.sh scripts/check-release-config.sh scripts/verify-release.sh`
- `shellcheck --severity=warning scripts/package-app.sh scripts/check-release-config.sh scripts/verify-release.sh`
- `./scripts/check-release-config.sh`
- YAML parse for CI and Release workflows
- `xcodebuildmcp swift-package build --package-path /private/tmp/jarvis-release-notary-ticket --configuration debug --output text`
- `swift build && ./scripts/run-tests.sh` — 754 tests in 89 suites passed

An end-to-end Developer ID/notary submission remains a post-merge release-environment check because it requires the protected signing and Apple credentials.