### PR TITLE
test: make the ci race tests deterministic

### DIFF
--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -150,6 +150,11 @@ public final class CoachDriver: @unchecked Sendable {
         var alreadyExhausted = false
     }
 
+    /// Injected rather than reached for through `ActivityLog.shared` so each driver records into
+    /// its own log. The activity log is process-wide state: with a singleton, any two drivers alive
+    /// at once — which is every parallel test — append to whichever log happens to be enabled.
+    private let activityLog: ActivityLog
+
     public init(
         config: Config,
         transcript: RollingTranscript,
@@ -159,8 +164,10 @@ public final class CoachDriver: @unchecked Sendable {
         clock: Clock,
         sessionStart: TimeInterval? = nil,
         coachingAttempts: (any CoachingAttemptAuditing)? = nil,
-        automaticAttemptDelay: AutomaticAttemptDelay? = nil
+        automaticAttemptDelay: AutomaticAttemptDelay? = nil,
+        activityLog: ActivityLog = .shared
     ) {
+        self.activityLog = activityLog
         self.config = config
         self.transcript = transcript
         self.configuredRoute = route
@@ -845,7 +852,7 @@ public final class CoachDriver: @unchecked Sendable {
                 case .retry(let failureCount, let advanced):
                     routeChanged = false
                     if !advanced {
-                        ActivityLog.shared.record(
+                        activityLog.record(
                             .coachingTurnFailed(provider: attempt.target.provider))
                     }
                     let policy = failure.disposition == .permanent
@@ -959,7 +966,7 @@ public final class CoachDriver: @unchecked Sendable {
         if reason == .manualHint && !work.manualHintPrepared {
             if let prompt = context.promptLine {
                 jlog("⌨️ hint shortcut — \(prompt)")
-                ActivityLog.shared.record(.manualHint(prompt: prompt))
+                activityLog.record(.manualHint(prompt: prompt))
             }
             let screen = self.screen
             let shot = await Self.captureScreen(using: screen)
@@ -969,7 +976,7 @@ public final class CoachDriver: @unchecked Sendable {
             }
             if let shot {
                 jlog("👁 looking at your screen")
-                ActivityLog.shared.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
+                activityLog.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
                 var observations: [ChatMessage] = [.userImage(shot.imageBase64)]
                 turnMessages.append(.userImage(shot.imageBase64))
                 if let text = shot.recognizedText {
@@ -981,7 +988,7 @@ public final class CoachDriver: @unchecked Sendable {
                 work.observations = observations
             } else {
                 jlog("👁 screenshot failed")
-                ActivityLog.shared.record(.screenViewFailed)
+                activityLog.record(.screenViewFailed)
                 work.observations = [
                     .user(JarvisPrompts.Coach.manualHintCaptureFailed),
                 ]
@@ -1085,7 +1092,7 @@ public final class CoachDriver: @unchecked Sendable {
                     }
                     if let shot {
                         jlog("👁 looking at your screen")
-                        ActivityLog.shared.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
+                        activityLog.record(.screenViewed(imageBase64JPEG: shot.imageBase64))
                         if let text = shot.recognizedText {
                             jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
                         }
@@ -1097,7 +1104,7 @@ public final class CoachDriver: @unchecked Sendable {
                         ]
                     } else {
                         jlog("👁 screenshot failed")
-                        ActivityLog.shared.record(.screenViewFailed)
+                        activityLog.record(.screenViewFailed)
                         work.observations = [
                             .user(JarvisPrompts.Coach.earlierCaptureFailed),
                         ]
@@ -1132,7 +1139,7 @@ public final class CoachDriver: @unchecked Sendable {
                         return .cancelled
                     }
                     jlog("💬 \(lines.joined(separator: " "))")
-                    ActivityLog.shared.record(.tip(lines: lines))
+                    activityLog.record(.tip(lines: lines))
                     overlay.render(
                         lines,
                         perLineSeconds: lines.map {
@@ -1153,7 +1160,7 @@ public final class CoachDriver: @unchecked Sendable {
                         return .cancelled
                     }
                     jlog("… nothing useful to add, staying silent")
-                    ActivityLog.shared.record(.stayedSilent)
+                    activityLog.record(.stayedSilent)
                     commitIfWorthKeeping(turnMessages, deltaText: substantiveDeltaText)
                     commitTranscript(through: delta.upTo)
                     return .completed(.silentByModel)

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -60,7 +60,9 @@ public final class CoachDriver: @unchecked Sendable {
         let transcriptBoundary: Int?
     }
 
-    private struct AttemptBrain {
+    // Module-visible only because `BrainSelectionStep` carries one; see the note on the route
+    // delivery types below.
+    struct AttemptBrain {
         let routeRevision: UInt
         let routeTopologyRevision: UInt
         let routeIndex: Int
@@ -104,7 +106,8 @@ public final class CoachDriver: @unchecked Sendable {
         let result: AttemptResult
     }
 
-    private struct RouteExhaustionDelivery {
+    // Module-visible only because `BrainSelectionStep` carries one; see the note below.
+    struct RouteExhaustionDelivery {
         let generation: UInt
         let topologyRevision: UInt
         let target: BrainTarget
@@ -114,23 +117,31 @@ public final class CoachDriver: @unchecked Sendable {
         let callback: (@MainActor @Sendable (BrainTarget, BrainFailure) -> Void)?
     }
 
+    // Committing a route notice and delivering it are deliberately separate phases: the commit
+    // captures the callback under `stateLock`, and the delivery replays that captured callback
+    // after crossing to the main actor, so a client refresh in between can neither drop nor
+    // redirect it. The two phases and their delivery types are module-visible rather than private
+    // so a test can drive them in sequence. Through the public async API they are adjacent within
+    // one task with nothing observable in between, which leaves a test only able to guess when the
+    // commit landed — a race that no amount of waiting closes.
+
     /// A route-health notice committed under the lock and consumed once after crossing to the main
     /// actor. Client-only refreshes preserve it; an explicit topology edit supersedes it.
-    private struct RouteSkipDelivery {
+    struct RouteSkipDelivery {
         let topologyRevision: UInt
         let target: BrainTarget
         let callback: (@MainActor @Sendable (BrainTarget) -> Void)?
     }
 
     /// The paired target transition committed when the next constructible target is selected.
-    private struct RouteAdvanceDelivery {
+    struct RouteAdvanceDelivery {
         let topologyRevision: UInt
         let previous: BrainTarget
         let current: BrainTarget
         let callback: (@MainActor @Sendable (BrainTarget, BrainTarget) -> Void)?
     }
 
-    private struct BrainSelectionStep {
+    struct BrainSelectionStep {
         var selected: AttemptBrain? = nil
         var advanced: RouteAdvanceDelivery? = nil
         var skipped: RouteSkipDelivery? = nil
@@ -523,7 +534,7 @@ public final class CoachDriver: @unchecked Sendable {
         }
     }
 
-    private func takeBrainSelectionStep() -> BrainSelectionStep {
+    func takeBrainSelectionStep() -> BrainSelectionStep {
         stateLock.lock()
         defer { stateLock.unlock() }
         guard !routeIsExhausted else {
@@ -711,7 +722,7 @@ public final class CoachDriver: @unchecked Sendable {
         }
     }
 
-    private func deliverRouteSkip(_ delivery: RouteSkipDelivery) async {
+    func deliverRouteSkip(_ delivery: RouteSkipDelivery) async {
         guard let callback = delivery.callback else { return }
         await MainActor.run {
             guard isCurrentRouteTopologyRevision(delivery.topologyRevision) else {
@@ -722,7 +733,7 @@ public final class CoachDriver: @unchecked Sendable {
         }
     }
 
-    private func deliverRouteAdvance(_ delivery: RouteAdvanceDelivery) async {
+    func deliverRouteAdvance(_ delivery: RouteAdvanceDelivery) async {
         guard let callback = delivery.callback else { return }
         await MainActor.run {
             guard isCurrentRouteTopologyRevision(delivery.topologyRevision) else {

--- a/Sources/JarvisCore/Screen/ScreenCaptureRunner.swift
+++ b/Sources/JarvisCore/Screen/ScreenCaptureRunner.swift
@@ -20,7 +20,11 @@ public final class ScreenCaptureRunner: @unchecked Sendable {
 
     /// `@unchecked Sendable` is justified because `lock` guards `started`, `finished`, `cancelled`,
     /// and `identity` — the whole mutable process lifecycle this command owns.
-    private final class Command: @unchecked Sendable {
+    // Module-visible rather than private so the cancel-after-exit contract below can be driven
+    // directly. Through `capture(arguments:)` that state is only reachable inside the window where
+    // the helper has exited and the transient JPEG is still being read and deleted, which a test
+    // can aim at but never be sure of entering.
+    final class Command: @unchecked Sendable {
         enum Result {
             case exited(Int32)
             case failed

--- a/Sources/JarvisCore/Transcription/TranscriptionCoachingCoordinator.swift
+++ b/Sources/JarvisCore/Transcription/TranscriptionCoachingCoordinator.swift
@@ -14,6 +14,9 @@ public final class TranscriptionCoachingCoordinator: @unchecked Sendable {
     private let onTurnEnd: @Sendable (_ transcriptBoundary: Int) -> Void
     private let onSilence: @Sendable (TimeInterval) -> Void
     private let onTranscriptionWorkChanged: @Sendable (Bool) -> Void
+    /// Injected for the same reason as `CoachDriver`'s: heard speech must land in this session's
+    /// log rather than whichever one is globally enabled.
+    private let activityLog: ActivityLog
 
     private let lock = NSLock()
     private let pending = UtteranceBuffer()
@@ -38,9 +41,11 @@ public final class TranscriptionCoachingCoordinator: @unchecked Sendable {
         silenceEnabled: Bool,
         onTurnEnd: @escaping @Sendable (_ transcriptBoundary: Int) -> Void,
         onSilence: @escaping @Sendable (TimeInterval) -> Void,
-        onTranscriptionWorkChanged: @escaping @Sendable (Bool) -> Void
+        onTranscriptionWorkChanged: @escaping @Sendable (Bool) -> Void,
+        activityLog: ActivityLog = .shared
     ) {
         precondition(transcriptBatchingWindow >= 0 && transcriptBatchingWindow.isFinite)
+        self.activityLog = activityLog
         self.speaker = speaker
         self.transcript = transcript
         self.clock = clock
@@ -111,7 +116,7 @@ public final class TranscriptionCoachingCoordinator: @unchecked Sendable {
         let generation = generation
         // Activity and model context share the same speech-time chronology. Transcript completion
         // time remains visible in debug, but it must not decide conversation order.
-        ActivityLog.shared.record(
+        activityLog.record(
             .heard(speaker: speaker, text: text),
             at: Date(timeIntervalSince1970: sessionStart + at))
         jlog("🗣 heard (\(speaker.rawValue)): \"\(text)\" (\(source))")

--- a/Tests/JarvisCoreTests/Benchmark/TranscriptionBenchmarkAbortMonitorTests.swift
+++ b/Tests/JarvisCoreTests/Benchmark/TranscriptionBenchmarkAbortMonitorTests.swift
@@ -9,32 +9,28 @@ struct TranscriptionBenchmarkAbortMonitorTests {
         let directory = ActivityLogTests.tmp()
         defer { try? FileManager.default.removeItem(at: directory) }
         let marker = directory.appendingPathComponent("abort")
-        let setupFinished = SetupCompletionFlag()
-        let operation = Task {
+        // The operation ignores the cancellation the monitor sends it and stays outstanding until
+        // this test releases it, which is what makes the claim decidable by ordering alone. Racing
+        // a timed operation instead left the assertion measuring how promptly a loaded machine
+        // happened to schedule the abort rather than whether the abort waited for anything.
+        let setup = ManualSetupOperation()
+        defer { setup.release() }
+        let monitored = Task {
             try await TranscriptionBenchmarkAbortMonitor.run(
                 marker: marker,
                 pollInterval: .milliseconds(5)
             ) {
-                await withCheckedContinuation { continuation in
-                    DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
-                        setupFinished.set()
-                        continuation.resume(returning: "finished")
-                    }
-                }
+                await setup.run()
             }
         }
 
-        try await Task.sleep(for: .milliseconds(50))
+        await setup.waitUntilStarted()
         try Data().write(to: marker)
         do {
-            _ = try await operation.value
+            _ = try await monitored.value
             Issue.record("expected the abort marker to win the setup race")
         } catch TranscriptionBenchmarkAbortMonitor.Failure.aborted {
-            // Ordering, not wall clock: "did not wait for the operation" is exactly "returned while
-            // the operation was still outstanding". A loaded machine can delay this return by
-            // hundreds of milliseconds with the monitor never having waited on anything, which an
-            // elapsed-time budget misreads as a regression.
-            #expect(!setupFinished.isSet)
+            #expect(!setup.hasFinished)
         } catch {
             Issue.record("expected an aborted failure, got \(error)")
         }
@@ -55,10 +51,69 @@ struct TranscriptionBenchmarkAbortMonitorTests {
     }
 }
 
-/// `@unchecked Sendable` is safe because `lock` guards `completed`.
-private final class SetupCompletionFlag: @unchecked Sendable {
+/// Setup work that begins when the monitor runs it and finishes only when the test releases it,
+/// standing in for a non-cooperative operation such as a model download that ignores cancellation.
+/// `@unchecked Sendable` is safe because `lock` guards every stored property.
+private final class ManualSetupOperation: @unchecked Sendable {
     private let lock = NSLock()
-    private var completed = false
-    var isSet: Bool { lock.withLock { completed } }
-    func set() { lock.withLock { completed = true } }
+    private var startWaiter: CheckedContinuation<Void, Never>?
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+    private var didStart = false
+    private var didRelease = false
+    private var didFinish = false
+
+    var hasFinished: Bool { lock.withLock { didFinish } }
+
+    func run() async -> String {
+        reportStarted()
+        await waitForRelease()
+        lock.withLock { didFinish = true }
+        return "finished"
+    }
+
+    func waitUntilStarted() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let alreadyStarted: Bool = lock.withLock {
+                guard didStart else {
+                    startWaiter = continuation
+                    return false
+                }
+                return true
+            }
+            if alreadyStarted { continuation.resume() }
+        }
+    }
+
+    func release() {
+        let waiter: CheckedContinuation<Void, Never>? = lock.withLock {
+            didRelease = true
+            let waiting = releaseWaiter
+            releaseWaiter = nil
+            return waiting
+        }
+        waiter?.resume()
+    }
+
+    private func reportStarted() {
+        let waiter: CheckedContinuation<Void, Never>? = lock.withLock {
+            didStart = true
+            let waiting = startWaiter
+            startWaiter = nil
+            return waiting
+        }
+        waiter?.resume()
+    }
+
+    private func waitForRelease() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let alreadyReleased: Bool = lock.withLock {
+                guard didRelease else {
+                    releaseWaiter = continuation
+                    return false
+                }
+                return true
+            }
+            if alreadyReleased { continuation.resume() }
+        }
+    }
 }

--- a/Tests/JarvisCoreTests/Benchmark/TranscriptionBenchmarkAbortMonitorTests.swift
+++ b/Tests/JarvisCoreTests/Benchmark/TranscriptionBenchmarkAbortMonitorTests.swift
@@ -9,6 +9,7 @@ struct TranscriptionBenchmarkAbortMonitorTests {
         let directory = ActivityLogTests.tmp()
         defer { try? FileManager.default.removeItem(at: directory) }
         let marker = directory.appendingPathComponent("abort")
+        let setupFinished = SetupCompletionFlag()
         let operation = Task {
             try await TranscriptionBenchmarkAbortMonitor.run(
                 marker: marker,
@@ -16,6 +17,7 @@ struct TranscriptionBenchmarkAbortMonitorTests {
             ) {
                 await withCheckedContinuation { continuation in
                     DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+                        setupFinished.set()
                         continuation.resume(returning: "finished")
                     }
                 }
@@ -23,14 +25,16 @@ struct TranscriptionBenchmarkAbortMonitorTests {
         }
 
         try await Task.sleep(for: .milliseconds(50))
-        let abortStartedAt = ContinuousClock.now
         try Data().write(to: marker)
         do {
             _ = try await operation.value
             Issue.record("expected the abort marker to win the setup race")
         } catch TranscriptionBenchmarkAbortMonitor.Failure.aborted {
-            let elapsed = abortStartedAt.duration(to: .now)
-            #expect(elapsed < .milliseconds(500))
+            // Ordering, not wall clock: "did not wait for the operation" is exactly "returned while
+            // the operation was still outstanding". A loaded machine can delay this return by
+            // hundreds of milliseconds with the monitor never having waited on anything, which an
+            // elapsed-time budget misreads as a regression.
+            #expect(!setupFinished.isSet)
         } catch {
             Issue.record("expected an aborted failure, got \(error)")
         }
@@ -49,4 +53,12 @@ struct TranscriptionBenchmarkAbortMonitorTests {
 
         #expect(value == "prepared")
     }
+}
+
+/// `@unchecked Sendable` is safe because `lock` guards `completed`.
+private final class SetupCompletionFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completed = false
+    var isSet: Bool { lock.withLock { completed } }
+    func set() { lock.withLock { completed = true } }
 }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverContextMessageTests.swift
@@ -18,7 +18,8 @@ import Testing
                 ConfiguredBrainTarget(target: target, brain: brain),
             ]),
             screen: FakeScreen(), overlay: FakeOverlay(), clock: clock,
-            automaticAttemptDelay: { _ in }
+            automaticAttemptDelay: { _ in },
+            activityLog: ActivityLog()
         )
         return (driver, transcript)
     }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverManualHintTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverManualHintTests.swift
@@ -26,7 +26,8 @@ private final class FailingScreen: ScreenCapturing, @unchecked Sendable {
                 ConfiguredBrainTarget(target: target, brain: brain),
             ]),
             screen: screen, overlay: overlay, clock: clock,
-            automaticAttemptDelay: { _ in }
+            automaticAttemptDelay: { _ in },
+            activityLog: ActivityLog()
         )
         return (driver, transcript)
     }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -2372,11 +2372,15 @@ private func waitForSemaphore(_ semaphore: DispatchSemaphore) async {
     }
 }
 
-/// The main actor is deliberately blocked before the route task starts. Yielding here lets that task
-/// commit its lock-protected notice and park at the actor hop before the test refreshes clients.
+/// The main actor is deliberately blocked before the route task starts, so once that task reaches
+/// its delivery hop it parks there until the test releases it — a state that waiting longer can only
+/// help us reach. Yielding reschedules *this* task and never hands the route task any CPU of its
+/// own, so on a loaded machine the refresh below could land before the notice was even committed,
+/// and the delivery would then carry the refreshed callback instead of the original one. Sleeping
+/// gives the route task real scheduling opportunities rather than spinning through this one.
 private func allowPendingRouteDeliveryToReachMainActor() async {
-    for _ in 0..<1_000 {
-        await Task.yield()
+    for _ in 0..<300 {
+        try? await Task.sleep(for: .milliseconds(1))
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -1146,14 +1146,124 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(refreshedFallback.calls.count == 1)
     }
 
-    @Test func refreshingClientsCannotDropOrRedirectACommittedSkip() async {
+    /// Regression: a route notice belongs to the callback it was committed against. A client
+    /// refresh landing after the commit but before the delivery crosses to the main actor may
+    /// neither redirect the notice onto the replacement callback nor drop it.
+    ///
+    /// The commit and the delivery are driven directly because that is the only way to sit inside
+    /// that window. Under `handleTrigger` the two are adjacent within a single task with nothing
+    /// observable in between, so a test can only guess when the commit landed — and a guess that
+    /// lands early silently asserts nothing while a guess that lands late fails for no reason.
+    @Test func aCommittedSkipIsDeliveredToTheCallbackItWasCommittedAgainst() async throws {
+        let unavailableTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
+        let availableTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
+        let originalSkip = RouteTargetRecorder()
+        let refreshedSkip = RouteTargetRecorder()
+        let driver = CoachDriver(
+            config: .default,
+            transcript: RollingTranscript(),
+            route: ConfiguredBrainRoute(
+                targets: [
+                    ConfiguredBrainTarget(
+                        unavailable: unavailableTarget,
+                        detail: "Claude Code is signed out"),
+                    ConfiguredBrainTarget(
+                        target: availableTarget,
+                        brain: ScriptedBrain(script: [
+                            .init(toolCalls: [.staySilent(callId: "old-client")]),
+                        ])),
+                ],
+                onSkipped: { originalSkip.record($0) }),
+            screen: FakeScreen(),
+            overlay: FakeOverlay(),
+            clock: ManualClock(),
+            automaticAttemptDelay: { _ in })
+
+        let committed = try #require(driver.takeBrainSelectionStep().skipped)
+        #expect(driver.refreshBrainRouteClients(ConfiguredBrainRoute(
+            targets: [
+                ConfiguredBrainTarget(
+                    unavailable: unavailableTarget,
+                    detail: "Claude Code is still signed out"),
+                ConfiguredBrainTarget(
+                    target: availableTarget,
+                    brain: ScriptedBrain(script: [
+                        .init(toolCalls: [.staySilent(callId: "new-client")]),
+                    ])),
+            ],
+            onSkipped: { refreshedSkip.record($0) })))
+        await driver.deliverRouteSkip(committed)
+
+        #expect(originalSkip.targets == [unavailableTarget])
+        #expect(refreshedSkip.targets.isEmpty)
+    }
+
+    /// The paired transition commits the target the route left behind together with the callback
+    /// live at that moment, so the same refresh window must not redirect or drop it either.
+    @Test func aCommittedAdvanceIsDeliveredToTheCallbackItWasCommittedAgainst() async throws {
+        let unavailableTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
+        let availableTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
+        let originalAdvance = RouteTransitionRecorder()
+        let refreshedAdvance = RouteTransitionRecorder()
+        let driver = CoachDriver(
+            config: .default,
+            transcript: RollingTranscript(),
+            route: ConfiguredBrainRoute(
+                targets: [
+                    ConfiguredBrainTarget(
+                        unavailable: unavailableTarget,
+                        detail: "Claude Code is signed out"),
+                    ConfiguredBrainTarget(
+                        target: availableTarget,
+                        brain: ScriptedBrain(script: [
+                            .init(toolCalls: [.staySilent(callId: "old-client")]),
+                        ])),
+                ],
+                onAdvanced: { originalAdvance.record(from: $0, to: $1) }),
+            screen: FakeScreen(),
+            overlay: FakeOverlay(),
+            clock: ManualClock(),
+            automaticAttemptDelay: { _ in })
+
+        // The first step skips the unavailable head and remembers where the route came from; the
+        // second commits the transition onto the target that can actually run.
+        _ = driver.takeBrainSelectionStep()
+        let committed = try #require(driver.takeBrainSelectionStep().advanced)
+        #expect(driver.refreshBrainRouteClients(ConfiguredBrainRoute(
+            targets: [
+                ConfiguredBrainTarget(
+                    unavailable: unavailableTarget,
+                    detail: "Claude Code is still signed out"),
+                ConfiguredBrainTarget(
+                    target: availableTarget,
+                    brain: ScriptedBrain(script: [
+                        .init(toolCalls: [.staySilent(callId: "new-client")]),
+                    ])),
+            ],
+            onAdvanced: { refreshedAdvance.record(from: $0, to: $1) })))
+        await driver.deliverRouteAdvance(committed)
+
+        #expect(originalAdvance.events == [
+            .init(from: unavailableTarget, to: availableTarget),
+        ])
+        #expect(refreshedAdvance.events.isEmpty)
+    }
+
+    /// The other half of the contract, driven end to end: a refresh raised from inside the notice
+    /// itself must not repeat that notice on the replacement callback, and the attempt that
+    /// follows must run on the replacement client rather than the one the route started with.
+    @Test func refreshingClientsDuringASkipRetargetsOnlyTheFollowingAttempt() async {
         let unavailableTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
         let availableTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
         let originalAvailable = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "old-client")]),
         ])
+        let refreshedAvailable = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "new-client")]),
+        ])
         let originalSkip = RouteTargetRecorder()
         let refreshedSkip = RouteTargetRecorder()
+        let holder = CoachDriverHolder()
         let transcript = RollingTranscript()
         let driver = CoachDriver(
             config: .default,
@@ -1165,112 +1275,88 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                         detail: "Claude Code is signed out"),
                     ConfiguredBrainTarget(target: availableTarget, brain: originalAvailable),
                 ],
-                onSkipped: { originalSkip.record($0) }),
+                onSkipped: { target in
+                    originalSkip.record(target)
+                    holder.refreshClients(ConfiguredBrainRoute(
+                        targets: [
+                            ConfiguredBrainTarget(
+                                unavailable: unavailableTarget,
+                                detail: "Claude Code is still signed out"),
+                            ConfiguredBrainTarget(
+                                target: availableTarget,
+                                brain: refreshedAvailable),
+                        ],
+                        onSkipped: { refreshedSkip.record($0) }))
+                }),
             screen: FakeScreen(),
             overlay: FakeOverlay(),
             clock: ManualClock(),
             automaticAttemptDelay: { _ in })
+        holder.install(driver)
         transcript.append(.init(speaker: .me, text: "skip without losing the notice", at: 0))
 
-        let mainActorEntered = DispatchSemaphore(value: 0)
-        let releaseMainActor = DispatchSemaphore(value: 0)
-        let mainActorBlocker = Task { @MainActor in
-            blockMainActor(entered: mainActorEntered, release: releaseMainActor)
-        }
-        await waitForSemaphore(mainActorEntered)
-        async let outcome = driver.handleTrigger(.turnEnd)
-        await allowPendingRouteDeliveryToReachMainActor()
-
-        let refreshedAvailable = ScriptedBrain(script: [
-            .init(toolCalls: [.staySilent(callId: "new-client")]),
-        ])
-        #expect(driver.refreshBrainRouteClients(ConfiguredBrainRoute(
-            targets: [
-                ConfiguredBrainTarget(
-                    unavailable: unavailableTarget,
-                    detail: "Claude Code is still signed out"),
-                ConfiguredBrainTarget(target: availableTarget, brain: refreshedAvailable),
-            ],
-            onSkipped: { refreshedSkip.record($0) })))
-
-        releaseMainActor.signal()
-        await mainActorBlocker.value
-        #expect(await outcome == .silentByModel)
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
         #expect(originalSkip.targets == [unavailableTarget])
         #expect(refreshedSkip.targets.isEmpty)
         #expect(originalAvailable.calls.isEmpty)
         #expect(refreshedAvailable.calls.count == 1)
     }
 
-    @Test func refreshingClientsCannotDropOrRedirectACommittedAdvance() async {
-        let primaryTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
-        let fallbackTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
-        let responseGate = AsyncGate()
-        let originalPrimary = GatedThrowingBrain(
-            gate: responseGate,
-            error: BrainFailure(
-                disposition: .permanent,
-                detail: "primary permanently failed"))
-        let originalFallback = ScriptedBrain(script: [
-            .init(toolCalls: [.staySilent(callId: "old-fallback")]),
+    /// The same shape around a transition. The selection committed alongside the advance is stale
+    /// once the refresh bumps the route revision, so it must be discarded and re-taken against the
+    /// replacement client instead of running the client the route had already chosen.
+    @Test func refreshingClientsDuringAnAdvanceRetargetsOnlyTheFollowingAttempt() async {
+        let unavailableTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
+        let availableTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
+        let originalAvailable = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "old-client")]),
+        ])
+        let refreshedAvailable = ScriptedBrain(script: [
+            .init(toolCalls: [.staySilent(callId: "new-client")]),
         ])
         let originalAdvance = RouteTransitionRecorder()
         let refreshedAdvance = RouteTransitionRecorder()
+        let holder = CoachDriverHolder()
         let transcript = RollingTranscript()
         let driver = CoachDriver(
             config: .default,
             transcript: transcript,
             route: ConfiguredBrainRoute(
                 targets: [
-                    ConfiguredBrainTarget(target: primaryTarget, brain: originalPrimary),
-                    ConfiguredBrainTarget(target: fallbackTarget, brain: originalFallback),
+                    ConfiguredBrainTarget(
+                        unavailable: unavailableTarget,
+                        detail: "Claude Code is signed out"),
+                    ConfiguredBrainTarget(target: availableTarget, brain: originalAvailable),
                 ],
-                onAdvanced: {
-                    originalAdvance.record(from: $0, to: $1)
+                onAdvanced: { previous, current in
+                    originalAdvance.record(from: previous, to: current)
+                    holder.refreshClients(ConfiguredBrainRoute(
+                        targets: [
+                            ConfiguredBrainTarget(
+                                unavailable: unavailableTarget,
+                                detail: "Claude Code is still signed out"),
+                            ConfiguredBrainTarget(
+                                target: availableTarget,
+                                brain: refreshedAvailable),
+                        ],
+                        onAdvanced: { refreshedAdvance.record(from: $0, to: $1) }))
                 }),
             screen: FakeScreen(),
             overlay: FakeOverlay(),
             clock: ManualClock(),
             automaticAttemptDelay: { _ in })
+        holder.install(driver)
         transcript.append(.init(speaker: .me, text: "advance without losing the notice", at: 0))
 
-        async let outcome = driver.handleTrigger(.turnEnd)
-        await responseGate.waitUntilEntered()
-        let mainActorEntered = DispatchSemaphore(value: 0)
-        let releaseMainActor = DispatchSemaphore(value: 0)
-        let mainActorBlocker = Task { @MainActor in
-            blockMainActor(entered: mainActorEntered, release: releaseMainActor)
-        }
-        await waitForSemaphore(mainActorEntered)
-        await responseGate.release()
-        await allowPendingRouteDeliveryToReachMainActor()
-
-        let refreshedPrimary = ThrowingBrain(error: BrainFailure(
-            disposition: .permanent,
-            detail: "refreshed primary should not run"))
-        let refreshedFallback = ScriptedBrain(script: [
-            .init(toolCalls: [.staySilent(callId: "new-fallback")]),
-        ])
-        #expect(driver.refreshBrainRouteClients(ConfiguredBrainRoute(
-            targets: [
-                ConfiguredBrainTarget(target: primaryTarget, brain: refreshedPrimary),
-                ConfiguredBrainTarget(target: fallbackTarget, brain: refreshedFallback),
-            ],
-            onAdvanced: {
-                refreshedAdvance.record(from: $0, to: $1)
-            })))
-
-        releaseMainActor.signal()
-        await mainActorBlocker.value
-        #expect(await outcome == .silentByModel)
+        #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
         #expect(originalAdvance.events == [
-            .init(from: primaryTarget, to: fallbackTarget),
+            .init(from: unavailableTarget, to: availableTarget),
         ])
         #expect(refreshedAdvance.events.isEmpty)
-        #expect(originalFallback.calls.isEmpty)
-        #expect(refreshedPrimary.callCount == 0)
-        #expect(refreshedFallback.calls.count == 1)
+        #expect(originalAvailable.calls.isEmpty)
+        #expect(refreshedAvailable.calls.count == 1)
     }
+
 
     @Test func inFlightSuccessAcrossClientRefreshResetsTheFailureSequence() async {
         let primaryTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
@@ -2372,18 +2458,6 @@ private func waitForSemaphore(_ semaphore: DispatchSemaphore) async {
     }
 }
 
-/// The main actor is deliberately blocked before the route task starts, so once that task reaches
-/// its delivery hop it parks there until the test releases it — a state that waiting longer can only
-/// help us reach. Yielding reschedules *this* task and never hands the route task any CPU of its
-/// own, so on a loaded machine the refresh below could land before the notice was even committed,
-/// and the delivery would then carry the refreshed callback instead of the original one. Sleeping
-/// gives the route task real scheduling opportunities rather than spinning through this one.
-private func allowPendingRouteDeliveryToReachMainActor() async {
-    for _ in 0..<300 {
-        try? await Task.sleep(for: .milliseconds(1))
-    }
-}
-
 /// `@unchecked Sendable` is safe because `lock` guards the recorded route transitions.
 private final class RouteTransitionRecorder: @unchecked Sendable {
     struct Event: Equatable {
@@ -2431,6 +2505,10 @@ private final class CoachDriverHolder: @unchecked Sendable {
 
     func updateRoute(_ route: ConfiguredBrainRoute) {
         lock.withLock { driver }?.updateBrainRoute(route)
+    }
+
+    func refreshClients(_ route: ConfiguredBrainRoute) {
+        lock.withLock { driver }?.refreshBrainRouteClients(route)
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -171,11 +171,13 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 }
 
-// `.serialized`: the activity-log end-to-end tests drive the shared `ActivityLog` singleton.
-// Serializing the suite keeps their enable()/disable() calls from racing each other — they are the
-// only code that enables the shared log, so no other suite can collide.
-@Suite(.serialized) struct CoachDriverPipelineTests {
-    private func makeDriver(brain: BrainClient, brainProvider: BrainProvider? = nil,
+// Each test that reads activity owns the `ActivityLog` it hands its driver, so a snapshot holds
+// that test's rows and nothing else. Being the only suite that *enables* the shared log was never
+// enough on its own: every driver alive anywhere in the process appended to whichever log happened
+// to be enabled, so a peer suite's rows landed in these snapshots.
+@Suite struct CoachDriverPipelineTests {
+    private func makeDriver(activityLog: ActivityLog = ActivityLog(),
+                            brain: BrainClient, brainProvider: BrainProvider? = nil,
                             summarizer: BrainClient? = nil,
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
@@ -198,7 +200,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             config: config, transcript: transcript,
             route: route, screen: screen, overlay: overlay, clock: clock,
             coachingAttempts: coachingAttempts,
-            automaticAttemptDelay: automaticAttemptDelay
+            automaticAttemptDelay: automaticAttemptDelay,
+            activityLog: activityLog
         )
         return (driver, transcript)
     }
@@ -209,7 +212,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         overlay: OverlayRendering = FakeOverlay(),
         onAdvanced: (@Sendable (BrainTarget, BrainTarget) -> Void)? = nil,
         onSkipped: (@Sendable (BrainTarget) -> Void)? = nil,
-        onExhausted: (@MainActor @Sendable (BrainTarget, BrainFailure) -> Void)? = nil
+        onExhausted: (@MainActor @Sendable (BrainTarget, BrainFailure) -> Void)? = nil,
+        activityLog: ActivityLog = ActivityLog()
     ) -> (CoachDriver, RollingTranscript) {
         let transcript = RollingTranscript()
         let route = ConfiguredBrainRoute(
@@ -227,7 +231,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                 screen: screen,
                 overlay: overlay,
                 clock: ManualClock(),
-                automaticAttemptDelay: { _ in }),
+                automaticAttemptDelay: { _ in },
+                activityLog: activityLog),
             transcript)
     }
 
@@ -321,14 +326,14 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// the activity log as a genuine, owner-only JPEG rendered as a clickable thumbnail linked to
     /// the full image — the behaviour verified by hand, now automated against regressions.
     ///
-    /// This drives the shared `ActivityLog` singleton through the real typed activity-event path.
-    /// `disable()` in defer resets the singleton afterwards.
+    /// This drives a test-owned `ActivityLog` through the real typed activity-event path.
     @Test func screenshotLandsInActivityLogAsValidJpeg() async throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-e2e-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
-        ActivityLog.shared.enable(directory: dir)
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        activityLog.enable(directory: dir)
 
         let clock = ManualClock(now: 100)
         let brain = ScriptedBrain(script: [
@@ -339,20 +344,21 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                                              argumentsJSON: #"{"lines":["Watch the off-by-one there."]}"#)]),
         ])
         let screen = FakeScreen(payload: TestFixtures.tinyJpegBase64)   // a real JPEG, like screencapture
-        let (driver, transcript) = makeDriver(brain: brain, screen: screen, clock: clock)
+        let (driver, transcript) = makeDriver(
+            activityLog: activityLog, brain: brain, screen: screen, clock: clock)
         transcript.append(.init(speaker: .me, text: "here's my solution", at: 100))
 
         await driver.handleTrigger(.turnEnd)
 
         // attach() runs on the activity log's serial queue (a sync barrier after the async record()
         // calls), so everything is persisted before we assert.
-        _ = ActivityLog.shared.attach { _ in }
+        _ = activityLog.attach { _ in }
         let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
         #expect(jsonl.contains("looking at your screen"))   // the capture line
         #expect(jsonl.contains("shot-"))                     // line references the saved screenshot
 
-        // Find OUR screenshot by exact byte-match to the fixture (not just "first valid JPEG"), so a
-        // peer test sharing the singleton can't be mistaken for ours. This proves the capture
+        // Match the fixture byte for byte rather than taking the first valid JPEG, so this asserts
+        // on the image the capture actually persisted. This proves the capture
         // round-tripped to disk unchanged. Then assert it's owner-only.
         let shots = try FileManager.default.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
             .filter { $0.lastPathComponent.hasPrefix("shot-") && $0.pathExtension == "jpg" }
@@ -368,23 +374,24 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     /// A hotkey trigger leaves no "🗣 heard:" transcript line (the user pressed a key, didn't speak),
     /// so the manual hint must record its OWN activity line — including the synthetic message we
     /// pre-fill as the user's request — so the viewer shows what the shortcut sent to the brain.
-    /// Drives the shared `ActivityLog` like the screenshot e2e above; the suite is `.serialized` so
-    /// the shared-log tests don't race.
+    /// Drives a test-owned `ActivityLog` like the screenshot e2e above.
     @Test func manualHintTriggerAndPrefilledMessageLandInActivityLog() async throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-hintlog-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
-        ActivityLog.shared.enable(directory: dir)
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        activityLog.enable(directory: dir)
 
         let clock = ManualClock(now: 100)
         let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["use a hash map"])])])
-        let (driver, transcript) = makeDriver(brain: brain, clock: clock)
+        let (driver, transcript) = makeDriver(
+            activityLog: activityLog, brain: brain, clock: clock)
         transcript.append(.init(speaker: .me, text: "stuck on two-sum", at: 100))
 
         await driver.handleTrigger(.manualHint)
 
-        _ = ActivityLog.shared.attach { _ in }   // sync barrier: all async record()s have landed
+        _ = activityLog.attach { _ in }   // sync barrier: all async record()s have landed
         let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
         // The trigger marker carries the pre-filled synthetic request ("…pressed the hint shortcut…").
         #expect(jsonl.contains("hint shortcut"))
@@ -396,18 +403,20 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-activity-boundary-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
         JarvisLog.enableFileLogging(directory: dir)
-        ActivityLog.shared.enable(directory: dir)
+        activityLog.enable(directory: dir)
 
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.speak(callId: "s", lines: ["activity-boundary-tip-417"])])
         ])
-        let (driver, _) = makeDriver(brain: brain, clock: ManualClock(now: 417))
+        let (driver, _) = makeDriver(
+            activityLog: activityLog, brain: brain, clock: ManualClock(now: 417))
 
         #expect(await driver.handleTrigger(.silence(secondsQuiet: 417)) == .spoke)
 
-        _ = ActivityLog.shared.attach { _ in }   // sync barrier: all async records have landed
+        _ = activityLog.attach { _ in }   // sync barrier: all async records have landed
         let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
         #expect(jsonl.contains("activity-boundary-tip-417"))
         #expect(!jsonl.contains("quiet for 417s"))
@@ -424,23 +433,24 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             .appendingPathComponent(
                 "jarvis-attempt-failure-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
-        ActivityLog.shared.enable(directory: dir)
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        activityLog.enable(directory: dir)
 
         let brain = ScriptedThrowBrain(script: [
             nil,
             nil,
             .init(toolCalls: [.speak(callId: "recovered", lines: ["recovered coaching"])]),
         ])
-        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        let (driver, transcript) = makeDriver(
+            activityLog: activityLog, brain: brain, clock: ManualClock(now: 0))
         transcript.append(.init(speaker: .me, text: "keep listening after failures", at: 0))
 
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
 
-        let snapshot = ActivityLog.shared.attach { _ in }
-        // Activity is process-global: another suite can emit while this test owns the enabled log.
-        // Anchor on our unique recovery, then inspect the two relevant failures before it instead of
-        // assuming the global snapshot has only our rows.
+        let snapshot = activityLog.attach { _ in }
+        // Anchor on the recovery row and inspect the two failures before it: this asserts the
+        // ordering around the recovery rather than the log's total length.
         let recoveryIndex = try #require(
             snapshot.rows.firstIndex { $0.contains("recovered coaching") })
         let failureRows = snapshot.rows[..<recoveryIndex].filter {
@@ -549,19 +559,21 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-silent-action-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
-        ActivityLog.shared.enable(directory: dir)
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        activityLog.enable(directory: dir)
 
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.staySilent(callId: "quiet")],
                   rawToolCalls: [RawToolCall(id: "quiet", name: "stay_silent", argumentsJSON: "{}")])
         ])
-        let (driver, transcript) = makeDriver(brain: brain, clock: ManualClock(now: 0))
+        let (driver, transcript) = makeDriver(
+            activityLog: activityLog, brain: brain, clock: ManualClock(now: 0))
         transcript.append(.init(speaker: .me, text: "thinking about the columns", at: 0))
 
         #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
 
-        let snapshot = ActivityLog.shared.attach { _ in }
+        let snapshot = activityLog.attach { _ in }
         #expect(snapshot.rows.count == 1)
         #expect(snapshot.rows[0].contains("stayed silent"))
     }
@@ -572,8 +584,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("jarvis-failed-screen-action-\(ProcessInfo.processInfo.globallyUniqueString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        defer { ActivityLog.shared.disable(); try? FileManager.default.removeItem(at: dir) }
-        ActivityLog.shared.enable(directory: dir)
+        let activityLog = ActivityLog()
+        defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        activityLog.enable(directory: dir)
 
         let brain = ScriptedBrain(script: [
             .init(toolCalls: [.captureScreen(callId: "capture")],
@@ -581,13 +594,14 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             .init(toolCalls: [.staySilent(callId: "quiet")],
                   rawToolCalls: [RawToolCall(id: "quiet", name: "stay_silent", argumentsJSON: "{}")]),
         ])
-        let (driver, transcript) = makeDriver(brain: brain, screen: UnavailableScreen(),
-                                              clock: ManualClock(now: 0))
+        let (driver, transcript) = makeDriver(
+            activityLog: activityLog, brain: brain, screen: UnavailableScreen(),
+            clock: ManualClock(now: 0))
         transcript.append(.init(speaker: .me, text: "look at this", at: 0))
 
         #expect(await driver.handleTrigger(.turnEnd) == .silentByModel)
 
-        let snapshot = ActivityLog.shared.attach { _ in }
+        let snapshot = activityLog.attach { _ in }
         #expect(snapshot.rows.count == 2)
         #expect(snapshot.rows[0].contains("couldn't view your screen"))
         #expect(snapshot.rows[0].contains("screen capture failed"))

--- a/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
@@ -417,7 +417,8 @@ import Testing
             overlay: overlay,
             clock: ManualClock(),
             coachingAttempts: coachingAttempts,
-            automaticAttemptDelay: { _ in })
+            automaticAttemptDelay: { _ in },
+            activityLog: ActivityLog())
         transcript.append(.init(
             speaker: .me,
             text: "compare audit observer behavior",

--- a/Tests/JarvisCoreTests/Screen/ScreenCaptureRunnerTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenCaptureRunnerTests.swift
@@ -156,6 +156,11 @@ import Testing
     /// finished" as "still pending", so a request landing in the window between the helper exiting
     /// and `capture(arguments:)` deregistering — the transient JPEG's read and deletion sit in it —
     /// silently cancelled the *next* screenshot instead.
+    ///
+    /// Landing inside that window depends on how long the read and delete happen to take, so this
+    /// asserts only what holds either way: the capture answers its own request and nothing survives
+    /// to reach the next one. That the request counts at all once the helper is gone is pinned by
+    /// `aCancellationArrivingAfterTheHelperExitedStillMarksItsOwnCommand`.
     @Test func cancellationLosingTheRaceWithTheHelperCancelsOnlyItsOwnCapture() async throws {
         let directory = try makeDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -175,34 +180,24 @@ import Testing
             captureDirectory: directory,
             executable: executable)
 
-        // That window is only as wide as the read and delete take, and a loaded machine can starve
-        // the wait below past its close — every request then lands on a finished call and is
-        // correctly a no-op, which is a missed race rather than a regression. Re-run it instead of
-        // failing on a window we never entered; a held-over request is still caught by the
-        // follow-up capture on whichever attempt does land inside it.
-        var landedInWindow = false
-        attempts: for _ in 0..<20 {
-            try? FileManager.default.removeItem(at: exitedFile)
-            let capture = Task.detached { runner.capture(arguments: []) }
-            try await waitForFile(exitedFile, pollNanoseconds: 500_000)
-            // Repeat across the window: with no pending-request latch, a request that arrives once
-            // the call has returned is a no-op, so over-asking cannot itself poison the runner.
-            for _ in 0..<200 {
-                runner.cancelCapture()
-                try await Task.sleep(nanoseconds: 500_000)
-            }
-            switch await capture.value {
-            case .cancelled:
-                landedInWindow = true
-                break attempts
-            case .captured:
-                continue attempts
-            case .failed, .cleanupFailed:
-                Issue.record("the raced capture must not fail outright")
-                break attempts
-            }
+        let capture = Task.detached { runner.capture(arguments: []) }
+        try await waitForFile(exitedFile, pollNanoseconds: 500_000)
+        // Repeat across the window: with no pending-request latch, a request that arrives once the
+        // call has returned is a no-op, so over-asking cannot itself poison the runner.
+        for _ in 0..<200 {
+            runner.cancelCapture()
+            try await Task.sleep(nanoseconds: 500_000)
         }
-        try #require(landedInWindow, "never landed a cancellation inside the post-exit window")
+        switch await capture.value {
+        case .cancelled, .captured:
+            // Both are correct, and which one happens comes down to how fast the read and delete
+            // were: the request either landed inside the window and was answered here, or arrived
+            // after the call had already returned and was a no-op. What has to hold either way is
+            // that it did not survive — that is the assertion below.
+            break
+        case .failed, .cleanupFailed:
+            Issue.record("the raced capture must not fail outright")
+        }
 
         // The request belonged to that capture. An unrelated later one must still shoot.
         switch runner.capture(arguments: []) {
@@ -212,6 +207,27 @@ import Testing
             Issue.record("a later capture must not inherit a spent cancellation request")
         }
         #expect(try transientJPEGs(in: directory).isEmpty)
+    }
+
+    /// The half of the regression a capture-level test can only aim at: once the helper has exited,
+    /// a cancellation still belongs to the command it was issued against. Marking it is what makes
+    /// `capture(arguments:)` report `.cancelled` on its way out rather than leaving the request to
+    /// be answered by the next screenshot.
+    @Test func aCancellationArrivingAfterTheHelperExitedStillMarksItsOwnCommand() throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let executable = try makeExecutable(in: directory, script: "#!/bin/sh\nexit 0\n")
+        let command = ScreenCaptureRunner.Command(
+            executable: executable,
+            arguments: [],
+            output: directory.appendingPathComponent("capture.jpg"))
+
+        // Run to completion first: the helper is already gone when the request arrives, which is
+        // the state the capture call is in while it reads and deletes the transient JPEG.
+        _ = command.run()
+        command.cancel()
+
+        #expect(command.wasCancelled)
     }
 
     /// Regression: `cancelCapture()` with nothing in flight must be a no-op. `CoachDriver`'s

--- a/Tests/JarvisCoreTests/Screen/ScreenCaptureRunnerTests.swift
+++ b/Tests/JarvisCoreTests/Screen/ScreenCaptureRunnerTests.swift
@@ -175,20 +175,34 @@ import Testing
             captureDirectory: directory,
             executable: executable)
 
-        let capture = Task.detached { runner.capture(arguments: []) }
-        try await waitForFile(exitedFile, pollNanoseconds: 500_000)
-        // Repeat across the window: with no pending-request latch, a request that arrives once the
-        // call has returned is a no-op, so over-asking cannot itself poison the runner.
-        for _ in 0..<200 {
-            runner.cancelCapture()
-            try await Task.sleep(nanoseconds: 500_000)
+        // That window is only as wide as the read and delete take, and a loaded machine can starve
+        // the wait below past its close — every request then lands on a finished call and is
+        // correctly a no-op, which is a missed race rather than a regression. Re-run it instead of
+        // failing on a window we never entered; a held-over request is still caught by the
+        // follow-up capture on whichever attempt does land inside it.
+        var landedInWindow = false
+        attempts: for _ in 0..<20 {
+            try? FileManager.default.removeItem(at: exitedFile)
+            let capture = Task.detached { runner.capture(arguments: []) }
+            try await waitForFile(exitedFile, pollNanoseconds: 500_000)
+            // Repeat across the window: with no pending-request latch, a request that arrives once
+            // the call has returned is a no-op, so over-asking cannot itself poison the runner.
+            for _ in 0..<200 {
+                runner.cancelCapture()
+                try await Task.sleep(nanoseconds: 500_000)
+            }
+            switch await capture.value {
+            case .cancelled:
+                landedInWindow = true
+                break attempts
+            case .captured:
+                continue attempts
+            case .failed, .cleanupFailed:
+                Issue.record("the raced capture must not fail outright")
+                break attempts
+            }
         }
-        switch await capture.value {
-        case .cancelled:
-            break
-        case .captured, .failed, .cleanupFailed:
-            Issue.record("expected the in-flight capture to answer the cancellation itself")
-        }
+        try #require(landedInWindow, "never landed a cancellation inside the post-exit window")
 
         // The request belonged to that capture. An unrelated later one must still shoot.
         switch runner.capture(arguments: []) {

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,6 +7,14 @@ cd "$(dirname "$0")/.."
 ./scripts/check-app-identities.sh
 ./scripts/check-release-config.sh
 
+# `ActivityLog.shared` is a process-wide singleton that the coach records through, so a test that
+# enables it captures rows from every other test running at that moment: suites execute in parallel
+# by default, and swift-testing's `.serialized` only orders tests within one suite. Running the
+# whole suite serially is what makes each test see only its own activity. Roughly doubles the
+# wall-clock time, which the gate can afford; the alternative is injecting the log through every
+# call site that records to it.
+PARALLELISM=(--no-parallel)
+
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's
 # already on the toolchain path, so plain `swift test` works — detect which toolchain is active.
@@ -14,11 +22,12 @@ if [ "$(xcode-select -p 2>/dev/null)" = "/Library/Developer/CommandLineTools" ];
   FW=/Library/Developer/CommandLineTools/Library/Developer/Frameworks
   IOP=/Library/Developer/CommandLineTools/Library/Developer/usr/lib
   exec swift test \
+    "${PARALLELISM[@]}" \
     -Xswiftc -F -Xswiftc "$FW" \
     -Xlinker -F -Xlinker "$FW" \
     -Xlinker -rpath -Xlinker "$FW" \
     -Xlinker -rpath -Xlinker "$IOP" \
     "$@"
 else
-  exec swift test "$@"
+  exec swift test "${PARALLELISM[@]}" "$@"
 fi

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -7,14 +7,6 @@ cd "$(dirname "$0")/.."
 ./scripts/check-app-identities.sh
 ./scripts/check-release-config.sh
 
-# `ActivityLog.shared` is a process-wide singleton that the coach records through, so a test that
-# enables it captures rows from every other test running at that moment: suites execute in parallel
-# by default, and swift-testing's `.serialized` only orders tests within one suite. Running the
-# whole suite serially is what makes each test see only its own activity. Roughly doubles the
-# wall-clock time, which the gate can afford; the alternative is injecting the log through every
-# call site that records to it.
-PARALLELISM=(--no-parallel)
-
 # On a Command-Line-Tools-only machine, swift-testing ships with the CLT but isn't on the default
 # search path, so we point swift at it explicitly. With full Xcode active (e.g. CI runners) it's
 # already on the toolchain path, so plain `swift test` works — detect which toolchain is active.
@@ -22,12 +14,11 @@ if [ "$(xcode-select -p 2>/dev/null)" = "/Library/Developer/CommandLineTools" ];
   FW=/Library/Developer/CommandLineTools/Library/Developer/Frameworks
   IOP=/Library/Developer/CommandLineTools/Library/Developer/usr/lib
   exec swift test \
-    "${PARALLELISM[@]}" \
     -Xswiftc -F -Xswiftc "$FW" \
     -Xlinker -F -Xlinker "$FW" \
     -Xlinker -rpath -Xlinker "$FW" \
     -Xlinker -rpath -Xlinker "$IOP" \
     "$@"
 else
-  exec swift test "${PARALLELISM[@]}" "$@"
+  exec swift test "$@"
 fi


### PR DESCRIPTION
## Problem

CI was failing on roughly **one run in six** (6 of the last ~40), each time on a *different* test. PR #179 is the clean tell: failed at 08:34, passed at 08:40, same branch, no code change.

| Test | CI failures | Root cause |
|---|---|---|
| `refreshingClientsCannotDropOrRedirectACommitted{Skip,Advance}` | 3 | a `Task.yield()` spin used as synchronisation |
| `cancellationLosingTheRaceWithTheHelperCancelsOnlyItsOwnCapture` | 2 | a missed race window reported as a regression |
| `abortsNonCooperativeOperation` | 1 | a wall-clock budget vs. scheduling delay |
| `failedScreenActionAndStaySilentBothLandInActivityLog` | latent | `ActivityLog` singleton shared across suites |

Two distinct bugs, both in the tests. The fourth was found by a load soak, not by CI — it hadn't failed there yet.

## Bug 1 — three tests were guessing at timing

The driver **writes down** which callback to notify (under `stateLock`), then **notifies it** (crossing to the main actor). A test wants to swap the callbacks between those two steps, to prove a swap can't hijack a notice that was already committed.

It had no way to know when the first step finished, so it called `Task.yield()` a thousand times and hoped. `yield` only reschedules the *calling* task — it makes no promise the driver ever ran. On a 3-core runner with 757 tests in flight, the swap sometimes landed before the commit, and every assertion came back inverted.

Same mistake in the other two: an abort asserted to return "within 500ms" (CI measured 568ms while behaving correctly), and a cancellation aimed at a window a few milliseconds wide.

**Fix — don't wait for the moment, construct it.** The commit and the delivery were already separate phases; they were just `private`. They are now module-visible, and the tests run `commit → refresh → deliver` in sequence in one task. No threads, no waiting, the window guaranteed. Two end-to-end tests keep the composition covered by raising the refresh from inside the notice callback. `Command` gets the same treatment so "a cancellation after the helper exited still marks its own command" is asserted directly. The abort's operation no longer finishes on a timer — it stays outstanding until the test releases it, so the claim is settled by ordering.

## Bug 2 — a singleton is a hidden global argument

`ActivityLog.shared.record(...)` looks like it has no inputs, but it silently wrote to whichever log was globally enabled. A driver never knew which log was its own, so a test that enabled one and read it back collected rows from every driver alive in the process.

The suite's comment recorded the mistaken reasoning:

> *"they are the only code that enables the shared log, so no other suite can collide"*

Enabling is exclusive; **appending is not**. The contaminating rows came from a suite that only ever appended.

**Fix — hand the log in.** `CoachDriver` and `TranscriptionCoachingCoordinator` now take an `ActivityLog`, defaulting to `.shared`. Nine call sites in JarvisCore; the seventeen in JarvisApp keep the singleton through that default, so the app is unchanged. Each test hands its driver a log it made, so a snapshot can only hold its own rows.

An earlier revision of this PR used `--no-parallel` instead. That prevented the collision without removing it and left the design for the next test to trip over, so it has been reverted — the suite runs in parallel again at 25.6s rather than 55s, and `CoachDriverPipelineTests` no longer needs `.serialized`.

Note the two failing assertions were exact counts (`rows.count == 1`, `== 2`). They were correct all along — they simply could not hold while the log was shared.

## Verification

Every new test was **mutation-tested**: the bug it guards was reintroduced, the test confirmed to fail deterministically, then reverted. The old tests only ever failed by accident.

Full suite under CPU saturation (24 spinners on 10 cores), emulating a loaded runner:

| | Before | After |
|---|---|---|
| Full suite under load | 2 of 12 runs failed | **39 of 39 passed** |
| Coach tests, filtered | 1 of 25 failed | 40 of 40 passed |

The final 14 of those runs were with parallelism restored — the configuration that originally failed.

```
$ swift build && ./scripts/run-tests.sh
Build complete!
✔ Test run with 760 tests in 89 suites passed after 25.633 seconds.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
