### PR TITLE
ci: skip claude code review on the release pr

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,7 +8,12 @@ on:
 
 jobs:
   review:
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+    # release-please's standing Release PR carries only generated version bumps (CHANGELOG,
+    # Info.plist, manifest) — nothing an author wrote and nothing a review can improve.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
+      && !startsWith(github.head_ref, 'release-please--')
     uses: JINGBANZ/workflows/.github/workflows/claude-code-review.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
## What

Adds a guard to `.github/workflows/claude-code-review.yml` so the automatic review job skips
pull requests whose head branch starts with `release-please--`.

## Why

release-please's standing Release PR (e.g. #190) only carries generated version bumps —
`CHANGELOG.md`, `Resources/Info.plist`, `.release-please-manifest.json`. There is nothing an
author wrote and nothing a review can improve. Worse, the review job currently *fails* on it, so
every Release PR sits with a red `review / claude-review` check right up to the merge that cuts
the release.

The other two conditions (same-repo head, non-dependabot actor) are unchanged; the `if` moved to
a folded scalar only so three clauses stay readable.

## Verification

- `swift build && ./scripts/run-tests.sh` → `Test run with 775 tests in 90 suites passed`
- YAML re-parsed to confirm the folded `if` yields the single intended expression:
  `... && !startsWith(github.head_ref, 'release-please--')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)