### PR TITLE
docs(readme): simplify setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,12 @@ session for an immediate, screen-aware hint.
 
 ## Install Jarvis
 
-**Requirements:** an Apple silicon Mac running macOS 14.2 or later. No developer tools are needed.
+Requires an Apple silicon Mac running macOS 14.2 or later. No developer tools are needed.
 
-[**Download Jarvis for Apple silicon (macOS 14.2+)**](https://github.com/JINGBANZ/jarvis/releases/latest/download/Jarvis.dmg)
+[**Download Jarvis**](https://github.com/JINGBANZ/jarvis/releases/latest/download/Jarvis.dmg)
 
-After installing, open Jarvis from **Applications**. It appears in the menu bar rather than the Dock.
-Allow Microphone access and, for screen-aware hints, Screen Recording when macOS prompts. From the
-menu-bar icon, open **Settings**, choose transcription and brain providers, add any credential those
-providers require, then select **Start Jarvis**. Allow System Audio Recording when Start requests it
-so Jarvis can hear the other side.
+Open Jarvis from **Applications**, configure its providers in **Settings**, then select **Start
+Jarvis**. macOS will request the permissions Jarvis needs.
 
 ## How it works
 
@@ -39,12 +36,9 @@ flowchart TD
     G["⌥⌘J<br/>Ask for a hint"] --> F
 ```
 
-The detailed loop and its design rationale live in the
-[architecture guide](./wiki/architecture.md).
+## Build from source
 
-## Developer quick start
-
-Building locally additionally requires Swift 6 and the macOS Command Line Tools.
+Requires Swift 6 and the macOS Command Line Tools.
 
 ```bash
 git clone https://github.com/JINGBANZ/jarvis.git
@@ -52,12 +46,12 @@ cd jarvis
 ./scripts/build-app.sh --run
 ```
 
-`--run` builds and launches `Jarvis Dev.app`, which has separate macOS permissions from an installed
-`Jarvis.app`. On first use, choose **Always Allow** for its signing key, then grant its capture permissions.
+See [Build and run](./wiki/build-and-run.md) for signing, permissions, and troubleshooting.
 
-For signing details, permission recovery, and other commands, see
-[Build and run](./wiki/build-and-run.md). Always launch the app through the build script or `open`,
-not by running its bare executable.
+## Project links
+
+[Wiki](./wiki/index.md) · [Contributing](./CONTRIBUTING.md) · [Security](./SECURITY.md) ·
+[License](./LICENSE) · [Third-party notices](./THIRD_PARTY_NOTICES.md)
 
 ## Privacy
 
@@ -68,20 +62,3 @@ not by running its bare executable.
   OpenAI coaching requests currently enable server-side storage for debugging.
 
 See [Privacy and security](./wiki/sandbox.md) for the complete egress and retention model.
-
-## Learn more
-
-Start at the [wiki index](./wiki/index.md), or jump directly to:
-
-- [Architecture](./wiki/architecture.md) — design, components, and data flow
-- [Build and run](./wiki/build-and-run.md) — setup, signing, permissions, and troubleshooting
-- [Privacy and security](./wiki/sandbox.md) — local data, provider egress, retention, and isolation
-- [Project status](./wiki/status.md) — what is built and what comes next
-
-Contributions are welcome; read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening a pull request.
-Report security issues through the private process in [SECURITY.md](./SECURITY.md).
-
-## License
-
-Jarvis is licensed under the [Apache License 2.0](./LICENSE). Bundled third-party components are
-listed in [THIRD_PARTY_NOTICES.md](./THIRD_PARTY_NOTICES.md).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ session for an immediate, screen-aware hint.
 
 ## Install Jarvis
 
-Requires an Apple silicon Mac running macOS 14.2 or later. No developer tools are needed.
+Requires an Apple silicon Mac running macOS 14.2 or later.
 
 [**Download Jarvis**](https://github.com/JINGBANZ/jarvis/releases/latest/download/Jarvis.dmg)
 
@@ -36,7 +36,7 @@ flowchart TD
     G["⌥⌘J<br/>Ask for a hint"] --> F
 ```
 
-## Build from source
+## Developer quick start
 
 Requires Swift 6 and the macOS Command Line Tools.
 


### PR DESCRIPTION
## Summary

- reduce the install path to requirements, download, first-run setup, and automatic permission prompts
- shorten the Developer quick start and route signing or permission recovery to the wiki
- replace the detailed documentation map with compact project links and leave Privacy as the final section

## Impact

The README drops from 87 lines and 525 words to 64 lines and 331 words. The product positioning, consent and security warning, behavior diagram, and privacy disclosures remain unchanged.

## Validation

- `swift build && ./scripts/run-tests.sh` — passed; 757 tests across 89 suites, with the opt-in live capture test skipped as expected
- all 7 local README links resolve
- `git diff --check`