### PR TITLE
fix(release): remove sparkle's top-level xpc services alias

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -77,7 +77,8 @@ cp "$BIN_PATH" "$APP/Contents/MacOS/$BIN_NAME"
 # Sparkle is linked dynamically, so the framework must be embedded even though the development
 # bundle has no update feed — without it dyld cannot start the app at all.
 ditto "$(dirname "$BIN_PATH")/Sparkle.framework" "$APP/Contents/Frameworks/Sparkle.framework"
-rm -rf "$APP/Contents/Frameworks/Sparkle.framework/Versions/Current/XPCServices"
+rm -rf "$APP/Contents/Frameworks/Sparkle.framework/Versions/Current/XPCServices" \
+       "$APP/Contents/Frameworks/Sparkle.framework/XPCServices"
 cp Resources/Info.plist "$APP/Contents/Info.plist"
 cp Resources/Jarvis.icns "$APP/Contents/Resources/Jarvis.icns"
 # Resources/Info.plist remains the production source of truth. Override only the identity fields in

--- a/scripts/package-app.sh
+++ b/scripts/package-app.sh
@@ -95,8 +95,10 @@ cp LICENSE THIRD_PARTY_NOTICES.md "$APP/Contents/Resources/"
 SPARKLE="$APP/Contents/Frameworks/Sparkle.framework"
 ditto "$(dirname "$BIN_PATH")/Sparkle.framework" "$SPARKLE"
 # Sparkle's XPC services exist only to install updates from inside an App Sandbox. Jarvis is not
-# sandboxed, so shipping them would notarize and distribute code that can never run.
-rm -rf "$SPARKLE/Versions/Current/XPCServices"
+# sandboxed, so shipping them would notarize and distribute code that can never run. A versioned
+# framework exposes each versioned directory through a top-level alias, so the alias goes too —
+# leaving it behind would ship a symlink pointing at something no longer there.
+rm -rf "$SPARKLE/Versions/Current/XPCServices" "$SPARKLE/XPCServices"
 
 echo "▶ signing (hardened runtime + timestamp)"
 # Sparkle brings the bundle's only nested code, and codesign seals inner code before outer: the


### PR DESCRIPTION
The v0.1.9 publish failed in the same step as v0.1.8, but for a different reason. The staging-cleanup guard from #179 refused, naming the offender this time:

```
✅ Jarvis.dmg is notarized and ready to distribute (Apple silicon, macOS 14.2+)
error: refusing to clean disk-image staging with a symbolic link outside it:
/Users/runner/.../Jarvis.app/Contents/Frameworks/Sparkle.framework/XPCServices
```

## Cause

That link was **dangling**, not escaping. A versioned framework exposes each versioned directory through a top-level alias, so dropping Sparkle's sandbox-only XPC services removed `Versions/B/XPCServices` while leaving `Sparkle.framework/XPCServices -> Versions/Current/XPCServices` pointing at nothing.

The consequence goes beyond cleanup: **both signed bundles published so far contained a broken symlink**, and notarization accepted them. The guard added in #179 is what surfaced it — it treats a dangling link as escaping and failed closed on a genuine packaging defect.

Fixed in release packaging and in the development build, which had the same bug.

## Verification

Reproduced the dangling link, then verified the fix by assembling a real bundle through the same steps `package-app.sh` uses, signing it inside-out, and running the actual cleanup guard against a staged copy:

```
1. dangling symlinks in bundle                             none
2. XPCServices removed (both paths)                        yes
3. codesign --verify --strict --deep                       pass
4. cleanup guard on staged bundle                          cleans
```

Also confirmed the dev app still launches, so dyld resolves the framework without the alias.

Separately, the appcast step has never executed in CI (both failures happened before it). Exercised `generate-appcast.sh` locally in the exact shape CI produces — the secret expanded into an env var **with its trailing newline** — since a mishandled newline would make the new `SUPublicEDKey` guard reject the correct key:

```
✅ appcast.xml describes Jarvis 0.1.8
<enclosure url=".../releases/download/v0.1.8/Jarvis.dmg" ... sparkle:edSignature="..." />
```

Gate green: `swift build && ./scripts/run-tests.sh` → exit 0, 757 tests in 89 suites.

## Honest remaining risk

Notarization and Developer ID signing can only run in CI, and this changes what gets signed. Local signing uses the self-signed `Jarvis Dev` identity as a proxy — `--strict --deep` passes there, but Apple's notary service is the real judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)