### PR TITLE
refactor(diagnostics): carry one versioned SessionEvent over the settled audit transport

### DIFF
--- a/Sources/JarvisCore/Diagnostics/FileSessionAudit.swift
+++ b/Sources/JarvisCore/Diagnostics/FileSessionAudit.swift
@@ -62,11 +62,27 @@ public final class FileSessionAudit: BrainTrafficAuditing, CoachingAttemptAuditi
     }
 
     public func record(_ event: BrainTrafficAuditEvent) {
-        worker.record(event, for: session)
+        record(.brainTraffic(event))
     }
 
     public func record(_ event: CoachingAttemptAuditEvent) {
-        worker.record(event, for: session)
+        record(.coachingAttempt(event))
+    }
+
+    /// The one envelope admission every typed producer view converges on. The handle stamps
+    /// session attribution itself, so an event can only ever claim the session it was recorded
+    /// through. Internal until a later slice migrates producers onto the envelope directly; the
+    /// Activity presentation stays unused until Phase 2 moves Activity onto `SessionEvent`.
+    func record(
+        _ detail: SessionEvent.Detail,
+        presentingInActivity presentation: ActivityLog.Event? = nil
+    ) {
+        worker.record(
+            SessionEvent(
+                sessionID: session.id,
+                detail: detail,
+                activityPresentation: presentation),
+            for: session)
     }
 
     /// Seal the audit and wait for its accepted records plus one immutable terminal marker. Callers

--- a/Sources/JarvisCore/Diagnostics/SessionAuditWorker.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionAuditWorker.swift
@@ -5,7 +5,9 @@ import Darwin
 import Synchronization
 #endif
 
-/// One bounded process-level worker for every file-backed session audit.
+/// One bounded process-level worker for every file-backed session audit. Its mailbox carries one
+/// versioned `SessionEvent` per occurrence; the typed producer ports converge on it through their
+/// per-session handle.
 ///
 /// The mailbox lock protects only retained in-memory values and counters. Parsing, redaction,
 /// serialization, and file I/O run on the private serial queue after that lock is released.
@@ -113,8 +115,7 @@ final class SessionAuditWorker: @unchecked Sendable {
 
     private enum Payload: Sendable {
         case open
-        case traffic(BrainTrafficAuditEvent)
-        case attempt(CoachingAttemptAuditEvent)
+        case event(SessionEvent)
         case close(
             forcePartial: Bool,
             completion: @Sendable (SessionAuditCloseResult) -> Void)
@@ -182,7 +183,7 @@ final class SessionAuditWorker: @unchecked Sendable {
         return session
     }
 
-    func record(_ event: BrainTrafficAuditEvent, for session: Session) {
+    func record(_ event: SessionEvent, for session: Session) {
         guard !session.isSealed else {
             rejectLateEvent(for: session)
             return
@@ -190,19 +191,7 @@ final class SessionAuditWorker: @unchecked Sendable {
         _ = enqueue(
             Envelope(
                 session: session,
-                payload: .traffic(event),
-                retainedBytes: event.approximateRetainedBytes))
-    }
-
-    func record(_ event: CoachingAttemptAuditEvent, for session: Session) {
-        guard !session.isSealed else {
-            rejectLateEvent(for: session)
-            return
-        }
-        _ = enqueue(
-            Envelope(
-                session: session,
-                payload: .attempt(event),
+                payload: .event(event),
                 retainedBytes: event.approximateRetainedBytes))
     }
 
@@ -357,10 +346,8 @@ final class SessionAuditWorker: @unchecked Sendable {
         switch envelope.payload {
         case .open:
             _ = ensureOpen(envelope.session)
-        case .traffic(let event):
-            persistTraffic(event, session: envelope.session)
-        case .attempt(let event):
-            persistAttempt(event, session: envelope.session)
+        case .event(let event):
+            persist(event, session: envelope.session)
         case .close(let forcePartial, let completion):
             finalize(
                 envelope.session,
@@ -381,6 +368,17 @@ final class SessionAuditWorker: @unchecked Sendable {
         } catch {
             session.health.markOpenFailure()
             return false
+        }
+    }
+
+    /// Project one envelope onto the session folder. File choice per kind is a projection detail;
+    /// the record schemas and filenames are the unchanged Phase 0 contract.
+    private func persist(_ event: SessionEvent, session: Session) {
+        switch event.detail {
+        case .brainTraffic(let traffic):
+            persistTraffic(traffic, session: session)
+        case .coachingAttempt(let attempt):
+            persistAttempt(attempt, session: session)
         }
     }
 

--- a/Sources/JarvisCore/Diagnostics/SessionEvent.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEvent.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// The one versioned envelope for a session-evidence occurrence.
+///
+/// Phase 1 expand step of the lean coaching core ("One Event, Two Projections" in
+/// wiki/lean-coaching-core.md): every occurrence admitted to the shared bounded session-evidence
+/// transport travels as one `SessionEvent`. The narrow producer ports — `BrainTrafficAuditing` and
+/// `CoachingAttemptAuditing` — remain typed views that wrap their detail into this envelope on the
+/// one per-session handle; they are not separate queues, workers, health records, or lifecycles.
+///
+/// Persisted record files keep their own schemas and `audit_version`. This envelope carries its own
+/// version so a later persisted projection of the envelope itself can evolve independently of any
+/// single record file.
+public struct SessionEvent: Sendable {
+    /// The envelope-shape version stamped on every event.
+    public static let currentVersion = 1
+
+    /// Stable identity of the occurrence category. Raw values are persisted-projection-grade
+    /// identifiers: once a kind ships, its raw value never changes.
+    public enum Kind: String, Sendable {
+        case brainTraffic = "brain_traffic"
+        case coachingAttempt = "coaching_attempt"
+    }
+
+    /// The full typed payload of one occurrence. Later slices add cases here — a new producer
+    /// category joins the envelope, never a second admission stack.
+    public enum Detail: Sendable {
+        case brainTraffic(BrainTrafficAuditEvent)
+        case coachingAttempt(CoachingAttemptAuditEvent)
+    }
+
+    public let version: Int
+    /// Identity of the originating session handle. Every event is stamped at admission so late
+    /// work from a closing session can never be attributed to its replacement.
+    public let sessionID: UUID
+    /// When the producer handed the occurrence to the transport. The occurrence itself is
+    /// timestamped by `occurredAt`.
+    public let recordedAt: Date
+    public let detail: Detail
+    /// Closed human-safe copy for the Activity projection. `ActivityLog.Event` is the existing
+    /// closed presentation set, reused so the shared stack never opens a generic path for
+    /// producers to author human-facing strings. Unused until Phase 2 migrates Activity onto the
+    /// envelope: no persisted projection reads this field today.
+    public let activityPresentation: ActivityLog.Event?
+
+    public init(
+        sessionID: UUID,
+        detail: Detail,
+        activityPresentation: ActivityLog.Event? = nil,
+        recordedAt: Date = Date()
+    ) {
+        self.version = Self.currentVersion
+        self.sessionID = sessionID
+        self.detail = detail
+        self.activityPresentation = activityPresentation
+        self.recordedAt = recordedAt
+    }
+
+    /// Derived from `detail` so the stable kind can never disagree with the typed payload.
+    public var kind: Kind {
+        switch detail {
+        case .brainTraffic: .brainTraffic
+        case .coachingAttempt: .coachingAttempt
+        }
+    }
+
+    /// When the occurrence happened, as its typed detail recorded it. Derived rather than stored
+    /// twice so envelope timing cannot drift from what the persisted record encodes.
+    public var occurredAt: Date {
+        switch detail {
+        case .brainTraffic(let event): event.date
+        case .coachingAttempt(.started(let event)): event.date
+        case .coachingAttempt(.finished(let event)): event.date
+        }
+    }
+
+    /// Attempt attribution where applicable: nil for traffic outside a coaching attempt, such as
+    /// the summarizer. Derived from the detail's own attribution for the same no-drift reason.
+    public var attemptID: Int? {
+        switch detail {
+        case .brainTraffic(let event): event.requestContext?.attemptID
+        case .coachingAttempt(.started(let event)): event.attemptID
+        case .coachingAttempt(.finished(let event)): event.attemptID
+        }
+    }
+
+    /// Mailbox accounting for the whole envelope: the typed detail, the fixed envelope fields, and
+    /// the retained strings of an attached Activity presentation. The count/byte bound covers
+    /// everything an accepted envelope keeps in memory.
+    var approximateRetainedBytes: Int {
+        var bytes = 64
+        switch detail {
+        case .brainTraffic(let event):
+            bytes = Self.adding(bytes, event.approximateRetainedBytes)
+        case .coachingAttempt(let event):
+            bytes = Self.adding(bytes, event.approximateRetainedBytes)
+        }
+        if let activityPresentation {
+            let rendered = activityPresentation.rendered
+            bytes = Self.adding(bytes, rendered.message.utf8.count)
+            bytes = Self.adding(bytes, rendered.imageBase64?.utf8.count ?? 0)
+        }
+        return bytes
+    }
+
+    private static func adding(_ lhs: Int, _ rhs: Int) -> Int {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        return overflow ? .max : sum
+    }
+}

--- a/Tests/JarvisCoreTests/Diagnostics/SessionEventTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionEventTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct SessionEventTests {
+    @Test func envelopeDerivesKindTimingAndAttributionFromTypedDetail() {
+        let sessionID = UUID()
+        let occurred = Date(timeIntervalSince1970: 1_755_000_000)
+
+        let traffic = SessionEvent(
+            sessionID: sessionID,
+            detail: .brainTraffic(BrainTrafficAuditEvent(
+                tag: "coach",
+                request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+                response: nil,
+                status: nil,
+                latencyMs: 12,
+                error: nil,
+                phases: nil,
+                kind: .providerCall,
+                requestContext: CoachingRequestAttribution.context(
+                    attemptID: 7,
+                    wake: .trigger,
+                    reason: .turnEnd,
+                    phase: .initial,
+                    sequence: 1),
+                date: occurred)))
+        #expect(traffic.version == SessionEvent.currentVersion)
+        #expect(traffic.kind == .brainTraffic)
+        #expect(traffic.kind.rawValue == "brain_traffic")
+        #expect(traffic.sessionID == sessionID)
+        #expect(traffic.occurredAt == occurred)
+        #expect(traffic.attemptID == 7)
+        #expect(traffic.activityPresentation == nil)
+
+        let unattributed = SessionEvent(
+            sessionID: sessionID,
+            detail: .brainTraffic(BrainTrafficAuditEvent(
+                tag: "summarizer",
+                request: Data(),
+                response: nil,
+                status: nil,
+                latencyMs: 8,
+                error: nil,
+                phases: nil,
+                kind: .providerCall,
+                requestContext: nil,
+                date: occurred)))
+        #expect(unattributed.attemptID == nil)
+
+        let finished = SessionEvent(
+            sessionID: sessionID,
+            detail: .coachingAttempt(.finished(.init(
+                attemptID: 3,
+                terminal: .staySilent,
+                outcome: .silentByModel,
+                date: occurred))))
+        #expect(finished.kind == .coachingAttempt)
+        #expect(finished.kind.rawValue == "coaching_attempt")
+        #expect(finished.occurredAt == occurred)
+        #expect(finished.attemptID == 3)
+    }
+
+    /// The expand-step pin: admitting through the typed producer views and admitting the same
+    /// occurrences as envelopes — even with an Activity presentation attached — must leave the
+    /// persisted session folder byte-for-byte identical.
+    @Test func typedViewsAndEnvelopeAdmissionPersistByteIdenticalRecords() async throws {
+        let viewDirectory = ActivityLogTests.tmp()
+        let envelopeDirectory = ActivityLogTests.tmp()
+        defer {
+            try? FileManager.default.removeItem(at: viewDirectory)
+            try? FileManager.default.removeItem(at: envelopeDirectory)
+        }
+        let occurred = Date(timeIntervalSince1970: 1_755_000_000)
+        let trafficEvent = BrainTrafficAuditEvent(
+            tag: "coach",
+            request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+            response: Data(#"{"status":"completed"}"#.utf8),
+            status: 200,
+            latencyMs: 12,
+            error: nil,
+            phases: nil,
+            kind: .providerCall,
+            requestContext: nil,
+            date: occurred)
+        let transcript = [TranscriptLine(speaker: .them, text: "Explain the tradeoff", at: 1)]
+        let startedEvent = CoachingAttemptAuditEvent.started(.init(
+            attemptID: 3,
+            wake: .trigger,
+            reason: .turnEnd,
+            target: BrainTarget(provider: .openAI, modelID: "gpt-5.5"),
+            transcriptStartIndex: 8,
+            transcriptLines: transcript,
+            classifications: [.substantive],
+            brainFacingTranscriptIndices: [8],
+            date: occurred))
+        let finishedEvent = CoachingAttemptAuditEvent.finished(.init(
+            attemptID: 3,
+            terminal: .speak,
+            outcome: .spoke,
+            date: occurred))
+
+        let viewAudit = await FileSessionAudit.readyForTesting(directory: viewDirectory)
+        viewAudit.record(trafficEvent)
+        viewAudit.record(startedEvent)
+        viewAudit.record(finishedEvent)
+        #expect(await viewAudit.closeForTesting() == .complete)
+
+        let envelopeAudit = await FileSessionAudit.readyForTesting(directory: envelopeDirectory)
+        envelopeAudit.record(
+            .brainTraffic(trafficEvent),
+            presentingInActivity: .tip(lines: ["same tip"]))
+        envelopeAudit.record(.coachingAttempt(startedEvent))
+        envelopeAudit.record(.coachingAttempt(finishedEvent))
+        #expect(await envelopeAudit.closeForTesting() == .complete)
+
+        for filename in [
+            FileSessionAudit.brainTrafficFilename,
+            FileSessionAudit.coachingAttemptsFilename,
+            FileSessionAudit.healthFilename,
+        ] {
+            let viewBytes = try Data(
+                contentsOf: viewDirectory.appendingPathComponent(filename))
+            let envelopeBytes = try Data(
+                contentsOf: envelopeDirectory.appendingPathComponent(filename))
+            #expect(viewBytes == envelopeBytes, "\(filename) diverged between admission paths")
+            #expect(!viewBytes.isEmpty, "\(filename) comparison must not be vacuous")
+        }
+    }
+
+    /// The retained-byte bound covers the whole envelope, not only its typed detail: a small
+    /// occurrence dragging an oversize Activity presentation is dropped, and later admission
+    /// continues independently.
+    @Test func anOversizeActivityPresentationCountsAgainstTheByteBound() async throws {
+        let directory = ActivityLogTests.tmp()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let audit = FileSessionAudit(
+            directory: directory,
+            worker: SessionAuditWorker(
+                limits: .init(maxEventCount: 8, maxRetainedBytes: 1_024),
+                writer: SessionAuditFileWriter()))
+        await waitForHealthMarker(in: directory)
+
+        audit.record(
+            .brainTraffic(BrainTrafficAuditEvent(
+                tag: "small-detail",
+                request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+                response: nil,
+                status: nil,
+                latencyMs: 5,
+                error: nil,
+                phases: nil,
+                kind: .providerCall,
+                requestContext: nil,
+                date: Date())),
+            presentingInActivity: .screenViewed(
+                imageBase64JPEG: String(repeating: "A", count: 4_096)))
+        audit.record(
+            tag: "after-presentation-drop",
+            request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+            response: nil,
+            status: nil,
+            latencyMs: 5)
+
+        #expect(await audit.close() == .partial)
+        let text = try String(
+            contentsOf: directory.appendingPathComponent(
+                FileSessionAudit.brainTrafficFilename),
+            encoding: .utf8)
+        let tags = text.split(separator: "\n")
+            .compactMap {
+                (try? JSONSerialization.jsonObject(with: Data($0.utf8))) as? [String: Any]
+            }
+            .compactMap { $0["tag"] as? String }
+        #expect(tags == ["after-presentation-drop"])
+        let health = try Data(
+            contentsOf: directory.appendingPathComponent(FileSessionAudit.healthFilename))
+        let marker = try #require(
+            JSONSerialization.jsonObject(with: health) as? [String: Any])
+        #expect(marker["state"] as? String == "partial")
+        #expect(marker["oversize_record"] as? Int == 1)
+    }
+
+    private func waitForHealthMarker(in directory: URL) async {
+        let marker = directory.appendingPathComponent(FileSessionAudit.healthFilename)
+        let deadline = ContinuousClock.now.advanced(by: .seconds(5))
+        while !FileManager.default.fileExists(atPath: marker.path),
+              ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+    }
+}


### PR DESCRIPTION
Closes #196. Phase 1 expand step of the lean coaching core (`wiki/lean-coaching-core.md`, "One Event, Two Projections"; decision record "2026-08-16 — Session evidence uses one shared stack and two projections").

## What changed

- **`SessionEvent.swift` (new):** the one versioned envelope for a session-evidence occurrence. Stored fields: `version` (stamped `currentVersion = 1`), `sessionID`, `recordedAt`, typed `detail`, and an optional `activityPresentation`. The stable `kind`, `occurredAt`, and `attemptID` are derived from the typed detail so envelope metadata can never disagree with the payload. The presentation field reuses the existing closed `ActivityLog.Event` set, so the shared stack opens no generic path for producers to author human-facing copy; it stays unused until the Phase 2 Activity migration.
- **`SessionAuditWorker.swift`:** the mailbox payload now carries `.event(SessionEvent)` instead of separate traffic/attempt cases, admitted through one `record(_:for:)` entry point. The worker projects each envelope onto the unchanged Phase 0 encoders — file choice per kind is a projection detail. Ring, limits, health counters, deferred-close table, and lifecycle are untouched.
- **`FileSessionAudit.swift`:** the `BrainTrafficAuditing` / `CoachingAttemptAuditing` port methods become one-line typed views over a single internal envelope-admission method. The handle stamps session attribution itself, so an event can only claim the session it was recorded through. Retained-byte accounting now covers the whole envelope, including an attached presentation.
- **`SessionEventTests.swift` (new):** pins envelope derivation, byte-for-byte identical persisted files between typed-view admission and direct envelope admission (with a presentation attached), and oversize rejection when a presentation drags a small detail past the byte bound.

## Acceptance criteria

- **Versioned `SessionEvent` envelope with stable kind, session/attempt attribution, occurrence and record timing, typed detail, optional Activity presentation** — `SessionEvent.swift`; derivation pinned by `envelopeDerivesKindTimingAndAttributionFromTypedDetail`.
- **Phase 0 worker admits and persists `SessionEvent`; ports become typed views over one session handle** — worker mailbox carries only `.open` / `.event(SessionEvent)` / `.close`; both port methods wrap into `SessionEvent.Detail` and converge on `FileSessionAudit`'s one handle.
- **Exactly one mailbox, worker, per-session handle, close lifecycle, completeness record** — no new type was introduced besides the value-type envelope; the diff touches only payload shape and admission signatures.
- **Persisted filenames, record schemas, evaluator-visible provenance byte-for-byte unchanged** — encoders (`encodeTraffic`/`encodeAttempt`/`healthData`) untouched; `typedViewsAndEnvelopeAdmissionPersistByteIdenticalRecords` compares all three files byte-for-byte; `FileSessionAuditTrafficTests` / `FileSessionAuditAttemptTests` pass unmodified.
- **Admission nonthrowing, non-waiting, bounded by count and bytes** — admission path unchanged apart from the payload type; the byte bound now honestly covers envelope overhead and presentation strings (`anOversizeActivityPresentationCountsAgainstTheByteBound`).
- **#146 close semantics hold** — seal/close/abandon logic untouched; `SessionAuditIsolationTests` (seal-once, monotonic health, async Stop seal, independent Start, deferred closes) pass unmodified.
- **Parity harness passes unchanged** — `CoachingParityHarness.swift` untouched; the absent/enabled/full/blocked/oversize/failing parity test passes.
- **Existing `FileSessionAudit` and `SessionAuditIsolation` tests pass without relaxed assertions** — no existing test file was edited.
- **Gate passes** — `swift build && ./scripts/run-tests.sh`: build complete, ghost-mode + coaching-kernel + capture/identity/release guards passed, `✔ Test run with 780 tests in 91 suites passed after 25.542 seconds`.

## Explicitly not done (later tickets)

Producer migration onto the envelope, routing `jlog` diagnostics through the worker, and the Activity projection (Phase 2). No file renames or record-schema changes — file partitioning stays a projection detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)