### PR TITLE
feat(release): add guided DMG installer layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,17 @@ jobs:
       - name: Run repository gate
         run: swift build && ./scripts/run-tests.sh
 
+      # dmgbuild writes the curated Finder layout without opening Finder, so the release remains
+      # deterministic on a headless runner. Install only hash-pinned wheels into an ephemeral venv.
+      - name: Install DMG layout tool
+        run: |
+          RELEASE_TOOLS="$RUNNER_TEMP/release-tools"
+          python3 -m venv "$RELEASE_TOOLS"
+          "$RELEASE_TOOLS/bin/python" -m pip install \
+            --require-hashes \
+            --requirement scripts/requirements-release.txt
+          echo "DMGBUILD_PYTHON=$RELEASE_TOOLS/bin/python" >> "$GITHUB_ENV"
+
       # GitHub's documented recipe for signing on a hosted runner: decode the Developer ID
       # certificate into a fresh temporary keychain. set-key-partition-list is what lets codesign
       # use the key without a GUI prompt (which would hang forever headless); the keychain

--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -8,10 +8,14 @@ release_header=".github/release-header.md"
 package_script="scripts/package-app.sh"
 verify_script="scripts/verify-release.sh"
 sdk_guard="scripts/check-release-sdk.sh"
+dmg_settings="scripts/dmg-settings.py"
+dmg_layout_guard="scripts/verify-dmg-layout.py"
+release_requirements="scripts/requirements-release.txt"
 package_guard_call="./scripts/check-release-sdk.sh \"\$BIN_PATH\""
 verify_guard_call="./scripts/check-release-sdk.sh \"\$EXTRACTED_BIN\""
 
-for path in "$workflow" "$ci_workflow" "$release_header" "$package_script" "$verify_script" "$sdk_guard"; do
+for path in "$workflow" "$ci_workflow" "$release_header" "$package_script" "$verify_script" \
+    "$sdk_guard" "$dmg_settings" "$dmg_layout_guard" "$release_requirements"; do
   if [[ ! -f "$path" || -L "$path" ]]; then
     echo "Release configuration guard: $path must be a regular file." >&2
     exit 1
@@ -54,8 +58,26 @@ if ! /usr/bin/grep -Fq 'DMG="Jarvis.dmg"' "$package_script" \
     || ! /usr/bin/grep -Fq 'DMG_IDENTIFIER="com.jarvis.coach.dmg"' "$package_script" \
     || ! /usr/bin/grep -Fq 'codesign --force --timestamp --identifier "$DMG_IDENTIFIER" --sign "$IDENTITY" "$DMG"' \
       "$package_script" \
-    || ! /usr/bin/grep -Fq 'ln -s /Applications "$DMG_STAGE/Applications"' "$package_script"; then
-  echo "Release packaging must create an identified Jarvis.dmg with an Applications shortcut." >&2
+    || ! /usr/bin/grep -Fq 'EXPECTED_DMGBUILD_VERSION="1.6.7"' "$package_script" \
+    || ! /usr/bin/grep -Fq '"$DMGBUILD_PYTHON" -m dmgbuild' "$package_script" \
+    || ! /usr/bin/grep -Fq -- '--settings scripts/dmg-settings.py' "$package_script"; then
+  echo "Release packaging must create an identified Jarvis.dmg with the pinned layout tool." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq 'symlinks = {"Applications": "/Applications"}' "$dmg_settings" \
+    || ! /usr/bin/grep -Fq 'background = "builtin-arrow"' "$dmg_settings" \
+    || ! /usr/bin/grep -Fq 'window_rect = ((100, 100), (640, 280))' "$dmg_settings" \
+    || ! /usr/bin/grep -Fq 'APP_NAME: (140, 120)' "$dmg_settings" \
+    || ! /usr/bin/grep -Fq '"Applications": (500, 120)' "$dmg_settings"; then
+  echo "Release DMG settings must preserve the reviewed arrow-and-drop-target layout." >&2
+  exit 1
+fi
+if ! /usr/bin/grep -Fq -- '--only-binary=:all:' "$release_requirements" \
+    || ! /usr/bin/grep -Fq 'dmgbuild==1.6.7' "$release_requirements" \
+    || ! /usr/bin/grep -Fq -- '--require-hashes' "$workflow" \
+    || ! /usr/bin/grep -Fq -- '--requirement scripts/requirements-release.txt' "$workflow" \
+    || ! /usr/bin/grep -Fq 'DMGBUILD_PYTHON=$RELEASE_TOOLS/bin/python' "$workflow"; then
+  echo "Release workflow must install the hash-pinned DMG layout tool in its own environment." >&2
   exit 1
 fi
 if ! /usr/bin/grep -Fq 'xcrun notarytool submit "$artifact"' "$package_script"; then
@@ -67,6 +89,7 @@ package_flow=(
   'notarize_artifact "$APP_NOTARY_ARCHIVE" "application"'
   'xcrun stapler staple "$APP"'
   'ditto "$APP" "$DMG_STAGE/$APP"'
+  '"$DMGBUILD_PYTHON" -m dmgbuild'
   'notarize_artifact "$DMG" "disk image"'
   'xcrun stapler staple "$DMG"'
   './scripts/verify-release.sh "${verify_args[@]}"'
@@ -88,9 +111,11 @@ if ! /usr/bin/grep -Fq 'hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$
       "$verify_script" \
     || ! /usr/bin/grep -Fq '"$(readlink "$APPLICATIONS_LINK")" != "/Applications"' \
       "$verify_script" \
+    || ! /usr/bin/grep -Fq '"$DMGBUILD_PYTHON" scripts/verify-dmg-layout.py "$MOUNT_POINT"' \
+      "$verify_script" \
     || ! /usr/bin/grep -Fq 'syspolicy_check distribution "$EXTRACTED_APP" --verbose' \
       "$verify_script"; then
-  echo "Final release verification must inspect the mounted layout and modern system policy." >&2
+  echo "Final release verification must inspect the mounted Finder layout and modern system policy." >&2
   exit 1
 fi
 if ! /usr/bin/grep -Fq 'ASSET="Jarvis.dmg"' "$workflow" \

--- a/scripts/dmg-settings.py
+++ b/scripts/dmg-settings.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+APP_NAME = "Jarvis.app"
+
+try:
+    application = Path(defines["app"])  # type: ignore[name-defined]
+except (KeyError, NameError) as error:
+    raise ValueError("dmgbuild requires -D app=/absolute/path/to/Jarvis.app") from error
+
+if not application.is_absolute():
+    raise ValueError("the Jarvis.app path must be absolute")
+if application.name != APP_NAME or application.is_symlink() or not application.is_dir():
+    raise ValueError("the DMG source must be a regular Jarvis.app bundle")
+
+# Keep the visible surface to the two conventional drag-install targets. dmgbuild writes the
+# Finder metadata and bundled arrow directly, so this layout is deterministic without a GUI session.
+files = [(str(application), APP_NAME)]
+symlinks = {"Applications": "/Applications"}
+hide_extensions = [APP_NAME]
+
+format = "UDZO"
+filesystem = "HFS+"
+
+background = "builtin-arrow"
+window_rect = ((100, 100), (640, 280))
+show_status_bar = False
+show_tab_view = False
+show_toolbar = False
+show_pathbar = False
+show_sidebar = False
+default_view = "icon-view"
+
+arrange_by = None
+label_pos = "bottom"
+text_size = 16
+icon_size = 128
+icon_locations = {
+    APP_NAME: (140, 120),
+    "Applications": (500, 120),
+}
+include_icon_view_settings = True
+include_list_view_settings = False

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -25,6 +25,17 @@ cd "$(dirname "$0")/.."
 
 APP="Jarvis.app"
 BIN_NAME="JarvisApp"
+DMGBUILD_PYTHON="${DMGBUILD_PYTHON:-python3}"
+EXPECTED_DMGBUILD_VERSION="1.6.7"
+
+if ! "$DMGBUILD_PYTHON" -c \
+    'import dmgbuild, sys; sys.exit(dmgbuild.__version__ != sys.argv[1])' \
+    "$EXPECTED_DMGBUILD_VERSION"; then
+  echo "error: dmgbuild $EXPECTED_DMGBUILD_VERSION is required for the installer layout." >&2
+  echo "       Install scripts/requirements-release.txt in a virtual environment, then pass" >&2
+  echo "       DMGBUILD_PYTHON=/path/to/venv/bin/python." >&2
+  exit 1
+fi
 
 if [[ -z "${IDENTITY:-}" ]]; then
   IDENTITY="$(security find-identity -v -p codesigning \
@@ -103,24 +114,14 @@ if [[ -z "$DMG_STAGE" || "$DMG_STAGE" != "$DMG_STAGE_PREFIX"* \
 fi
 cleanup_dmg_stage() {
   local exit_code=$?
-  local cleanup_safe=true
   trap - EXIT
   if [[ -n "${DMG_STAGE:-}" && -n "${DMG_STAGE_PREFIX:-}" \
         && "$DMG_STAGE" == "$DMG_STAGE_PREFIX"* && -d "$DMG_STAGE" \
         && ! -L "$DMG_STAGE" ]]; then
-    if [[ -L "$DMG_STAGE/Applications" \
-          && "$(readlink "$DMG_STAGE/Applications")" == "/Applications" ]]; then
-      unlink "$DMG_STAGE/Applications"
-    elif [[ -e "$DMG_STAGE/Applications" || -L "$DMG_STAGE/Applications" ]]; then
-      echo "error: refusing to clean an unexpected Applications staging entry" >&2
-      exit_code=1
-      cleanup_safe=false
-    fi
     if find "$DMG_STAGE" -type l -print -quit | grep -q .; then
       echo "error: refusing to clean disk-image staging with an unexpected symbolic link" >&2
       exit_code=1
-      cleanup_safe=false
-    elif [[ "$cleanup_safe" == "true" ]]; then
+    else
       rm -rf -- "$DMG_STAGE"
     fi
   fi
@@ -142,9 +143,11 @@ xcrun stapler validate "$APP"
 
 echo "▶ creating drag-install disk image"
 ditto "$APP" "$DMG_STAGE/$APP"
-ln -s /Applications "$DMG_STAGE/Applications"
 rm -f "$DMG"
-hdiutil create -volname Jarvis -srcfolder "$DMG_STAGE" -fs HFS+ -format UDZO -ov "$DMG"
+"$DMGBUILD_PYTHON" -m dmgbuild \
+  --settings scripts/dmg-settings.py \
+  -D "app=$DMG_STAGE/$APP" \
+  Jarvis "$DMG"
 codesign --force --timestamp --identifier "$DMG_IDENTIFIER" --sign "$IDENTITY" "$DMG"
 codesign --verify --strict --verbose=2 "$DMG"
 

--- a/scripts/requirements-release.txt
+++ b/scripts/requirements-release.txt
@@ -1,0 +1,8 @@
+--only-binary=:all:
+
+dmgbuild==1.6.7 \
+    --hash=sha256:37ee5771c377beb3203d9164aae8046ffed8531c06edf9227f5788b3c599b1bf
+ds-store==1.3.3 \
+    --hash=sha256:b92a371efbf1b4ccce2a04d1ed13fceacc4736c81ba09cf5aefb74c088160a35
+mac-alias==2.2.3 \
+    --hash=sha256:7362b521d2132ef92f606a37abfed5fcd849ceb2f28b6f9743e014b02af92f0d

--- a/scripts/verify-dmg-layout.py
+++ b/scripts/verify-dmg-layout.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
 import hashlib
+import struct
 import subprocess
 import sys
 from pathlib import Path
 
 from ds_store import DSStore
+from mac_alias import Alias
 
 
 APP_NAME = "Jarvis.app"
@@ -33,6 +35,53 @@ def record(store: DSStore, filename: str, code: str):
 def require_equal(actual, expected, description: str) -> None:
     if actual != expected:
         fail(f"{description} is {actual!r}; expected {expected!r}")
+
+
+def alias_text(value):
+    return value.decode("utf-8") if isinstance(value, bytes) else value
+
+
+def verify_background_alias(alias_data, background_path: Path) -> None:
+    if not isinstance(alias_data, (bytes, bytearray)):
+        fail("Finder background alias is not binary Alias data")
+
+    try:
+        actual = Alias.from_bytes(bytes(alias_data))
+    except (OverflowError, TypeError, UnicodeError, ValueError, struct.error):
+        fail("Finder background alias is malformed")
+
+    if actual.volume is None or actual.target is None:
+        fail("Finder background alias has no target identity")
+
+    try:
+        expected = Alias.for_file(str(background_path))
+    except OSError:
+        fail("could not read the mounted arrow background identity")
+
+    identity_fields = (
+        ("volume name", alias_text(actual.volume.name), alias_text(expected.volume.name)),
+        ("volume creation date", actual.volume.creation_date, expected.volume.creation_date),
+        ("volume filesystem", actual.volume.fs_type, expected.volume.fs_type),
+        ("volume disk type", actual.volume.disk_type, expected.volume.disk_type),
+        ("volume filesystem id", actual.volume.fs_id, expected.volume.fs_id),
+        ("target kind", actual.target.kind, expected.target.kind),
+        (
+            "target filename",
+            alias_text(actual.target.filename),
+            alias_text(expected.target.filename),
+        ),
+        ("target folder id", actual.target.folder_cnid, expected.target.folder_cnid),
+        ("target catalog id", actual.target.cnid, expected.target.cnid),
+        ("target creation date", actual.target.creation_date, expected.target.creation_date),
+        ("target Carbon path", actual.target.carbon_path, expected.target.carbon_path),
+        (
+            "target POSIX path",
+            alias_text(actual.target.posix_path),
+            alias_text(expected.target.posix_path),
+        ),
+    )
+    for field, actual_value, expected_value in identity_fields:
+        require_equal(actual_value, expected_value, f"Finder background alias {field}")
 
 
 def main() -> None:
@@ -71,8 +120,10 @@ def main() -> None:
 
         icon_settings = record(store, ".", "icvp")
         require_equal(icon_settings.get("backgroundType"), 2, "Finder background type")
-        if not icon_settings.get("backgroundImageAlias"):
+        background_alias = icon_settings.get("backgroundImageAlias")
+        if not background_alias:
             fail("Finder metadata does not point to the arrow background")
+        verify_background_alias(background_alias, background_path)
         require_equal(icon_settings.get("arrangeBy"), "none", "Finder icon arrangement")
         require_equal(icon_settings.get("labelOnBottom"), True, "Finder icon label position")
         require_equal(icon_settings.get("textSize"), 16.0, "Finder label size")

--- a/scripts/verify-dmg-layout.py
+++ b/scripts/verify-dmg-layout.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import hashlib
+import subprocess
+import sys
+from pathlib import Path
+
+from ds_store import DSStore
+
+
+APP_NAME = "Jarvis.app"
+APPLICATIONS_NAME = "Applications"
+EXPECTED_BACKGROUND_SHA256 = "a0b620ebf085f7bfd975b5cbbf25f3245afd95cef598f4ac80e05a5672e18290"
+EXPECTED_ICON_LOCATIONS = {
+    APP_NAME: (140, 120),
+    APPLICATIONS_NAME: (500, 120),
+}
+EXPECTED_WINDOW_BOUNDS = "{{100, 100}, {640, 280}}"
+FINDER_EXTENSION_HIDDEN = 0x0010
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"error: {message}")
+
+
+def record(store: DSStore, filename: str, code: str):
+    try:
+        return store[filename][code]
+    except KeyError:
+        fail(f"disk image Finder metadata is missing {filename!r} {code!r}")
+
+
+def require_equal(actual, expected, description: str) -> None:
+    if actual != expected:
+        fail(f"{description} is {actual!r}; expected {expected!r}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        fail(f"usage: {Path(sys.argv[0]).name} /path/to/mounted/Jarvis")
+
+    mount_point = Path(sys.argv[1])
+    if mount_point.is_symlink() or not mount_point.is_dir():
+        fail("disk image mount point must be a regular directory")
+
+    ds_store_path = mount_point / ".DS_Store"
+    background_path = mount_point / ".background.tiff"
+    if ds_store_path.is_symlink() or not ds_store_path.is_file():
+        fail("disk image is missing its regular .DS_Store layout metadata")
+    if background_path.is_symlink() or not background_path.is_file():
+        fail("disk image is missing its regular arrow background")
+
+    background_digest = hashlib.sha256(background_path.read_bytes()).hexdigest()
+    require_equal(background_digest, EXPECTED_BACKGROUND_SHA256, "arrow background digest")
+
+    with DSStore.open(str(ds_store_path), "r") as store:
+        require_equal(
+            record(store, ".", "icvl"),
+            (b"type", b"icnv"),
+            "default Finder view",
+        )
+
+        browser_settings = record(store, ".", "bwsp")
+        require_equal(
+            browser_settings.get("WindowBounds"),
+            EXPECTED_WINDOW_BOUNDS,
+            "Finder window bounds",
+        )
+        for key in ("ShowStatusBar", "ShowTabView", "ShowToolbar", "ShowPathbar", "ShowSidebar"):
+            require_equal(browser_settings.get(key), False, f"Finder setting {key}")
+
+        icon_settings = record(store, ".", "icvp")
+        require_equal(icon_settings.get("backgroundType"), 2, "Finder background type")
+        if not icon_settings.get("backgroundImageAlias"):
+            fail("Finder metadata does not point to the arrow background")
+        require_equal(icon_settings.get("arrangeBy"), "none", "Finder icon arrangement")
+        require_equal(icon_settings.get("labelOnBottom"), True, "Finder icon label position")
+        require_equal(icon_settings.get("textSize"), 16.0, "Finder label size")
+        require_equal(icon_settings.get("iconSize"), 128.0, "Finder icon size")
+
+        for filename, expected_location in EXPECTED_ICON_LOCATIONS.items():
+            require_equal(
+                record(store, filename, "Iloc"),
+                expected_location,
+                f"Finder position for {filename}",
+            )
+
+    try:
+        finder_info_hex = subprocess.check_output(
+            ["/usr/bin/xattr", "-px", "com.apple.FinderInfo", mount_point / APP_NAME],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        finder_info = bytes.fromhex(finder_info_hex)
+    except (OSError, subprocess.CalledProcessError, ValueError):
+        fail("Jarvis.app is missing its Finder presentation metadata")
+    if len(finder_info) < 10:
+        fail("Jarvis.app has incomplete Finder presentation metadata")
+    finder_flags = int.from_bytes(finder_info[8:10], byteorder="big")
+    if finder_flags & FINDER_EXTENSION_HIDDEN == 0:
+        fail("Finder metadata must display the application as Jarvis without the .app extension")
+
+    print("Disk image Finder layout passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -5,9 +5,17 @@ cd "$(dirname "$0")/.."
 
 DMG="${1:-}"
 EXPECTED_RELEASE_TAG="${2:-}"
+DMGBUILD_PYTHON="${DMGBUILD_PYTHON:-python3}"
 if [[ $# -gt 2 || -z "$DMG" || ! -f "$DMG" || -L "$DMG" ]]; then
   echo "usage: $0 Jarvis.dmg [v<version>]" >&2
   exit 2
+fi
+
+if ! "$DMGBUILD_PYTHON" -c 'from ds_store import DSStore' 2>/dev/null; then
+  echo "error: the pinned release-layout dependencies are required to verify the DMG." >&2
+  echo "       Install scripts/requirements-release.txt in a virtual environment, then pass" >&2
+  echo "       DMGBUILD_PYTHON=/path/to/venv/bin/python." >&2
+  exit 1
 fi
 DMG="$(cd "$(dirname "$DMG")" && pwd)/$(basename "$DMG")"
 if [[ "$(basename "$DMG")" != "Jarvis.dmg" ]]; then
@@ -63,14 +71,17 @@ MOUNTED=true
 EXTRACTED_APP="$MOUNT_POINT/$APP"
 APPLICATIONS_LINK="$MOUNT_POINT/Applications"
 ENTRY_COUNT="$(find "$MOUNT_POINT" -mindepth 1 -maxdepth 1 -print | wc -l | tr -d '[:space:]')"
-if [[ "$ENTRY_COUNT" != "2" || ! -d "$EXTRACTED_APP" || -L "$EXTRACTED_APP" ]]; then
-  echo "error: final disk image must contain one regular $APP bundle and one Applications shortcut" >&2
+if [[ "$ENTRY_COUNT" != "4" || ! -d "$EXTRACTED_APP" || -L "$EXTRACTED_APP" \
+      || ! -f "$MOUNT_POINT/.DS_Store" || -L "$MOUNT_POINT/.DS_Store" \
+      || ! -f "$MOUNT_POINT/.background.tiff" || -L "$MOUNT_POINT/.background.tiff" ]]; then
+  echo "error: final disk image must contain the two visible install targets and exact layout metadata" >&2
   exit 1
 fi
 if [[ ! -L "$APPLICATIONS_LINK" || "$(readlink "$APPLICATIONS_LINK")" != "/Applications" ]]; then
   echo "error: final disk image must contain an Applications shortcut targeting /Applications" >&2
   exit 1
 fi
+"$DMGBUILD_PYTHON" scripts/verify-dmg-layout.py "$MOUNT_POINT"
 
 VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
   "$EXTRACTED_APP/Contents/Info.plist")"

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -64,25 +64,34 @@ Gatekeeper blocks the app. Distributable builds go through `scripts/package-app.
 signs the bundle once with a **Developer ID Application** certificate — hardened runtime + secure
 timestamp (both notarization requirements) — with the `audio-input` entitlement that hardened runtime
 requires for microphone capture. It submits a temporary zip of that app to Apple's notary service,
-staples and validates the app's ticket, then places the stapled app beside an `Applications` shortcut
-in `Jarvis.dmg`. It signs and notarizes that outer disk image separately, then staples the container's
-ticket to the exact file users download. Both layers therefore remain verifiable offline.
+staples and validates the app's ticket, then uses the hash-pinned release-only `dmgbuild` tool to
+place the stapled app beside an `Applications` shortcut in `Jarvis.dmg`. The mounted Finder window is
+a fixed icon view: Jarvis on the left, Applications on the right, and a large arrow between them,
+with the extension and window chrome hidden. `dmgbuild` writes that metadata directly rather than
+automating Finder, so the hosted runner does not need a GUI session. The script signs and notarizes
+the outer disk image separately, then staples the container's ticket to the exact file users
+download. Both layers therefore remain verifiable offline.
 
 The script passes that final DMG to `scripts/verify-release.sh`, which verifies the disk image and its
-ticket, mounts it read-only, and requires exactly one regular `Jarvis.app` plus one symbolic link to
-`/Applications`. It checks the mounted app's version, arm64 architecture, linked macOS 26-or-newer
-SDK, notices, strict code signature, and Gatekeeper policy result before detaching the image. The same
-SDK guard runs immediately after the release build, before signing or notarization; the pre-container
-app is not accepted as a proxy for the downloaded artifact.
+ticket, mounts it read-only, and requires exactly the two visible install targets plus the hidden
+Finder metadata and arrow background. `scripts/verify-dmg-layout.py` reads the final `.DS_Store` and
+checks the icon view, window size, chrome, icon size and positions, background link and digest, and
+hidden `.app` extension. Release verification also checks the Applications target, mounted app
+version, arm64 architecture, linked macOS 26-or-newer SDK, notices, strict code signature, and
+Gatekeeper policy result before detaching the image. The same SDK guard runs immediately after the
+release build, before signing or notarization; the pre-container app is not accepted as a proxy for
+the downloaded artifact.
 
 Releases are cut by `.github/workflows/release.yml`, not by hand: on every push to `main`,
 **release-please** maintains a standing Release PR from the conventional-commit history (bumping both
 version keys in `Resources/Info.plist` via `x-release-please-version` annotations, plus the
 CHANGELOG — config in `release-please-config.json`). Merging that PR is the manual release approval:
 it creates the GitHub Release **as a draft**, with no second deployment approval. An Apple-silicon
-`macos-26` job then runs the test gate, signs/notarizes with secrets scoped to the main-only `release`
-environment (the base64 `.p12` certificate and an App Store Connect API key — names in the workflow),
-attaches only `Jarvis.dmg`, and then publishes the Release. The stable installation block in
+`macos-26` job then runs the test gate, installs only the hash-pinned pure-Python wheels in
+`scripts/requirements-release.txt` into an ephemeral environment, and signs/notarizes with secrets
+scoped to the main-only `release` environment (the base64 `.p12` certificate and an App Store Connect
+API key — names in the workflow). It attaches only `Jarvis.dmg`, then publishes the Release. The
+stable installation block in
 `.github/release-header.md` links directly to that tag's DMG and explains the in-window drag to
 Applications; GitHub still supplies its automatic source archives. A failed sign, notarization, or
 final-image verification therefore never leaves a public Release without a validated app. The exact
@@ -91,9 +100,11 @@ AppKit controls on the same macOS 26 design as local development builds instead 
 compatibility appearance of an older linked SDK. The publish job lives in the same workflow because
 tags created with `GITHUB_TOKEN` never trigger other workflows.
 
-`package-app.sh` also runs locally (one-time `xcrun notarytool store-credentials jarvis-notary …`,
-then just run the script) for packaging without CI. Distributed builds require macOS 14.2 or later
-and run on Apple silicon only because `libjarvis-aec.a` is arm64-only. The README owns the user
+`package-app.sh` also runs locally for packaging without CI. Create a virtual environment, install
+`scripts/requirements-release.txt` with `--require-hashes`, and pass its interpreter through
+`DMGBUILD_PYTHON`; notarization also needs the one-time
+`xcrun notarytool store-credentials jarvis-notary …` setup. Distributed builds require macOS 14.2 or
+later and run on Apple silicon only because `libjarvis-aec.a` is arm64-only. The README owns the user
 installation steps; provider credentials remain user-supplied in Settings.
 
 ## Running

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1740,6 +1740,9 @@
 - **Supersedes in part:** 2026-07-17 — Distribution via release-please + notarized zip on GitHub
   Releases. Its release-please flow, Developer ID identity, notarization credentials, and
   draft-until-validated publication semantics stand.
+- **Superseded in part by:** 2026-08-17 — DMG makes the drag-install gesture explicit. The single
+  artifact, two visible targets, owner-driven gesture, and trust chain stand; the unarranged native
+  presentation and rejection of a release-only layout dependency do not.
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
   `scripts/package-app.sh`, `scripts/verify-release.sh`, `.github/workflows/release.yml`,
   `.github/release-header.md`.
@@ -1760,3 +1763,29 @@
 - **Extends:** 2026-07-17 — Distribution via release-please + notarized zip on GitHub Releases.
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
   `.github/workflows/release.yml`, `scripts/check-release-config.sh`.
+
+### 2026-08-17 — DMG makes the drag-install gesture explicit
+
+- **Chose:** Keep the single `Jarvis.dmg` and its two visible targets, but present them in a fixed
+  640×280 Finder icon view: a 128-point Jarvis icon on the left, the system Applications folder on
+  the right, and a large arrow between them. Hide the `.app` extension and Finder chrome. Use
+  `dmgbuild` 1.6.7 as a release-only dependency, with it and its two pure-Python dependencies pinned
+  to wheel hashes in `scripts/requirements-release.txt`; it writes `.DS_Store` directly and never
+  launches Finder. Verify the mounted final image's exact visible/hidden entries, background digest,
+  Finder view and window settings, icon positions and sizes, and extension flag before publication.
+- **Why:** The unarranged image contained the correct app and shortcut but did not visually explain
+  their relationship, so a user could open Jarvis from the read-only image instead of installing it.
+  Apple explicitly treats arranged icons, a background, and an Applications symlink as the standard
+  single-app disk-image experience. Encoding and checking the presentation makes that gesture
+  obvious while preserving headless CI and the existing signing, notarization, and Gatekeeper chain.
+- **Rejected:** (a) Keep the plain two-entry image and rely on release-note instructions—the user is
+  already inside Finder when the decision matters. (b) Drive Finder with AppleScript—hosted release
+  jobs should not depend on GUI state or automation permission. (c) Commit generated `.DS_Store` or
+  background binaries—reviewable settings plus a pinned built-in arrow avoid opaque source assets.
+  (d) Add a package installer or make Jarvis move itself—the app remains a single bundle and the
+  installation action remains explicit and owner-controlled.
+- **Supersedes in part:** 2026-08-16 — Distribution uses one drag-install DMG. Its artifact and trust
+  decisions stand; its deliberately uncurated Finder presentation does not.
+- **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
+  `scripts/dmg-settings.py`, `scripts/verify-dmg-layout.py`, `scripts/package-app.sh`,
+  `.github/workflows/release.yml`.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -146,8 +146,9 @@ Public docs disclose the current unsandboxed boundary, contribution and private-
 present, and the latest GitHub Release carries a Developer ID-signed, notarized Apple silicon app.
 The release workflow builds with the macOS 26 SDK while retaining a macOS 14.2 deployment target,
 then signs and notarizes one stable `Jarvis.dmg`, mounts that final image, and checks its two-item
-drag-install layout, Applications target, linked SDK, signature, ticket, and Gatekeeper result. The
-next release uploads that DMG as its only Jarvis-built asset and links to it directly; GitHub's
+drag-install surface plus its fixed icon view, large arrow, Applications target, linked SDK,
+signature, ticket, and Gatekeeper result. The next release uploads that DMG as its only Jarvis-built
+asset and links to it directly; GitHub's
 automatic source archives remain. The app bundle carries the Apache license plus third-party notices. Local builds
 use the independent `Jarvis Dev.app` / `com.jarvis.coach.dev` identity while releases retain
 `Jarvis.app` / `com.jarvis.coach`, so their TCC grants and preferences can coexist on one Mac. The
@@ -252,7 +253,7 @@ thin OS shell, verified by the smoke run.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 + classic VAD native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).
 - `scripts/build-app.sh` — the local self-signed `Jarvis Dev.app` build with an independent bundle id and TCC identity; its production plist source remains unchanged.
-- `.github/workflows/` + `scripts/package-app.sh` + `scripts/check-release-sdk.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then a macOS-26-SDK release-please Release PR → Developer ID-signed, notarized, stapled, mounted, layout/SDK/Gatekeeper-checked `Jarvis.dmg` with an Applications shortcut and bundled Apache and third-party notices; that DMG is the Release's only Jarvis-built asset ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
+- `.github/workflows/` + `scripts/package-app.sh` + `scripts/dmg-settings.py` + `scripts/verify-dmg-layout.py` + `scripts/check-release-sdk.sh` + `scripts/verify-release.sh` — hosted automation only: owner-gated development agents, the repository gate on pull requests, then a macOS-26-SDK release-please Release PR → Developer ID-signed, notarized, stapled, mounted, Finder-layout/SDK/Gatekeeper-checked `Jarvis.dmg` with a visible drag arrow, an Applications shortcut, and bundled Apache and third-party notices; that DMG is the Release's only Jarvis-built asset ([build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci)).
 - `AGENTS.md` + `.github/workflows/sync-shared-rules.yml` — project-specific agent guidance with a
   machine-managed shared-rules block that syncs weekly from `JINGBANZ/rules`; `CLAUDE.md` imports the
   same canonical file.


### PR DESCRIPTION
## Summary

- arrange the mounted DMG as a fixed 640×280 Finder icon view with Jarvis on the left, Applications on the right, and a large arrow between them
- install a hash-pinned release-only `dmgbuild` environment in CI while preserving the existing app and DMG signing, notarization, stapling, and Gatekeeper flow
- reject release artifacts whose final mounted Finder metadata, background, icon positions, hidden extension, or Applications target drift from the reviewed layout
- document the new release behavior and decision

## Why

The existing DMG contains the correct app and Applications shortcut, but their relationship is not visually explicit. Users can reasonably open Jarvis from the read-only image instead of installing it. This follows [Apple's documented disk-image packaging pattern](https://developer.apple.com/documentation/xcode/packaging-mac-software-for-distribution?changes=_7) while keeping release automation headless and deterministic.

## Validation

- `swift build && ./scripts/run-tests.sh` — passed, 754 tests in 89 suites
- focused Swift package build through XcodeBuildMCP — succeeded
- `./scripts/check-release-config.sh` — passed
- `shellcheck -e SC2016 scripts/package-app.sh scripts/verify-release.sh scripts/check-release-config.sh` — passed
- clean `pip install --require-hashes --requirement scripts/requirements-release.txt` — passed
- built and mounted an unsigned local DMG fixture; the structural verifier passed and visual inspection confirmed the Jarvis → Applications layout
- GitHub Actions `CI #502`, attempt 2 — passed; attempt 1 hit an existing ScreenCaptureRunner cancellation-race test and was retried without code changes

The Developer ID signing and Apple notarization path was not executed locally because it requires release credentials; the existing trust sequence remains enforced by the release workflow and its final-artifact verifier. No Jarvis capture or live app pipeline was run.