### PR TITLE
fix(release): preserve signed app integrity

### DIFF
--- a/scripts/check-release-config.sh
+++ b/scripts/check-release-config.sh
@@ -72,6 +72,13 @@ if ! /usr/bin/grep -Fq 'symlinks = {"Applications": "/Applications"}' "$dmg_sett
   echo "Release DMG settings must preserve the reviewed arrow-and-drop-target layout." >&2
   exit 1
 fi
+# dmgbuild implements extension hiding with SetFile -a E, which attaches com.apple.FinderInfo to
+# the signed app. Strict code-signature verification rejects that metadata after the DMG is mounted.
+if /usr/bin/grep -Fq 'hide_extensions' "$dmg_settings" \
+    || /usr/bin/grep -Fq 'com.apple.FinderInfo' "$dmg_layout_guard"; then
+  echo "Release DMG layout must not attach FinderInfo metadata to the signed app." >&2
+  exit 1
+fi
 if ! /usr/bin/grep -Fq -- '--only-binary=:all:' "$release_requirements" \
     || ! /usr/bin/grep -Fq 'dmgbuild==1.6.7' "$release_requirements" \
     || ! /usr/bin/grep -Fq -- '--require-hashes' "$workflow" \
@@ -112,6 +119,8 @@ if ! /usr/bin/grep -Fq 'hdiutil attach "$DMG" -readonly -nobrowse -mountpoint "$
     || ! /usr/bin/grep -Fq '"$(readlink "$APPLICATIONS_LINK")" != "/Applications"' \
       "$verify_script" \
     || ! /usr/bin/grep -Fq '"$DMGBUILD_PYTHON" scripts/verify-dmg-layout.py "$MOUNT_POINT"' \
+      "$verify_script" \
+    || ! /usr/bin/grep -Fq 'codesign --verify --strict --verbose=2 "$EXTRACTED_APP"' \
       "$verify_script" \
     || ! /usr/bin/grep -Fq 'syspolicy_check distribution "$EXTRACTED_APP" --verbose' \
       "$verify_script"; then

--- a/scripts/dmg-settings.py
+++ b/scripts/dmg-settings.py
@@ -17,7 +17,6 @@ if application.name != APP_NAME or application.is_symlink() or not application.i
 # Finder metadata and bundled arrow directly, so this layout is deterministic without a GUI session.
 files = [(str(application), APP_NAME)]
 symlinks = {"Applications": "/Applications"}
-hide_extensions = [APP_NAME]
 
 format = "UDZO"
 filesystem = "HFS+"

--- a/scripts/verify-dmg-layout.py
+++ b/scripts/verify-dmg-layout.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import struct
-import subprocess
 import sys
 from pathlib import Path
 
@@ -18,7 +17,6 @@ EXPECTED_ICON_LOCATIONS = {
     APPLICATIONS_NAME: (500, 120),
 }
 EXPECTED_WINDOW_BOUNDS = "{{100, 100}, {640, 280}}"
-FINDER_EXTENSION_HIDDEN = 0x0010
 
 
 def fail(message: str) -> None:
@@ -135,21 +133,6 @@ def main() -> None:
                 expected_location,
                 f"Finder position for {filename}",
             )
-
-    try:
-        finder_info_hex = subprocess.check_output(
-            ["/usr/bin/xattr", "-px", "com.apple.FinderInfo", mount_point / APP_NAME],
-            stderr=subprocess.DEVNULL,
-            text=True,
-        )
-        finder_info = bytes.fromhex(finder_info_hex)
-    except (OSError, subprocess.CalledProcessError, ValueError):
-        fail("Jarvis.app is missing its Finder presentation metadata")
-    if len(finder_info) < 10:
-        fail("Jarvis.app has incomplete Finder presentation metadata")
-    finder_flags = int.from_bytes(finder_info[8:10], byteorder="big")
-    if finder_flags & FINDER_EXTENSION_HIDDEN == 0:
-        fail("Finder metadata must display the application as Jarvis without the .app extension")
 
     print("Disk image Finder layout passed.")
 

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -67,16 +67,17 @@ requires for microphone capture. It submits a temporary zip of that app to Apple
 staples and validates the app's ticket, then uses the hash-pinned release-only `dmgbuild` tool to
 place the stapled app beside an `Applications` shortcut in `Jarvis.dmg`. The mounted Finder window is
 a fixed icon view: Jarvis on the left, Applications on the right, and a large arrow between them,
-with the extension and window chrome hidden. `dmgbuild` writes that metadata directly rather than
-automating Finder, so the hosted runner does not need a GUI session. The script signs and notarizes
-the outer disk image separately, then staples the container's ticket to the exact file users
-download. Both layers therefore remain verifiable offline.
+with the window chrome hidden. `dmgbuild` writes that layout metadata directly rather than automating
+Finder, so the hosted runner does not need a GUI session. It deliberately leaves the signed app free
+of FinderInfo extended attributes, which strict code-signature verification rejects. The script signs
+and notarizes the outer disk image separately, then staples the container's ticket to the exact file
+users download. Both layers therefore remain verifiable offline.
 
 The script passes that final DMG to `scripts/verify-release.sh`, which verifies the disk image and its
 ticket, mounts it read-only, and requires exactly the two visible install targets plus the hidden
 Finder metadata and arrow background. `scripts/verify-dmg-layout.py` reads the final `.DS_Store` and
 checks the icon view, window size, chrome, icon size and positions, background link and digest, and
-hidden `.app` extension. Release verification also checks the Applications target, mounted app
+Applications target position. Release verification also checks the Applications target, mounted app
 version, arm64 architecture, linked macOS 26-or-newer SDK, notices, strict code signature, and
 Gatekeeper policy result before detaching the image. The same SDK guard runs immediately after the
 release build, before signing or notarization; the pre-container app is not accepted as a proxy for

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1786,6 +1786,32 @@
   installation action remains explicit and owner-controlled.
 - **Supersedes in part:** 2026-08-16 — Distribution uses one drag-install DMG. Its artifact and trust
   decisions stand; its deliberately uncurated Finder presentation does not.
+- **Superseded in part by:** 2026-08-17 — DMG layout does not mutate the signed app. The fixed icon
+  view, arrow, Applications shortcut, and headless layout generation stand; forced extension hiding
+  and its FinderInfo validation do not.
 - **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
   `scripts/dmg-settings.py`, `scripts/verify-dmg-layout.py`, `scripts/package-app.sh`,
   `.github/workflows/release.yml`.
+
+### 2026-08-17 — DMG layout does not mutate the signed app
+
+- **Chose:** Keep the guided Finder window, but do not force-hide the `Jarvis.app` extension or add
+  any FinderInfo extended attribute to the signed bundle. Keep strict signature verification of the
+  mounted app and make the release configuration guard reject both the extension-hiding setting and
+  a verifier that depends on `com.apple.FinderInfo`.
+- **Why:** The v0.1.6 release proved the two requirements incompatible. `dmgbuild` implements forced
+  extension hiding with `SetFile -a E` after the stapled app enters the image, which attaches
+  `com.apple.FinderInfo`; the final `codesign --verify --strict` then correctly rejects the exact app
+  users would install. Both app and DMG notarization had succeeded, so weakening final verification
+  would publish an artifact whose embedded bundle no longer satisfies the signing contract.
+- **Rejected:** (a) Remove or relax strict signature verification—the invalid downloadable artifact
+  is the defect, not the guard. (b) Add a post-layout re-sign and re-notarization cycle—it creates a
+  second app trust path solely for cosmetic metadata, which must still be absent when strict
+  verification runs. (c) Drop the guided layout—the arrow, icon positions, and Applications shortcut
+  do not mutate the app and remain useful. (d) Add a second packaging implementation only to hide the
+  extension—the small cosmetic difference does not justify another trust path.
+- **Supersedes in part:** 2026-08-17 — DMG makes the drag-install gesture explicit. Its guided layout
+  stands; forced extension hiding and its validation do not.
+- **Detail:** [build-and-run.md → Distribution](./build-and-run.md#distribution--signed-notarized-releases-from-ci),
+  `scripts/dmg-settings.py`, `scripts/verify-dmg-layout.py`, `scripts/check-release-config.sh`,
+  `scripts/verify-release.sh`.


### PR DESCRIPTION
## Summary

- stop `dmgbuild` from attaching FinderInfo metadata to the signed app
- preserve the guided DMG window, arrow, icon positions, and Applications shortcut
- retain strict mounted-app verification and add a static regression guard
- align the distribution runbook and decision record with the signing boundary

## Root cause

The v0.1.6 release job notarized and stapled both the app and DMG successfully, then failed while verifying the mounted app. `hide_extensions = [APP_NAME]` made `dmgbuild` run `SetFile -a E`, which added `com.apple.FinderInfo` after the signed app entered the image. The final `codesign --verify --strict` correctly rejected that downloadable bundle.

Failed job: https://github.com/JINGBANZ/jarvis/actions/runs/32030405578/job/95388970767

## User-visible tradeoff

Users who enable Finder filename extensions may see `Jarvis.app`. The drag-install layout and trust checks remain unchanged.

## Validation

- regression guard reproduced the old configuration failure before the fix
- `./scripts/check-release-config.sh`
- `bash -n scripts/check-release-config.sh`
- Python compilation checks for both DMG scripts
- `swift build && ./scripts/run-tests.sh` — 757 tests in 89 suites passed
