### PR TITLE
build(core): guard the coaching kernel and generalize the observer parity harness

### DIFF
--- a/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
@@ -1,0 +1,186 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import JarvisCore
+
+/// Drives one fixed, fully deterministic coaching scenario and captures everything optional
+/// evidence must never change: terminal coaching outcomes, the provider request sequence, overlay
+/// output events, and route transitions (advance, skip, exhaustion).
+///
+/// The scenario walks the whole route-health surface in two triggers over a three-target route:
+///
+/// 1. The primary target fails three temporary transport attempts and exhausts, the preflight-proven
+///    unavailable middle target is skipped, and the route advances to the final target, which
+///    delivers one tip (`.spoke`).
+/// 2. The final target fails three temporary attempts, so the route terminally exhausts
+///    (`.brainError`).
+///
+/// The harness is evidence-agnostic: a variant hands its observer wiring to `run` and gets back a
+/// `Snapshot` to compare against the absent-evidence baseline. A later slice that adds a new
+/// evidence category extends `EvidenceObservers` with an absent-by-default field rather than
+/// building a new harness or editing the scenario. Everything is driven by deterministic fakes —
+/// scripted transports, `ManualClock`, and a no-op attempt delay — never by wall-clock thresholds.
+enum CoachingParityHarness {
+    static let primaryTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
+    static let unavailableTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
+    static let finalTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5-mini")
+
+    /// The optional evidence wiring for one parity variant. Every field defaults to absent so a
+    /// later evidence category joins as a new field without touching existing call sites.
+    struct EvidenceObservers {
+        var brainTraffic: (any BrainTrafficAuditing)?
+        var coachingAttempts: (any CoachingAttemptAuditing)?
+
+        init(
+            brainTraffic: (any BrainTrafficAuditing)? = nil,
+            coachingAttempts: (any CoachingAttemptAuditing)? = nil
+        ) {
+            self.brainTraffic = brainTraffic
+            self.coachingAttempts = coachingAttempts
+        }
+    }
+
+    /// One route-health event as the App edge would observe it. Failure detail stays out: raw
+    /// provider errors are diagnostics, never product behavior, so parity compares target identity.
+    enum RouteTransition: Equatable {
+        case advanced(from: BrainTarget, to: BrainTarget)
+        case skipped(BrainTarget)
+        case exhausted(BrainTarget)
+    }
+
+    /// One `render` call as the overlay port received it.
+    struct OverlayEvent: Equatable {
+        let lines: [String]
+        let perLineSeconds: [TimeInterval]
+    }
+
+    /// The complete observable coaching behavior of one scenario run. Two variants behave
+    /// identically exactly when their snapshots are equal.
+    struct Snapshot: Equatable {
+        let outcomes: [TurnOutcome]
+        let providerRequests: [Data]
+        let overlayEvents: [OverlayEvent]
+        let routeTransitions: [RouteTransition]
+    }
+
+    static func run(observers: EvidenceObservers = EvidenceObservers()) async -> Snapshot {
+        let requests = RequestCapture()
+        let transitions = TransitionCapture()
+        let transportFailure = NSError(
+            domain: "coaching-parity", code: 503,
+            userInfo: [NSLocalizedDescriptionKey: "injected transport failure"])
+
+        let primary = OpenAIBrainClient(
+            apiKey: "parity-key",
+            model: primaryTarget.modelID,
+            traffic: observers.brainTraffic,
+            send: { request in
+                try requests.append(request)
+                throw transportFailure
+            })
+
+        let speakResponse = Data(
+            #"{"status":"completed","output":[{"type":"function_call","call_id":"s1","name":"speak","arguments":"{\"lines\":[\"same tip\"]}"}]}"#.utf8)
+        let finalCalls = CallCounter()
+        let final = OpenAIBrainClient(
+            apiKey: "parity-key",
+            model: finalTarget.modelID,
+            traffic: observers.brainTraffic,
+            send: { request in
+                try requests.append(request)
+                guard finalCalls.next() == 1 else { throw transportFailure }
+                return (
+                    speakResponse,
+                    HTTPURLResponse(
+                        url: request.url!,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: nil))
+            })
+
+        let overlay = FakeOverlay()
+        let transcript = RollingTranscript()
+        let driver = CoachDriver(
+            config: .default,
+            transcript: transcript,
+            route: ConfiguredBrainRoute(
+                targets: [
+                    ConfiguredBrainTarget(target: primaryTarget, brain: primary),
+                    ConfiguredBrainTarget(
+                        unavailable: unavailableTarget,
+                        detail: "preflight-proven unavailable"),
+                    ConfiguredBrainTarget(target: finalTarget, brain: final),
+                ],
+                onAdvanced: { transitions.append(.advanced(from: $0, to: $1)) },
+                onSkipped: { transitions.append(.skipped($0)) },
+                onExhausted: { target, _ in transitions.append(.exhausted(target)) }),
+            screen: FakeScreen(),
+            overlay: overlay,
+            clock: ManualClock(),
+            coachingAttempts: observers.coachingAttempts,
+            automaticAttemptDelay: { _ in },
+            activityLog: ActivityLog())
+
+        var outcomes: [TurnOutcome] = []
+        transcript.append(.init(speaker: .me, text: "walk the route forward", at: 1))
+        outcomes.append(await driver.handleTrigger(.turnEnd))
+        transcript.append(.init(speaker: .me, text: "now exhaust the final target", at: 2))
+        outcomes.append(await driver.handleTrigger(.turnEnd))
+
+        return Snapshot(
+            outcomes: outcomes,
+            providerRequests: requests.bodies,
+            overlayEvents: zip(overlay.rendered, overlay.renderedSeconds)
+                .map { OverlayEvent(lines: $0, perLineSeconds: $1) },
+            routeTransitions: transitions.events)
+    }
+}
+
+/// Captures every provider request body in send order, re-serialized with sorted keys so two runs
+/// produce byte-comparable data. `@unchecked Sendable`: the lock guards the captured requests.
+private final class RequestCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [Data] = []
+
+    func append(_ request: URLRequest) throws {
+        let object = try JSONSerialization.jsonObject(with: request.httpBody ?? Data())
+        let normalized = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.sortedKeys])
+        lock.withLock { storage.append(normalized) }
+    }
+
+    var bodies: [Data] {
+        lock.withLock { storage }
+    }
+}
+
+/// Records route transitions in delivery order. `@unchecked Sendable`: the lock guards the
+/// recorded events, appended from the driver's main-actor callbacks and read after the run.
+private final class TransitionCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [CoachingParityHarness.RouteTransition] = []
+
+    func append(_ transition: CoachingParityHarness.RouteTransition) {
+        lock.withLock { storage.append(transition) }
+    }
+
+    var events: [CoachingParityHarness.RouteTransition] {
+        lock.withLock { storage }
+    }
+}
+
+/// Serial call counter for the succeed-once-then-fail transport script. `@unchecked Sendable`: the
+/// lock guards the count.
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func next() -> Int {
+        lock.withLock {
+            count += 1
+            return count
+        }
+    }
+}

--- a/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
@@ -8,26 +8,6 @@ import Testing
 // A few cases deliberately park the synchronous disk edge. Keep their gates serial so the parallel
 // repository test run never consumes several cooperative-pool threads on test-only blockers.
 @Suite(.serialized) struct SessionAuditIsolationTests {
-    private struct CoachingSnapshot: Equatable {
-        let outcome: TurnOutcome
-        let providerRequests: [Data]
-        let renderedTips: [[String]]
-    }
-
-    /// `@unchecked Sendable`: the lock protects all captured requests.
-    private final class RequestCapture: @unchecked Sendable {
-        private let lock = NSLock()
-        private var storage: [Data] = []
-
-        func append(_ request: Data) {
-            lock.withLock { storage.append(request) }
-        }
-
-        var requests: [Data] {
-            lock.withLock { storage }
-        }
-    }
-
     /// Holds the worker in its first open while mailbox admission remains available.
     private final class BlockingOpenWriter: SessionAuditWriting, @unchecked Sendable {
         let openEntered = DispatchSemaphore(value: 0)
@@ -160,51 +140,100 @@ import Testing
         }
     }
 
-    @Test func coachingIsIdenticalWithNoAuditOrAnEnabledOverloadedOrFailingAudit() async throws {
+    @Test func coachingIsIdenticalAcrossAbsentEnabledFullBlockedOversizeAndFailingEvidence()
+        async throws {
+        let absent = await CoachingParityHarness.run()
+
+        // The invariant is only as strong as the scenario behind it, so pin the baseline: both
+        // terminal outcomes, one provider request per attempt (3 primary + 1 tip + 3 final), the
+        // delivered tip, and all three route transition kinds in delivery order.
+        #expect(absent.outcomes == [.spoke, .brainError])
+        #expect(absent.providerRequests.count == 7)
+        #expect(absent.overlayEvents.map(\.lines) == [["same tip"]])
+        #expect(absent.routeTransitions == [
+            .skipped(CoachingParityHarness.unavailableTarget),
+            .advanced(
+                from: CoachingParityHarness.primaryTarget,
+                to: CoachingParityHarness.finalTarget),
+            .exhausted(CoachingParityHarness.finalTarget),
+        ])
+
         let enabledDirectory = ActivityLogTests.tmp()
-        let overloadedDirectory = ActivityLogTests.tmp()
+        let fullDirectory = ActivityLogTests.tmp()
+        let blockedDirectory = ActivityLogTests.tmp()
+        let oversizeDirectory = ActivityLogTests.tmp()
         let failingDirectory = ActivityLogTests.tmp()
         defer {
             try? FileManager.default.removeItem(at: enabledDirectory)
-            try? FileManager.default.removeItem(at: overloadedDirectory)
+            try? FileManager.default.removeItem(at: fullDirectory)
+            try? FileManager.default.removeItem(at: blockedDirectory)
+            try? FileManager.default.removeItem(at: oversizeDirectory)
             try? FileManager.default.removeItem(at: failingDirectory)
         }
 
+        // Enabled: a healthy audit records everything and closes complete.
         let enabled = FileSessionAudit(
             directory: enabledDirectory,
             worker: SessionAuditWorker(limits: .production, writer: SessionAuditFileWriter()))
-        let enabledSnapshot = await runCoaching(traffic: enabled, coachingAttempts: enabled)
+        let enabledSnapshot = await CoachingParityHarness.run(
+            observers: .init(brainTraffic: enabled, coachingAttempts: enabled))
         #expect(await enabled.close() == .complete)
 
-        let noAuditSnapshot = await runCoaching()
+        // Full: a one-event mailbox behind a parked open overflows, losing records.
+        let fullWriter = BlockingOpenWriter()
+        let full = FileSessionAudit(
+            directory: fullDirectory,
+            worker: SessionAuditWorker(
+                limits: .init(maxEventCount: 1, maxRetainedBytes: 4_096),
+                writer: fullWriter))
+        await wait(for: fullWriter.openEntered)
+        let fullSnapshot = await CoachingParityHarness.run(
+            observers: .init(brainTraffic: full, coachingAttempts: full))
+        fullWriter.releaseOpen()
+        #expect(await full.close() == .partial)
+        #expect((try healthMarker(in: fullDirectory)["queue_overflow"] as? Int ?? 0) > 0)
 
+        // Blocked: the worker never leaves its first open during the whole run. Nothing is lost
+        // under production limits, so the evidence still closes complete after release.
+        let blockedWriter = BlockingOpenWriter()
+        let blocked = FileSessionAudit(
+            directory: blockedDirectory,
+            worker: SessionAuditWorker(limits: .production, writer: blockedWriter))
+        await wait(for: blockedWriter.openEntered)
+        let blockedSnapshot = await CoachingParityHarness.run(
+            observers: .init(brainTraffic: blocked, coachingAttempts: blocked))
+        blockedWriter.releaseOpen()
+        #expect(await blocked.close() == .complete)
+
+        // Oversize: every brain-traffic record (a full request body) exceeds the retained-byte
+        // cap outright and is dropped.
+        let oversize = FileSessionAudit(
+            directory: oversizeDirectory,
+            worker: SessionAuditWorker(
+                limits: .init(maxEventCount: 256, maxRetainedBytes: 256),
+                writer: SessionAuditFileWriter()))
+        await waitForHealthMarker(in: oversizeDirectory)
+        let oversizeSnapshot = await CoachingParityHarness.run(
+            observers: .init(brainTraffic: oversize, coachingAttempts: oversize))
+        #expect(await oversize.close() == .partial)
+        #expect((try healthMarker(in: oversizeDirectory)["oversize_record"] as? Int ?? 0) > 0)
+
+        // Failing: the first file append fails; later records still persist.
         let failingWriter = FailFirstAppendWriter()
         let failing = FileSessionAudit(
             directory: failingDirectory,
             worker: SessionAuditWorker(limits: .production, writer: failingWriter))
         await wait(for: failingWriter.openCompleted)
-        let failingSnapshot = await runCoaching(traffic: failing, coachingAttempts: failing)
+        let failingSnapshot = await CoachingParityHarness.run(
+            observers: .init(brainTraffic: failing, coachingAttempts: failing))
         #expect(await failing.close() == .partial)
         #expect(failingWriter.appendCount > 1)
 
-        let blockingWriter = BlockingOpenWriter()
-        let overloadedWorker = SessionAuditWorker(
-            limits: .init(maxEventCount: 1, maxRetainedBytes: 4_096),
-            writer: blockingWriter)
-        let overloaded = FileSessionAudit(
-            directory: overloadedDirectory,
-            worker: overloadedWorker)
-        await wait(for: blockingWriter.openEntered)
-        let overloadedSnapshot = await runCoaching(
-            traffic: overloaded,
-            coachingAttempts: overloaded)
-        blockingWriter.releaseOpen()
-        #expect(await overloaded.close() == .partial)
-        #expect((try healthMarker(in: overloadedDirectory)["queue_overflow"] as? Int ?? 0) > 0)
-
-        #expect(enabledSnapshot == noAuditSnapshot)
-        #expect(enabledSnapshot == overloadedSnapshot)
-        #expect(enabledSnapshot == failingSnapshot)
+        #expect(enabledSnapshot == absent)
+        #expect(fullSnapshot == absent)
+        #expect(blockedSnapshot == absent)
+        #expect(oversizeSnapshot == absent)
+        #expect(failingSnapshot == absent)
     }
 
     @Test func aFullQueueDropsOnlyThatRecordAndLaterRecordingContinues() async throws {
@@ -377,57 +406,6 @@ import Testing
         #expect(try Data(contentsOf: trafficURL) == trafficBefore)
         #expect(try Data(contentsOf: healthURL) == healthBefore)
         #expect(try healthMarker(in: directory)["state"] as? String == "complete")
-    }
-
-    private func runCoaching(
-        traffic: (any BrainTrafficAuditing)? = nil,
-        coachingAttempts: (any CoachingAttemptAuditing)? = nil
-    ) async -> CoachingSnapshot {
-        let requests = RequestCapture()
-        let response = Data(
-            #"{"status":"completed","output":[{"type":"function_call","call_id":"s1","name":"speak","arguments":"{\"lines\":[\"same tip\"]}"}]}"#.utf8)
-        let client = OpenAIBrainClient(
-            apiKey: "test-key",
-            model: "gpt-5.5",
-            traffic: traffic,
-            send: { request in
-                let body = request.httpBody ?? Data()
-                let object = try JSONSerialization.jsonObject(with: body)
-                requests.append(try JSONSerialization.data(
-                    withJSONObject: object,
-                    options: [.sortedKeys]))
-                return (
-                    response,
-                    HTTPURLResponse(
-                        url: request.url!,
-                        statusCode: 200,
-                        httpVersion: nil,
-                        headerFields: nil))
-            })
-        let target = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
-        let overlay = FakeOverlay()
-        let transcript = RollingTranscript()
-        let driver = CoachDriver(
-            config: .default,
-            transcript: transcript,
-            route: ConfiguredBrainRoute(targets: [
-                ConfiguredBrainTarget(target: target, brain: client),
-            ]),
-            screen: FakeScreen(),
-            overlay: overlay,
-            clock: ManualClock(),
-            coachingAttempts: coachingAttempts,
-            automaticAttemptDelay: { _ in },
-            activityLog: ActivityLog())
-        transcript.append(.init(
-            speaker: .me,
-            text: "compare audit observer behavior",
-            at: 1))
-
-        return CoachingSnapshot(
-            outcome: await driver.handleTrigger(.turnEnd),
-            providerRequests: requests.requests,
-            renderedTips: overlay.rendered)
     }
 
     private func recordTraffic(_ audit: FileSessionAudit, tag: String) {

--- a/scripts/check-coaching-kernel.sh
+++ b/scripts/check-coaching-kernel.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Dependency guard over the product-critical coaching kernel: finalized transcript admission
+# through overlay delivery (wiki/lean-coaching-core.md, "Product-critical coaching kernel" in the
+# destination diagram; decision record "2026-08-16 — Session evidence uses one shared stack and two
+# projections"). From admission to delivery, coaching depends only on deterministic in-memory policy
+# and explicitly injected critical ports — so the kernel may not reach for the OS or for
+# evaluator/sealed-session machinery directly. Keeping this in the Gate makes a new reach-through
+# fail the normal test run instead of waiting on a future manual audit to notice it.
+#
+# Covered paths — the kernel per the destination diagram:
+#   Coach/          attempt scheduler, forward-only route state, attempt runner, history commit
+#   Transcription/  finalized transcript admission and the transcription ports
+#   Triggers/       trigger and turn-substance policy feeding the scheduler
+#   Overlay/        the enabled overlay output port (delivery itself; the AppKit panels in
+#                   Sources/JarvisOverlay are the deliberately thin OS-bound shell outside Core)
+#   Audio/          capture-side buffering and speech-activity policy ahead of admission
+#   Support/        Clock, retry schedule, and task plumbing the kernel depends on
+#   Brain/          the BrainClient port and route/model types — minus Adapters/ (below)
+#   Diagnostics/CaptureReadinessMonitor.swift, AudioContinuityWitness*.swift,
+#   AudioContinuityMatcher.swift
+#                   the capture-heartbeat source and capture health policy, which the diagram
+#                   places inside the kernel even though they live beside persistence code
+#
+# Deliberately outside the covered paths today; each joins with the slice that clears it:
+#   Brain/Adapters/ concrete provider adapters (URLSession, CLI Process). They are outside the
+#                   kernel by design and move outward with the Phase 4 adapter move; until then
+#                   they legitimately hold the OS symbols this guard bans.
+#   Screen/         ScreenSnapshotting is a kernel port, but it sits in the same directory as the
+#                   screencapture runner, which drives a Process and cleans up via FileManager.
+#                   The path (and with it Process/FileManager coverage over screen capture) joins
+#                   when the screen-capture move relocates that adapter.
+#   Diagnostics/ (rest)
+#                   evidence persistence by definition; only the heartbeat/health files above are
+#                   kernel.
+#
+# Rules a later slice adds — do not read today's set as the finished contract:
+#   - Persistence singletons (ActivityLog / .shared / jlog) arrive with the Activity projection and
+#     the diagnostics move onto SessionEvidence. CoachDriver and TranscriptionCoachingCoordinator
+#     still take an injected ActivityLog defaulting to .shared and call jlog synchronously, so that
+#     rule cannot land green yet.
+
+kernel_paths=(
+    Sources/JarvisCore/Coach
+    Sources/JarvisCore/Transcription
+    Sources/JarvisCore/Triggers
+    Sources/JarvisCore/Overlay
+    Sources/JarvisCore/Audio
+    Sources/JarvisCore/Support
+    Sources/JarvisCore/Brain
+    Sources/JarvisCore/Diagnostics/CaptureReadinessMonitor.swift
+    Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift
+    "Sources/JarvisCore/Diagnostics/AudioContinuityWitness+Types.swift"
+    Sources/JarvisCore/Diagnostics/AudioContinuityMatcher.swift
+)
+
+# Direct OS reach-through. File, process, network, and Console access belong behind injected ports
+# and the evidence stack, never inline in coaching policy.
+os_pattern='\bFileManager\b|\bFileHandle\b|\bProcess\b|\bURLSession\b|\bNSLog\b'
+
+# Evaluator and sealed-session types, plus the concrete evidence-persistence machinery. The kernel
+# may emit through its narrow observer ports (BrainTrafficAuditing, CoachingAttemptAuditing); it may
+# never name the offline analysis surface or the persistence implementation behind those ports.
+sealed_pattern='\bAgenticEvaluation\b|\bAgenticEvaluator\b|\bEvaluationTranscript\b|\bEvalReportPage\b|\bSessionEvidenceIndex\b|\bSessionMetrics\b|\bSessionStore\b|\bFileSessionAudit\b|\bSessionAuditWorker\b|\bSessionAuditFileWriter\b'
+
+check() {
+    local label="$1"
+    local pattern="$2"
+
+    local scan_status=0
+    local matches
+    matches="$(/usr/bin/grep -RInE --exclude-dir=Adapters "$pattern" "${kernel_paths[@]}")" \
+        || scan_status=$?
+    if [ "$scan_status" -gt 1 ]; then
+        echo "Coaching-kernel $label scan failed; refusing to pass without a complete scan." >&2
+        exit "$scan_status"
+    fi
+
+    # A line whose first non-whitespace is `//` is prose about a symbol, not API use, so it does
+    # not weaken the rule. Trailing comments on code lines still count, which errs strict.
+    local filter_status=0
+    local violations
+    violations="$(printf '%s' "$matches" | /usr/bin/grep -vE '^[^:]+:[0-9]+:[[:space:]]*//')" \
+        || filter_status=$?
+    if [ "$filter_status" -gt 1 ]; then
+        echo "Coaching-kernel $label comment filtering failed; refusing to pass." >&2
+        exit "$filter_status"
+    fi
+    if [ -n "$violations" ]; then
+        echo "Coaching-kernel $label violation — inject a port instead of reaching through:" >&2
+        echo "$violations" >&2
+        exit 1
+    fi
+}
+
+check "OS reach-through" "$os_pattern"
+check "evaluator/sealed-session reach-through" "$sealed_pattern"
+
+echo "Coaching-kernel dependency guard passed."

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 ./scripts/check-ghost-mode.sh
+./scripts/check-coaching-kernel.sh
 ./scripts/check-audio-capture-config.sh
 ./scripts/check-app-identities.sh
 ./scripts/check-release-config.sh


### PR DESCRIPTION
Closes #195 (sub-issue of #147). Design authority: `wiki/lean-coaching-core.md` and the decision record *2026-08-16 — Session evidence uses one shared stack and two projections*. No production behavior changes: the diff touches only `scripts/` and `Tests/`.

## What changed

- **`scripts/check-coaching-kernel.sh`** — a Gate-enforced dependency guard modelled on `check-ghost-mode.sh`, wired into `scripts/run-tests.sh` beside the other four checks. It scans the kernel paths (Coach, Transcription, Triggers, Overlay, Audio, Support, Brain minus Adapters, plus the capture-heartbeat/health files in Diagnostics, per the destination diagram's CORE subgraph) with two rule groups: direct OS reach-through (`FileManager`, `FileHandle`, `Process`, `URLSession`, `NSLog`) and evaluator/sealed-session/concrete-evidence-persistence types.
- **`Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift`** — an evidence-agnostic harness that drives one deterministic scenario (three temporary failures → advance, preflight-unavailable target → skip, tip delivery, then terminal exhaustion) and snapshots everything optional evidence must never change.
- **`SessionAuditIsolationTests`** — the parity test now runs that harness across six evidence variants and compares full snapshots; the audit-specific `runCoaching`/`CoachingSnapshot` helpers are gone.

## Acceptance criteria → how each is met

- **Guard runs from `run-tests.sh` and fails the Gate on new direct `FileManager`/`FileHandle`/`Process`/`URLSession`/`NSLog` use in the kernel** — `check-coaching-kernel.sh` is the second check in `run-tests.sh`; negative-tested by injecting `FileManager.default` into `Triggers/Trigger.swift` (guard exited 1 naming the line, then green again after revert).
- **Guard also rejects evaluator and sealed-session types** — second rule group bans `AgenticEvaluation`, `AgenticEvaluator`, `EvaluationTranscript`, `EvalReportPage`, `SessionEvidenceIndex`, `SessionMetrics`, `SessionStore`, and the concrete persistence machinery (`FileSessionAudit`, `SessionAuditWorker`, `SessionAuditFileWriter`); negative-tested with an injected `SessionEvidenceIndex` reference (exit 1). The narrow observer ports (`BrainTrafficAuditing`, `CoachingAttemptAuditing`) stay legal, as the design requires.
- **Covered paths and rule set documented inline, including rules later slices add** — the script header names each covered path and why, each exclusion and the slice that clears it (Brain/Adapters and Screen/ with the Phase 4 adapter/screen-capture moves), and the pending persistence-singleton rule (`ActivityLog` / `.shared` / `jlog`) that arrives with the Activity projection — `CoachDriver` still takes an injected `ActivityLog` defaulting to `.shared`, which is exactly why it cannot land yet.
- **Guard passes on `main` today without weakening or excepting any rule** — the only filtering is that a comment-only line is not API use (two `URLSession` doc mentions in `PCMBuffer.swift`); no rule has an exception marker and no violation was "fixed" to fit.
- **Parity snapshot compares terminal outcome, provider request sequence, overlay output events, and route transitions** — `CoachingParityHarness.Snapshot` holds `outcomes`, `providerRequests` (sorted-key request bodies in send order), `overlayEvents` (lines + per-line seconds), and `routeTransitions`; the test pins the baseline: `[.spoke, .brainError]`, 7 requests, one tip, and `[skipped, advanced, exhausted]` in delivery order.
- **Parity holds across absent, enabled, full, blocked, oversize, and failing evidence** — six variants, each with its own post-condition (complete close; `queue_overflow > 0`; blocked-then-released closes complete; `oversize_record > 0`; first-append failure closes partial) and each snapshot equal to the absent baseline.
- **Every case driven by deterministic fakes, no wall-clock latency thresholds** — scripted `send` transports, `ManualClock`, no-op attempt delay, and the suite's existing semaphore-gated writers (`BlockingOpenWriter`, `FailFirstAppendWriter`); every `@unchecked Sendable` carries its written lock justification.
- **Harness reusable by later evidence categories** — `EvidenceObservers` takes absent-by-default observer fields; a later slice adds a field for its category instead of building a new harness or editing the scenario.
- **Gate passes** — `swift build && ./scripts/run-tests.sh`: all five checks pass and 777 tests in 90 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)