### PR TITLE
ci(release): use release pr as approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
     # AppKit selects the macOS 26 control design from the linked SDK. Pin the release runner instead
     # of following macos-latest so distributed and local macOS 26 builds cannot silently diverge.
     runs-on: macos-26
-    # Keep signing and notarization credentials unavailable until the owner approves the job.
+    # Keep signing and notarization secrets scoped to the main-only release environment. Merging the
+    # release-please PR is the manual release approval, so the environment has no second reviewer gate.
     environment: release
     # Notarization occasionally stalls on Apple's side; without a cap, a stalled run rides the
     # 6-hour default timeout at the 10x macOS minute multiplier. Normal publishes finish well

--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -22,6 +22,10 @@ if ! /usr/bin/grep -Eq '^[[:space:]]*runs-on:[[:space:]]*macos-26[[:space:]]*$' 
   echo "Release publish job must use the Apple-silicon macos-26 runner." >&2
   exit 1
 fi
+if ! /usr/bin/grep -Eq '^[[:space:]]*environment:[[:space:]]*release[[:space:]]*$' "$workflow"; then
+  echo "Release publish job must bind the environment-scoped signing secrets." >&2
+  exit 1
+fi
 for checkout_workflow in "$workflow" "$ci_workflow"; do
   if ! /usr/bin/grep -Eq \
       '^[[:space:]]*-[[:space:]]*uses:[[:space:]]*actions/checkout@[0-9a-f]{40}[[:space:]]*#[[:space:]]*v([5-9]|[1-9][0-9]+)\.' \

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -78,10 +78,11 @@ app is not accepted as a proxy for the downloaded artifact.
 Releases are cut by `.github/workflows/release.yml`, not by hand: on every push to `main`,
 **release-please** maintains a standing Release PR from the conventional-commit history (bumping both
 version keys in `Resources/Info.plist` via `x-release-please-version` annotations, plus the
-CHANGELOG — config in `release-please-config.json`). Merging that PR creates the GitHub Release **as
-a draft**; an Apple-silicon `macos-26` job then runs the test gate, signs/notarizes via repo secrets
-(the base64 `.p12` certificate and an App Store Connect API key — names in the workflow), attaches
-only `Jarvis.dmg`, and then publishes the Release. The stable installation block in
+CHANGELOG — config in `release-please-config.json`). Merging that PR is the manual release approval:
+it creates the GitHub Release **as a draft**, with no second deployment approval. An Apple-silicon
+`macos-26` job then runs the test gate, signs/notarizes with secrets scoped to the main-only `release`
+environment (the base64 `.p12` certificate and an App Store Connect API key — names in the workflow),
+attaches only `Jarvis.dmg`, and then publishes the Release. The stable installation block in
 `.github/release-header.md` links directly to that tag's DMG and explains the in-window drag to
 Applications; GitHub still supplies its automatic source archives. A failed sign, notarization, or
 final-image verification therefore never leaves a public Release without a validated app. The exact

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1743,3 +1743,20 @@
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
   `scripts/package-app.sh`, `scripts/verify-release.sh`, `.github/workflows/release.yml`,
   `.github/release-header.md`.
+
+### 2026-08-17 — Merging the Release PR is the release approval
+
+- **Chose:** Keep the Developer ID and notarization secrets in the `release` environment and retain
+  its `main`-only deployment policy, but require no environment reviewer. Merging the release-please
+  PR is the sole manual release authorization; that merge alone lets the gated publish job continue.
+- **Why:** The Release PR exposes the exact version, changelog, and commits for owner review. Asking
+  the same owner to approve the resulting deployment again adds ceremony without strengthening the
+  trust boundary. The draft Release, repository Gate, signing, two-layer notarization, final-image
+  verification, and fail-closed asset reconciliation still prevent an invalid public release.
+- **Rejected:** (a) Keeping a second required-reviewer prompt after the Release PR merge—duplicate
+  authorization. (b) Removing the environment binding or moving its credentials to repository
+  scope—the five release-only secrets would become unavailable or unnecessarily broad. (c)
+  publishing on every push to `main`—only a merged release-please PR sets `release_created`.
+- **Extends:** 2026-07-17 — Distribution via release-please + notarized zip on GitHub Releases.
+- **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
+  `.github/workflows/release.yml`, `scripts/check-release-config.sh`.


### PR DESCRIPTION
## Summary

- treat merging the release-please PR as the sole manual release approval
- keep the publish job bound to the main-only `release` environment so its five signing and notarization secrets remain narrowly scoped
- guard the environment binding in release configuration checks
- document the policy and decision

The live `release` environment has also been updated to remove its required reviewer. Its `main`-only deployment policy and all five existing secret names were verified after the update.

## Why

A release-please PR already exposes the exact version, changelog, and commits for owner review. Requiring the same owner to approve the deployment after merging that PR duplicated authorization without strengthening the release trust boundary.

The repository Gate, draft Release, signing, app and DMG notarization, final-image verification, and fail-closed asset reconciliation are unchanged.

## Validation

- `bash -n scripts/check-release-config.sh`
- `./scripts/check-release-config.sh`
- Ruby YAML parse of `.github/workflows/release.yml`
- `shellcheck --severity=warning scripts/check-release-config.sh`
- `git diff --check`
- `xcodebuildmcp swift-package build --package-path /private/tmp/jarvis-release-environment-policy --configuration debug --output text`
- `swift build && ./scripts/run-tests.sh` — 754 tests in 89 suites passed
