### PR TITLE
fix(release): allow framework symlinks when cleaning dmg staging

### DIFF
--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -132,8 +132,22 @@ cleanup_dmg_stage() {
   if [[ -n "${DMG_STAGE:-}" && -n "${DMG_STAGE_PREFIX:-}" \
         && "$DMG_STAGE" == "$DMG_STAGE_PREFIX"* && -d "$DMG_STAGE" \
         && ! -L "$DMG_STAGE" ]]; then
-    if find "$DMG_STAGE" -type l -print -quit | grep -q .; then
-      echo "error: refusing to clean disk-image staging with an unexpected symbolic link" >&2
+    # A versioned framework is built out of relative symlinks (Versions/Current plus the aliases
+    # beside it), so the staged app legitimately contains them. What must never appear is a link
+    # resolving outside the staging directory — the only way this cleanup could reach anything else.
+    # A dangling link resolves to nothing and is treated as escaping, so the check fails closed.
+    stage_real="$(cd "$DMG_STAGE" && pwd -P)"
+    escaping_links=""
+    while IFS= read -r link; do
+      target="$(cd "$(dirname "$link")" 2>/dev/null && realpath "$(readlink "$link")" 2>/dev/null)" || true
+      case "$target" in
+        "$stage_real"/*) ;;
+        *) escaping_links="$escaping_links$link"$'\n' ;;
+      esac
+    done < <(find "$DMG_STAGE" -type l)
+    if [ -n "$escaping_links" ]; then
+      echo "error: refusing to clean disk-image staging with a symbolic link outside it:" >&2
+      printf '%s' "$escaping_links" >&2
       exit_code=1
     else
       rm -rf -- "$DMG_STAGE"


### PR DESCRIPTION
The v0.1.8 publish failed. It got all the way through — built, signed, notarized, stapled, and passed final release verification — then failed in `package-app.sh`'s cleanup trap:

```
✅ Jarvis.dmg is notarized and ready to distribute (Apple silicon, macOS 14.2+)
error: refusing to clean disk-image staging with an unexpected symbolic link
```

## Cause

The trap refused to `rm -rf` the staging directory if it contained **any** symbolic link. That assumption held while the bundle was a single statically-linked executable with no nested code. It stopped holding in #177, which embeds `Sparkle.framework` — a *versioned* framework built out of nine relative symlinks (`Versions/Current`, plus the `Sparkle`/`Resources`/`Headers`/`Modules`/`Autoupdate`/`Updater.app` aliases beside it).

A regression from the Sparkle work, not a pre-existing bug.

## Fix

Reject only links that resolve **outside** the staging directory — the condition the guard actually exists to catch — and name the offending link when refusing. A dangling link resolves to nothing and is still treated as escaping, so the check continues to fail closed.

## Verification

Exercised the guard logic against a real staged bundle, both ways:

```
case 1 (framework symlinks only), links=9   -> CLEAN
case 2 (plus a link to /etc)                -> REFUSE
  offending: .../Jarvis.app/escape
```

Gate green: `swift build && ./scripts/run-tests.sh` → exit 0, 757 tests in 89 suites.

## State left by the failed run

`v0.1.8` is a **draft with no assets** and `v0.1.7` is still `Latest`, so no user is affected and no partial artifact was published.

Note that the run failed *before* the appcast step, so the update-feed signing path — the `SUPublicEDKey` match guard and `sign_update` — has still never executed in CI. The next release is its first exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)