### PR TITLE
fix(coach): ground tip vocabulary in what the user can already see

### DIFF
--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -52,8 +52,14 @@ extension JarvisPrompts {
         the same request.
 
         # Tip style
-        Lead with the most useful point. Be brief, concrete, encouraging, and easy to read under pressure.
-        Prefer one pointed question or next step. Give a full solution only when "me" explicitly asks for it.
+        Lead with the most useful point. Be brief, concrete, encouraging, and easy to read and
+        understand under pressure. Prefer one pointed question or next step.
+        Give a full solution only when "me" explicitly asks for it.
+
+        Name things with the words already in front of "me" — on the captured screen, or in what
+        either speaker said. Do not use an unfamiliar term as if it were shared. When a new term or
+        symbol genuinely is the right one, gloss it on first use ("1<<h, that is 2 to the power h");
+        accuracy outranks brevity.
         """
 
         enum ToolDescription {

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -107,6 +107,25 @@ import Testing
         #expect(!JarvisPrompts.Coach.system.contains("never the whole answer"))
     }
 
+    /// A live session shipped "compare left spine height vs right spine height" — inside the line
+    /// budget, but built on a term that appeared nowhere on the user's screen. Tips borrow the
+    /// vocabulary already in front of the user; a genuinely necessary new term is glossed, not
+    /// dropped, because accuracy outranks brevity.
+    @Test func coachPromptGroundsTipVocabularyInWhatTheUserAlreadySees() {
+        let prompt = JarvisPrompts.Coach.system.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        #expect(prompt.contains("Name things with the words already in front of \"me\""))
+        // Either speaker: the interviewer's spoken terms are also in front of the user, and
+        // interviewer questions are first-class coaching input.
+        #expect(prompt.contains("on the captured screen, or in what either speaker said"))
+        // "use", not "introduce": saying "I'm not familiar with X" would otherwise make X a term
+        // "me" has said, and so licence reusing it unglossed.
+        #expect(prompt.contains("Do not use an unfamiliar term as if it were shared"))
+        #expect(prompt.contains("gloss it on first use"))
+        #expect(prompt.contains("accuracy outranks brevity"))
+        // The old rule only constrained reading effort; "spine" was easy to read and still opaque.
+        #expect(prompt.contains("easy to read and understand under pressure"))
+    }
+
     /// Silence is a TOOL now: the prompt must direct the model to stay_silent (never free text),
     /// or a required tool_choice would leave it no sanctioned way to stay quiet.
     @Test func coachPromptDirectsSilenceToTheStaySilentTool() {

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1841,3 +1841,30 @@
 - **Detail:** [build-and-run.md → In-app updates](./build-and-run.md#in-app-updates--sparkle-over-the-release-feed),
   `Sources/JarvisApp/Updates/UpdateController.swift`, `scripts/generate-appcast.sh`,
   `scripts/package-app.sh`, `scripts/check-release-config.sh`.
+
+### 2026-08-22 — Tips borrow the user's vocabulary instead of merely reading plainly
+
+- **Chose:** The coach's `# Tip style` now grounds word choice: name things with the words already on
+  the captured screen or in what either speaker said, never use an unfamiliar term as if it were
+  shared, and gloss a genuinely necessary new term on first use because accuracy outranks brevity.
+  The existing clause became "easy to read **and understand** under pressure".
+- **Why:** A live coding session produced a hint that sat well inside the overlay line budget and was
+  still unusable, because it named the central idea with a term that appeared nowhere in the user's
+  context; the same failure recurred later in that session with an unglossed symbol, which the user
+  said aloud they did not know. Brevity was never the defect. The 2026-06-18 "plain-language hints"
+  decision constrained reading effort rather than vocabulary, so it could not catch this — a short,
+  plainly-worded tip is still opaque when its nouns are unshared. Grounding is also free at inference
+  time: the screen text and the transcript are already in the request.
+- **Rejected:** (a) ASD-STE100 compliance — built for aerospace maintenance documentation that is
+  re-read at leisure, its ~900-word dictionary cannot fit in a prompt or be verified, and its rules
+  (mandatory articles, 20–25-word sentences) push tips *longer* against a ~12-word overlay budget. Its
+  Technical Names rule (a specialized term needs an approved source, not informal usage) and its
+  one-word-one-meaning rule are the parts that apply, and the grounding clause encodes them.
+  (b) A clause forbidding a near-synonym of a term already on screen, and a separate
+  terminology-consistency clause — both are subsumed: borrowing the screen's words already forbids the
+  substitution and produces consistency for free. (c) Restricting grounding to the user's own words —
+  interviewer questions are first-class coaching input ([architecture.md §2](./architecture.md#2-core-loop)),
+  so their vocabulary is in front of the user too. (d) A further OCR-verification clause — the Context
+  section already states unconditionally that the screenshot image is ground truth. (e) Shortening
+  tips further — brevity was never the defect.
+- **Detail:** `Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift` → `# Tip style`.


### PR DESCRIPTION
## Problem

A live coding session on the production build produced a hint that sat well inside the overlay line budget — three lines, 8–10 words each — and was still unusable under pressure.

The cause was vocabulary, not length. The hint named the problem's central idea with a term that appeared **nowhere** in the model's own input for that turn: not on the captured screen, not in the transcript. The word the problem itself used for that concept appeared six times. The coach also substituted a second, subtly different term of art for the one on screen, inviting the user to read it as a restatement when it wasn't.

**The same failure recurred 16 minutes later** with an unglossed symbol, which the user answered aloud by saying they didn't know it. Two occurrences in one session makes it systemic.

The coach demonstrated the fix unprompted a few turns later, rephrasing the same idea at the same length using only words already in the user's context. It just took nine minutes and a nudge to get there.

## Root cause

`# Tip style` asked for tips "easy to read under pressure". That constrains *reading effort*, not *word choice* — a short, simply-worded tip is still opaque when its nouns are unshared. Nothing in the prompt governed which words were permitted, so the 2026-06-18 "plain-language hints" decision could not catch this.

## Change

Three non-overlapping rules added to `# Tip style` (~51 words), plus `easy to read` → `easy to read and understand`.

```
Name things with the words already in front of "me" — on the captured screen, or in what
either speaker said. Do not use an unfamiliar term as if it were shared. When a new term or
symbol genuinely is the right one, gloss it on first use ("1<<h, that is 2 to the power h");
accuracy outranks brevity.
```

The `1<<h` example stays because it demonstrates the *format* of a gloss (inline, six words), so "gloss it" doesn't invite spending a whole overlay line. A counter-example illustrating unshared jargon was dropped by owner decision — declaring the rule is enough.

Cost: ~80 tokens on a 1,641-token cached prefix, read from cache every turn.

## Considered and rejected

- **ASD-STE100 compliance.** Right instinct, wrong instrument. It targets aerospace *maintenance documentation* read at leisure and optimized for non-native readers and machine translation; its ~900-word dictionary cannot fit in a prompt or be verified; and its rules (mandatory articles, 20–25-word sentences) push tips **longer** against a ~12-word budget. Its Technical Names rule (a specialized term needs an approved source, not informal usage) and its one-word-one-meaning rule are the parts that apply, and the grounding clause encodes both.
- **A separate near-synonym clause** — subsumed. A term that isn't in front of the user is already forbidden by rule 1.
- **A terminology-consistency clause** — also subsumed, and more cheaply: always reaching for the screen's words produces consistency for free.
- **Shortening tips further** — brevity was never the defect.

## Review feedback addressed

- **Interviewer vocabulary** (P2): the clause originally grounded names in the screen or *the user's own* words, excluding `them:`. But `wiki/architecture.md:89` makes interviewer questions first-class coaching input, and in a system-design interview the interviewer's terms are exactly what the user just heard. Now `in what either speaker said`. This doesn't touch the separate rule about never addressing `them:` directly — that governs addressee, not vocabulary.
- **"Unfamiliar" loophole** (P2): with `Do not **introduce** an unfamiliar term`, a user saying "I'm not familiar with X" made X *a word the user said*, and so grounded — licensing the coach to keep reusing it unglossed. That is the precise failure this PR exists to fix. `introduce` → `use` closes it at zero word cost, since "use" covers reuse where "introduce" means first mention.
- **Wiki runtime evidence** (P1): the `decisions.md` entry quoted session-specific runtime output. `wiki/AGENTS.md:119` excludes logs and runtime output from the wiki, and audio-derived data belongs only in the owner-only session directory. Rewritten to keep the decision and rationale in abstract form.
- **Further OCR verification** (P2, declined): the Context section already states unconditionally that "the screenshot image is ground truth" — only the *following* sentence is scoped to asserting a token is wrong. The new clause also says "on the captured **screen**", not "in the OCR text". Covered twice; a third clause would restate it and grow the prompt.

## Scope

Wording only, by owner decision. The session also shows the coach reading "give me some hints" as an explicit request for the full solution. That is a separate contract question and is deliberately **not** addressed here.

## Testing

`swift build && ./scripts/run-tests.sh` — **761 tests in 89 suites passed.**

`coachPromptGroundsTipVocabularyInWhatTheUserAlreadySees` added, using the file's existing whitespace-normalizing convention for phrases that wrap. Re-wrapping the paragraph initially split a phrase asserted by `coachPromptHasOneConsistentFullSolutionRule`; that was fixed, and both tests are confirmed executing rather than silently absent.

Whether the wording actually works is a live-model property, so real verification is the next live session — same as the `JarvisApp` smoke checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
