### PR TITLE
fix(diagnostics): account for Codex one-shot exec token usage

### DIFF
--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainClient.swift
@@ -192,7 +192,7 @@ public struct CLIBrainClient: BrainClient, Sendable {
             "provider": provider.rawValue,
             "model": configuration.model.isEmpty ? "(CLI default)" : configuration.model,
             "executable": configuration.executable.path,
-            "runtime": provider == .claudeCode ? "warm-query" : "app-server",
+            "runtime": runtime.transport.rawValue,
             "instructions": expectedInstructions,
             "input": auditInput,
         ]
@@ -240,7 +240,7 @@ public struct CLIBrainClient: BrainClient, Sendable {
             tag: trafficTag,
             request: requestRecord ?? Self.recordData([
                 "provider": provider.rawValue,
-                "runtime": provider == .claudeCode ? "warm-query" : "app-server",
+                "runtime": runtime.transport.rawValue,
             ]),
             response: nil,
             status: nil,
@@ -255,7 +255,8 @@ public struct CLIBrainClient: BrainClient, Sendable {
         if let metadata = result.metadata,
            let object = try? JSONSerialization.jsonObject(with: metadata) {
             // Keep Claude's established `response.cli` envelope so deterministic session metrics
-            // retain usage/cache/cost telemetry. Codex's completed-turn metadata has no usage.
+            // retain usage/cache/cost telemetry. Codex's completed turn goes under `runtime`, where
+            // the metrics reader pairs it with the request's transport name to read its usage.
             record[provider == .claudeCode ? "cli" : "runtime"] = object
         }
         return Self.recordData(record)

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/CLIBrainRuntime.swift
@@ -36,7 +36,19 @@ protocol LocalAgentConversation: Sendable {
     func finish() async
 }
 
+/// How a local-agent turn reached its provider, named in the session audit's request record.
+///
+/// The transports do not share a usage schema — Claude's warm query carries the Anthropic envelope,
+/// `codex exec` reports OpenAI-shaped totals under its own key names, and the app-server reports
+/// none — so a reader of the audit needs the transport to know which shape, if any, to expect.
+enum LocalAgentTransport: String, Sendable {
+    case warmQuery = "warm-query"
+    case appServer = "app-server"
+    case oneShotExec = "one-shot-exec"
+}
+
 protocol LocalAgentRuntimeBackend: Sendable {
+    var transport: LocalAgentTransport { get }
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws
     func openConversation(
         for configuration: LocalAgentConversationConfiguration,
@@ -81,6 +93,7 @@ public final class CLIBrainRuntime: @unchecked Sendable {
     }
 
     private let backend: any LocalAgentRuntimeBackend
+    var transport: LocalAgentTransport { backend.transport }
     private let ownerLock = NSLock()
     private var ownerCount = 0
     private var isTerminated = false

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/ClaudeCode/ClaudeCodeRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/ClaudeCode/ClaudeCodeRuntime.swift
@@ -9,6 +9,7 @@ actor ClaudeCodeRuntime: LocalAgentRuntimeBackend {
         let task: Task<ClaudeCodeQuery, Error>
     }
 
+    nonisolated let transport = LocalAgentTransport.warmQuery
     private let lifetime = AgentRuntimeLifetime()
     private var configuration: LocalAgentConversationConfiguration?
     private var ready: ClaudeCodeQuery?

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -63,6 +63,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         let supportedFeatures: Set<String>
     }
 
+    nonisolated let transport = LocalAgentTransport.appServer
     private let runtimeBaseDirectory: URL
     private let supportedFeatures: Set<String>
     private let lifetime = AgentRuntimeLifetime()

--- a/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexExecRuntime.swift
+++ b/Sources/JarvisCore/Brain/Adapters/LocalAgent/Codex/CodexExecRuntime.swift
@@ -16,6 +16,7 @@ import Foundation
 /// deny-by-default allowlist the app-server enforces, killing the process on anything else. Auth and
 /// config isolation reuse the app-server's private `CODEX_HOME`.
 struct CodexExecRuntime: LocalAgentRuntimeBackend {
+    let transport = LocalAgentTransport.oneShotExec
     private let supportedFeatures: Set<String>
     private let homeBaseDirectory: URL
     private let lifetime = AgentRuntimeLifetime()
@@ -128,9 +129,11 @@ private struct CodexExecConversation: LocalAgentConversation {
                 guard !trimmed.isEmpty else {
                     throw Self.error("codex exec produced no reply")
                 }
+                // The completed turn carries the turn's token usage; keeping it is what lets the
+                // session audit account for a compaction summary instead of reporting it unknown.
                 return LocalAgentTurnResult(
                     reply: trimmed,
-                    metadata: nil,
+                    metadata: try? JSONSerialization.data(withJSONObject: event),
                     dispatchedAt: dispatchedAt,
                     firstAssistantAt: firstAssistantAt,
                     completedAt: line.observedAt)

--- a/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionMetrics.swift
@@ -15,6 +15,10 @@ import Foundation
 ///     sidecar models (e.g. its haiku pass), which the call-level `usage` alone would hide.
 ///   - **Codex app-server** — the response record has no token, cache, or cost usage, so those
 ///     values remain unavailable rather than becoming zero.
+///   - **Codex one-shot `exec`** (the summarizer) — `response.runtime.usage`, in Codex's own key
+///     names: `input_tokens` (cached input included), `cached_input_tokens`,
+///     `cache_write_input_tokens`, and `output_tokens` (reasoning output included). No cost.
+///     Which Codex transport served a call is read from the request record's `runtime` name.
 enum SessionMetrics {
     /// One row of the per-call table. `perModel` attributes this call's usage to the concrete
     /// model(s) that served it (a CLI turn can touch a main model plus a sidecar).
@@ -207,6 +211,20 @@ enum SessionMetrics {
                                                        cacheWrite: call.cacheWrite, output: call.output,
                                                        cost: call.cost, calls: 1)
                 }
+            } else if request?["runtime"] as? String == LocalAgentTransport.oneShotExec.rawValue,
+                      let usage = (response?["runtime"] as? [String: Any])?["usage"]
+                        as? [String: Any] {
+                // Keyed on the transport, not on the envelope: both Codex transports record their
+                // completed turn under `response.runtime`, and only `codex exec` spells usage this
+                // way. `input_tokens` counts cached input and `output_tokens` includes reasoning
+                // output, as in OpenAI's schema. No per-call cost is reported.
+                call.input = int(usage["input_tokens"])
+                call.cacheRead = int(usage["cached_input_tokens"])
+                call.cacheWrite = int(usage["cache_write_input_tokens"])
+                call.output = int(usage["output_tokens"])
+                call.perModel[model] = ModelTotals(input: call.input, cacheRead: call.cacheRead,
+                                                   cacheWrite: call.cacheWrite, output: call.output,
+                                                   cost: nil, calls: 1)
             } else if let usage = response?["usage"] as? [String: Any] {
                 call.input = int(usage["input_tokens"])
                 let details = usage["input_tokens_details"] as? [String: Any]

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainClientTests.swift
@@ -23,6 +23,7 @@ import Testing
     ) -> (CLIBrainClient, FakeLocalAgentRuntime) {
         let backend = FakeLocalAgentRuntime(
             replies: replies,
+            transport: provider == .claudeCode ? .warmQuery : .appServer,
             openDelay: openDelay,
             failBeforeDispatch: failBeforeDispatch)
         let runtime = CLIBrainRuntime(backend: backend)
@@ -252,6 +253,7 @@ import Testing
         let traffic = await FileSessionAudit.readyForTesting(directory: workDir)
         let backend = FakeLocalAgentRuntime(
             replies: [],
+            transport: .appServer,
             openError: NSError(
                 domain: "test",
                 code: 7,
@@ -529,6 +531,9 @@ private actor FakeLocalAgentRuntime: LocalAgentRuntimeBackend {
         let timeout: TimeInterval
     }
 
+    /// The real backend this fake stands in for, so audit assertions see the transport name the
+    /// simulated runtime would have written.
+    nonisolated let transport: LocalAgentTransport
     private var replies: [String]
     private let openError: (any Error)?
     private let openDelay: TimeInterval
@@ -542,10 +547,12 @@ private actor FakeLocalAgentRuntime: LocalAgentRuntimeBackend {
 
     init(
         replies: [String],
+        transport: LocalAgentTransport = .warmQuery,
         openError: (any Error)? = nil,
         openDelay: TimeInterval = 0,
         failBeforeDispatch: Bool = false
     ) {
+        self.transport = transport
         self.replies = replies
         self.openError = openError
         self.openDelay = openDelay

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
@@ -54,6 +54,54 @@ import Testing
         runtime.terminateNow()
     }
 
+    /// The one-shot summary's `turn.completed` event carries the turn's token usage. Discarding it
+    /// left every Codex compaction in the session audit with unavailable input, cache, and output
+    /// values even though the transport had reported them. The request record must also name the
+    /// transport, because `codex exec` spells its usage keys differently from the app-server's
+    /// schema and the metrics reader has to know which one it is holding.
+    @Test func codexExecSummaryRecordsItsTransportAndTokenUsage() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let traffic = await FileSessionAudit.readyForTesting(directory: directory)
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(
+                trace: directory.appendingPathComponent("trace"),
+                threadResult: Self.ephemeralThreadResult,
+                execReply: "condensed briefing",
+                execUsage: #"{"input_tokens":17102,"cached_input_tokens":9984,"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}"#))
+        let runtime = CLIBrainRuntime(
+            backend: CodexExecRuntime(homeBaseDirectory: directory.appendingPathComponent("homes")))
+        let summarizer = makeClient(
+            provider: .codexCLI, executable: executable, directory: directory,
+            runtime: runtime, prewarm: false, traffic: traffic,
+            systemPrompt: "summarize", tools: [], toolChoice: .auto)
+
+        let summary = try await summarizer.respond(
+            messages: [.system("summarize"), .user("older turns")],
+            tools: [],
+            toolChoice: .auto)
+        #expect(summary.outputText == "condensed briefing")
+        runtime.terminateNow()
+        _ = await traffic.closeForTesting()
+
+        let jsonl = try String(
+            contentsOf: directory.appendingPathComponent(FileSessionAudit.brainTrafficFilename),
+            encoding: .utf8)
+        let line = try #require(jsonl.split(separator: "\n").first)
+        let entry = try #require(
+            try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+        #expect((entry["request"] as? [String: Any])?["runtime"] as? String == "one-shot-exec")
+        let usage = try #require(
+            ((entry["response"] as? [String: Any])?["runtime"] as? [String: Any])?["usage"]
+                as? [String: Any])
+        #expect(usage["input_tokens"] as? Int == 17102)
+        #expect(usage["cached_input_tokens"] as? Int == 9984)
+        #expect(usage["cache_write_input_tokens"] as? Int == 0)
+        #expect(usage["output_tokens"] as? Int == 5)
+    }
+
     /// The one-shot summarizer path is text-only by construction: an image is rejected before any
     /// process is spawned rather than silently dropped into the `codex exec` document.
     @Test func codexExecRuntimeRejectsImageInput() async throws {
@@ -785,6 +833,7 @@ import Testing
         directory: URL,
         runtime: CLIBrainRuntime,
         prewarm: Bool,
+        traffic: (any BrainTrafficAuditing)? = nil,
         systemPrompt: String = "coach prompt",
         tools: [ToolDef] = coachTools,
         toolChoice: ToolChoice = .required,
@@ -796,6 +845,7 @@ import Testing
             model: "",
             workDirectory: directory,
             timeout: timeout,
+            traffic: traffic,
             systemPrompt: systemPrompt,
             tools: tools,
             toolChoice: toolChoice,
@@ -829,7 +879,8 @@ import Testing
         trace: URL,
         threadResult: String,
         execReply: String? = nil,
-        execItemType: String = "agent_message"
+        execItemType: String = "agent_message",
+        execUsage: String = "{}"
     ) -> String {
         let recordArguments = argumentsFile.map {
             "printf 'arg=<%s>\\n' \"$@\" > '\(shellQuoted($0.path))'\n"
@@ -847,7 +898,7 @@ import Testing
               printf '{"type":"thread.started","thread_id":"t1"}\\n'
               printf '{"type":"turn.started"}\\n'
               printf '{"type":"item.completed","item":{"id":"i1","type":"\(execItemType)","text":"\(shellQuoted(reply))"}}\\n'
-              printf '{"type":"turn.completed","usage":{}}\\n'
+              printf '{"type":"turn.completed","usage":%s}\\n' '\(execUsage)'
               exit 0
             fi
 

--- a/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
+++ b/Tests/JarvisCoreTests/Brain/Adapters/LocalAgent/CLIBrainRuntimeTests.swift
@@ -62,7 +62,7 @@ import Testing
     @Test func codexExecSummaryRecordsItsTransportAndTokenUsage() async throws {
         let directory = try makeWorkDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
-        let traffic = await FileSessionAudit.readyForTesting(directory: directory)
+        let traffic = RecordingTrafficAudit()
         let executable = try makeExecutable(
             in: directory,
             named: "fake-codex",
@@ -84,18 +84,16 @@ import Testing
             toolChoice: .auto)
         #expect(summary.outputText == "condensed briefing")
         runtime.terminateNow()
-        _ = await traffic.closeForTesting()
 
-        let jsonl = try String(
-            contentsOf: directory.appendingPathComponent(FileSessionAudit.brainTrafficFilename),
-            encoding: .utf8)
-        let line = try #require(jsonl.split(separator: "\n").first)
-        let entry = try #require(
-            try JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
-        #expect((entry["request"] as? [String: Any])?["runtime"] as? String == "one-shot-exec")
+        let event = try #require(traffic.recorded.first)
+        let request = try #require(
+            try JSONSerialization.jsonObject(with: event.request) as? [String: Any])
+        #expect(request["runtime"] as? String == "one-shot-exec")
+        let responseBody = try #require(event.response)
+        let response = try #require(
+            try JSONSerialization.jsonObject(with: responseBody) as? [String: Any])
         let usage = try #require(
-            ((entry["response"] as? [String: Any])?["runtime"] as? [String: Any])?["usage"]
-                as? [String: Any])
+            (response["runtime"] as? [String: Any])?["usage"] as? [String: Any])
         #expect(usage["input_tokens"] as? Int == 17102)
         #expect(usage["cached_input_tokens"] as? Int == 9984)
         #expect(usage["cache_write_input_tokens"] as? Int == 0)
@@ -1044,5 +1042,27 @@ import Testing
         arguments.indices.dropLast().contains {
             arguments[$0] == first && arguments[$0 + 1] == second
         }
+    }
+}
+
+/// Captures the exact bytes the client hands the audit port, synchronously on the calling thread.
+///
+/// This suite is serialized and every test in it spawns real subprocesses that hold GCD threads, so
+/// a file-backed `FileSessionAudit` would add a background worker queue plus two waits with no
+/// deadline — its readiness spin and its close — either of which hangs the whole suite forever if
+/// that queue is slow to be scheduled. The record's JSONL round-trip is covered by
+/// `FileSessionAuditTrafficTests`; what matters here is what `CLIBrainClient` emits.
+///
+/// `@unchecked Sendable` is justified because `lock` guards the only mutable state.
+private final class RecordingTrafficAudit: BrainTrafficAuditing, @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [BrainTrafficAuditEvent] = []
+
+    var recorded: [BrainTrafficAuditEvent] {
+        lock.withLock { events }
+    }
+
+    func record(_ event: BrainTrafficAuditEvent) {
+        lock.withLock { events.append(event) }
     }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionMetricsTests.swift
@@ -98,6 +98,27 @@ import Foundation
         #expect(out.contains("| claude-opus-4-8 | 1 | 4 | 1285 | 12000 | 200 | $1.4000 |"))
     }
 
+    /// The one-shot `codex exec` summarizer records its completed turn, whose usage uses Codex's own
+    /// key names. Reading it keeps compaction token accounting in the session totals; before it the
+    /// values were rendered unavailable even though the transport had supplied them. No per-call
+    /// cost is reported, so cost stays unavailable.
+    @Test func rendersCodexOneShotExecUsage() throws {
+        let call = try line(
+            request: ["provider": "codex-cli", "model": "gpt-5.4", "runtime": "one-shot-exec"],
+            response: ["reply": "condensed",
+                       "runtime": ["type": "turn.completed",
+                                   "usage": ["input_tokens": 17102,
+                                             "cached_input_tokens": 9984,
+                                             "cache_write_input_tokens": 0,
+                                             "output_tokens": 5,
+                                             "reasoning_output_tokens": 0]]])
+        let out = SessionMetrics.render(jsonl: call)
+
+        #expect(out.contains("| 1 | coach | Codex CLI | gpt-5.4 | 200 | 500 | 17102 | 9984 | 0 | 5 | — |"))
+        #expect(out.contains("session totals: 1 calls · input 17102 · cache-read 9984 · cache-write 0 · output 5 · cost —"))
+        #expect(out.contains("| gpt-5.4 | 1 | 17102 | 9984 | 0 | 5 | — |"))
+    }
+
     /// Codex's recorded response has no usage envelope. Successful execution must not become a
     /// deterministic claim that the call consumed zero tokens and cost nothing.
     @Test func rendersCodexUsageAsUnavailable() throws {


### PR DESCRIPTION
Closes #191.

## What was wrong

`CodexExecRuntime` read the summary off the `agent_message` stream event and returned
`LocalAgentTurnResult(metadata: nil, …)`, discarding the `turn.completed` event that carries the
turn's token usage:

```json
{"type":"turn.completed","usage":{"input_tokens":17102,"cached_input_tokens":9984,
 "cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}}
```

So `CLIBrainClient.responseRecord` persisted only the reply text, and every Codex history-compaction
call landed in `SessionMetrics` with unavailable input, cache, and output values — leaving session
token totals incomplete even though the transport had reported them.

## The change

- `CodexExecRuntime` keeps the completed turn as the result's metadata, which the existing
  `response.runtime` envelope already carries into the audit.
- `SessionMetrics` reads `response.runtime.usage` with Codex's key names — `input_tokens` (cached
  input included), `cached_input_tokens`, `cache_write_input_tokens`, `output_tokens` (reasoning
  output included). No per-call cost is reported, so cost stays unavailable.
- That branch is keyed on the transport, not on the envelope shape, because both Codex transports
  record their completed turn under `response.runtime` and only `codex exec` spells usage this way.
  Each runtime backend now names itself through a `LocalAgentTransport` enum (`warm-query`,
  `app-server`, `one-shot-exec`), replacing the provider-derived guess the request record used to
  write — which had no way to tell the two Codex transports apart.

Usage key names verified against the installed `codex-cli 0.147.0` binary, not from memory.

## Non-goals

App-server usage accounting and per-call Codex cost are unchanged: neither transport reports cost,
and the app-server's completed-turn object still carries no usage, so both stay unavailable rather
than becoming zero.

## Tests

Test-first; both failed for the right reason before the fix.

- `codexExecSummaryRecordsItsTransportAndTokenUsage` — end to end through a fake `codex exec`: the
  audit's request record names `one-shot-exec` and the response carries the reported usage.
- `rendersCodexOneShotExecUsage` — the metrics table and session totals render that usage instead of
  `—`.

Gate: `swift build && ./scripts/run-tests.sh` → 777 tests in 90 suites passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
