### PR TITLE
refactor(screen): move screen-capture process and file I/O to the macOS edge

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,13 @@ let package = Package(
         // The AppKit overlay lives in its own library target (not the executable) so it can be
         // imported by tests — see Tests/JarvisOverlayTests for the screen-capture invisibility checks.
         .target(name: "JarvisOverlay", dependencies: ["JarvisCore"]),
+        // The OS-bound screen-capture adapter behind Core's ScreenCapturing port: the cancellable
+        // `screencapture` helper process, the transient session-local JPEG, and the
+        // cleanup-verification latch (wiki/lean-coaching-core.md Phase 4). A library target rather
+        // than JarvisApp code so Tests/JarvisScreenCaptureTests can keep driving the
+        // cancellation/cleanup/latch privacy contract headlessly, which Core's Foundation-only
+        // tests no longer can once the process leaves Core.
+        .target(name: "JarvisScreenCapture", dependencies: ["JarvisCore"]),
         // WebRTC audio processing (AEC3 + classic VAD), the OS/native-bound edge. The C++ AEC3
         // implementation and upstream VAD are prebuilt + statically merged with abseil into
         // Sources/CJarvisAEC/lib/libjarvis-aec.a by scripts/build-aec.sh (zero runtime dylib deps),
@@ -54,7 +61,8 @@ let package = Package(
         .executableTarget(
             name: "JarvisApp",
             dependencies: [
-                "JarvisCore", "JarvisEvaluation", "JarvisOverlay", "CJarvisAEC",
+                "JarvisCore", "JarvisEvaluation", "JarvisOverlay", "JarvisScreenCapture",
+                "CJarvisAEC",
                 .product(name: "Sparkle", package: "Sparkle"),
             ],
             swiftSettings: jarvisAppSwiftSettings,
@@ -83,6 +91,10 @@ let package = Package(
         .testTarget(
             name: "JarvisOverlayTests",
             dependencies: ["JarvisOverlay"]
+        ),
+        .testTarget(
+            name: "JarvisScreenCaptureTests",
+            dependencies: ["JarvisScreenCapture", "JarvisCore"]
         ),
         // WebKit-driven end-to-end tests for the activity viewer's shipped HTML/JS. Kept separate
         // from JarvisCoreTests so the core's own test target stays Foundation-only and the

--- a/Sources/JarvisApp/Capture/WindowScopedScreenCapture.swift
+++ b/Sources/JarvisApp/Capture/WindowScopedScreenCapture.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreGraphics
 import JarvisCore
+import JarvisScreenCapture
 
 /// Captures just the frontmost app window (`screencapture -l`) when the capture scope is
 /// `.activeWindow`, with an on-device OCR of the shot riding along as `recognizedText`. Falls back

--- a/Sources/JarvisCore/Screen/ScreenCapturing.swift
+++ b/Sources/JarvisCore/Screen/ScreenCapturing.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Returns a screenshot (plus optional OCR text) for the brain, or nil on failure.
+///
+/// This is the kernel's screen port: Core owns the contract and the pure selection/layout logic
+/// behind it, while the concrete `screencapture` helper, its transient session-local JPEG, and the
+/// cleanup-verification latch live at the macOS edge (`JarvisScreenCapture`'s `ScreenCaptureRunner`
+/// / `ScreenCaptureCLI`, composed by `WindowScopedScreenCapture` in JarvisApp).
+public protocol ScreenCapturing: Sendable {
+    func capture() -> ScreenSnapshot?
+    /// Stop an in-flight capture and make `capture()` return only after its helper and transient
+    /// file have been cleaned up.
+    func cancelCapture()
+}

--- a/Sources/JarvisScreenCapture/ScreenCaptureCLI.swift
+++ b/Sources/JarvisScreenCapture/ScreenCaptureCLI.swift
@@ -1,12 +1,5 @@
 import Foundation
-
-/// Returns a screenshot (plus optional OCR text) for the brain, or nil on failure.
-public protocol ScreenCapturing: Sendable {
-    func capture() -> ScreenSnapshot?
-    /// Stop an in-flight capture and make `capture()` return only after its helper and transient
-    /// file have been cleaned up.
-    func cancelCapture()
-}
+import JarvisCore
 
 /// Uses the built-in `screencapture -x -t jpg` (silent). In entire-display scope it shoots the
 /// display chosen in Settings (`ScreenCapturePreferences`, read at capture time so a change applies

--- a/Sources/JarvisScreenCapture/ScreenCaptureRunner.swift
+++ b/Sources/JarvisScreenCapture/ScreenCaptureRunner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JarvisCore
 #if canImport(Darwin)
 import Darwin
 #else
@@ -6,6 +7,14 @@ import Glibc
 #endif
 
 /// Owns one cancellable `screencapture` helper and its transient session-local JPEG.
+///
+/// This is the macOS edge behind Core's `ScreenCapturing` port: the helper process, the transient
+/// file, and the cleanup-verification latch live here so `JarvisCore`'s screen logic stays
+/// Foundation-only. The privacy contract is unchanged — cancellation owns helper teardown and file
+/// cleanup, cleanup must be proven before the capture returns, and an unprovable cleanup latches
+/// this runner so no later capture or display fallback starts while a screen-derived file is
+/// unaccounted for (see wiki/decisions.md, "Screen-capture cancellation owns helper and file
+/// cleanup").
 ///
 /// `@unchecked Sendable` is justified because `lock` guards `activeCommand` and `cleanupFailed`;
 /// each command separately guards its process lifecycle.

--- a/Tests/JarvisScreenCaptureTests/ScreenCaptureRunnerTests.swift
+++ b/Tests/JarvisScreenCaptureTests/ScreenCaptureRunnerTests.swift
@@ -1,7 +1,8 @@
 import Darwin
 import Foundation
+import JarvisCore
 import Testing
-@testable import JarvisCore
+@testable import JarvisScreenCapture
 
 @Suite(.serialized) struct ScreenCaptureRunnerTests {
     @Test func successfulCaptureDeletesItsTransientJPEGBeforeReturning() throws {

--- a/scripts/check-coaching-kernel.sh
+++ b/scripts/check-coaching-kernel.sh
@@ -19,6 +19,10 @@ cd "$(dirname "$0")/.."
 #   Audio/          capture-side buffering and speech-activity policy ahead of admission
 #   Support/        Clock, retry schedule, and task plumbing the kernel depends on
 #   Brain/          the BrainClient port and route/model types — minus Adapters/ (below)
+#   Screen/         the ScreenCapturing port, snapshot model, and pure window-selection and
+#                   recognized-text-layout logic. Foundation-only: the screencapture helper
+#                   process, transient JPEG, and cleanup-verification latch live at the macOS edge
+#                   in Sources/JarvisScreenCapture, behind the port.
 #   Diagnostics/CaptureReadinessMonitor.swift, AudioContinuityWitness*.swift,
 #   AudioContinuityMatcher.swift
 #                   the capture-heartbeat source and capture health policy, which the diagram
@@ -28,10 +32,6 @@ cd "$(dirname "$0")/.."
 #   Brain/Adapters/ concrete provider adapters (URLSession, CLI Process). They are outside the
 #                   kernel by design and move outward with the Phase 4 adapter move; until then
 #                   they legitimately hold the OS symbols this guard bans.
-#   Screen/         ScreenSnapshotting is a kernel port, but it sits in the same directory as the
-#                   screencapture runner, which drives a Process and cleans up via FileManager.
-#                   The path (and with it Process/FileManager coverage over screen capture) joins
-#                   when the screen-capture move relocates that adapter.
 #   Diagnostics/ (rest)
 #                   evidence persistence by definition; only the heartbeat/health files above are
 #                   kernel.
@@ -50,6 +50,7 @@ kernel_paths=(
     Sources/JarvisCore/Audio
     Sources/JarvisCore/Support
     Sources/JarvisCore/Brain
+    Sources/JarvisCore/Screen
     Sources/JarvisCore/Diagnostics/CaptureReadinessMonitor.swift
     Sources/JarvisCore/Diagnostics/AudioContinuityWitness.swift
     "Sources/JarvisCore/Diagnostics/AudioContinuityWitness+Types.swift"

--- a/scripts/check-ghost-mode.sh
+++ b/scripts/check-ghost-mode.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$0")/.."
 pattern='NSAlert\(|(NSApp|NSApplication\.shared)\.(activate|setActivationPolicy)|makeKeyAndOrderFront|\.makeKey\(|orderFrontRegardless|\.orderFront\(|beginSheet\(|\.show\(relativeTo:|NSWorkspace\.shared\.open|NSSound|AudioServicesPlaySystemSound|requestUserAttention|UNUserNotification|NSUserNotification|\.runModal\('
 
 scan_status=0
-matches="$(/usr/bin/grep -RInE "$pattern" Sources/JarvisApp Sources/JarvisOverlay)" || scan_status=$?
+matches="$(/usr/bin/grep -RInE "$pattern" Sources/JarvisApp Sources/JarvisOverlay Sources/JarvisScreenCapture)" || scan_status=$?
 if [ "$scan_status" -gt 1 ]; then
     echo "Ghost-mode presentation API scan failed; refusing to pass without a complete scan." >&2
     exit "$scan_status"

--- a/wiki/build-and-run.md
+++ b/wiki/build-and-run.md
@@ -11,13 +11,18 @@ The Command Line Tools SDK (`/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 ScreenCaptureKit, AVFoundation, AppKit, SwiftUI, Vision, CoreAudio, and Security — everything Jarvis
 needs — so a SwiftUI + ScreenCaptureKit binary builds with plain `swift build`. No `.xcodeproj`.
 
-- **Three-target split (load-bearing for testability):** `JarvisCore` holds the pure, deterministic
-  logic behind protocols (config, transcript, the coach loop, the OpenAI client, …) and is
-  unit-tested with mocks on **any** machine — no Mac UI, key, or permissions needed. `JarvisOverlay`
-  is a small library holding just the `NSPanel` overlay, split out so `JarvisOverlayTests` can import
-  it to verify screen-capture invisibility headlessly. `JarvisApp` is the thin executable that wires
-  the other two to the side-effectful macOS frameworks (mic, ScreenCaptureKit, the realtime websocket,
-  the menu bar). That split is what lets most of the system be verified headless.
+- **Library/executable split (load-bearing for testability):** `JarvisCore` holds the pure,
+  deterministic logic behind protocols (config, transcript, the coach loop, the OpenAI client, …)
+  and is unit-tested with mocks on **any** machine — no Mac UI, key, or permissions needed.
+  `JarvisOverlay` is a small library holding just the `NSPanel` overlay, split out so
+  `JarvisOverlayTests` can import it to verify screen-capture invisibility headlessly.
+  `JarvisScreenCapture` is the OS-bound `screencapture` process/file adapter behind Core's
+  `ScreenCapturing` port, split out so `JarvisScreenCaptureTests` can drive its cancellation,
+  cleanup-verification, and latch contract headlessly. `JarvisEvaluation` is the Foundation-only
+  sealed-session evaluation library shared by the app and `EvalPrep`. `JarvisApp` is the thin
+  executable that wires the libraries to the side-effectful macOS frameworks (mic,
+  ScreenCaptureKit, the realtime websocket, the menu bar). That split is what lets most of the
+  system be verified headless.
 - **Tests use swift-testing, not XCTest.** `import XCTest` fails with "no such module" under
   CLT-only. Run the suite via **`./scripts/run-tests.sh`**, which adds the swift-testing framework
   search/rpath flags that plain `swift test` lacks CLT-only. (One sharp edge: a direct

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -1966,3 +1966,33 @@
   land beat a third library target.
 - **Detail:** [lean-coaching-core.md → Phase 3 Implementation Contract](./lean-coaching-core.md#phase-3-implementation-contract--evaluation-extraction),
   `Package.swift`, `Sources/JarvisEvaluation/`.
+
+### 2026-08-27 — The screen-capture process edge lives in its own JarvisScreenCapture target
+
+- **Chose:** Move the `screencapture` helper process, the transient session-local JPEG, and the
+  cleanup-verification latch (`ScreenCaptureRunner`) plus the display-targeting CLI adapter
+  (`ScreenCaptureCLI`) out of `JarvisCore` into the `JarvisScreenCapture` library target, behind
+  Core's existing `ScreenCapturing` port. Core keeps the model-facing screen tool contract, the
+  `ScreenSnapshot` model, and the pure window-selection and recognized-text-layout logic. A pure
+  move: cancellation owning helper teardown and file cleanup, verified deletion before `capture()`
+  returns, the poison latch that blocks any later capture or display fallback while a
+  screen-derived file is unaccounted for, and owner-only session-directory placement are unchanged,
+  and the runner's regression tests moved with it (imports aside). With the process gone,
+  `scripts/check-coaching-kernel.sh` covers `Sources/JarvisCore/Screen/` and rejects
+  `Process`/`FileManager` there, and the ghost-mode scan adds the new OS-bound target.
+- **Why:** [lean-coaching-core.md Phase 4](./lean-coaching-core.md#phase-4-implementation-contract--screen-capture-adapter-move)
+  moves process and file adapters outward so the kernel guard can ban `Process` outright instead of
+  carving out the screen directory. A library target rather than `JarvisApp` code because
+  `JarvisApp` is verified only by live smoke: leaving the runner in the executable would orphan the
+  headless cancellation/cleanup/latch tests that prove the privacy contract — the architecture
+  contract's isolated-test-boundary trigger.
+- **Rejected:** (a) Keeping the display-fallback policy (`ScreenCaptureCLI`) in Core behind a new
+  runner port — a second Core-visible capture abstraction for ~40 lines of argument selection,
+  when the approved contract names `ScreenCapturing` as the one port and the fallback policy is
+  still tested with the runner at the edge. (b) Moving the runner into `JarvisOverlay` — it is
+  OS-bound and testable there, but the overlay target's one concern is the capture-invisible
+  panels. (c) Relocating the latch into Core as pure state — the latch is only trustworthy where
+  the deletion evidence is produced; splitting proof from policy would re-create the
+  cross-component coordination this design removes.
+- **Detail:** [lean-coaching-core.md → Phase 4 Implementation Contract](./lean-coaching-core.md#phase-4-implementation-contract--screen-capture-adapter-move),
+  `Package.swift`, `Sources/JarvisScreenCapture/`, `scripts/check-coaching-kernel.sh`.

--- a/wiki/lean-coaching-core.md
+++ b/wiki/lean-coaching-core.md
@@ -1,9 +1,10 @@
 # Lean Coaching Core
 
 > The approved target architecture and phased implementation contract for
-> [issue #147](https://github.com/JINGBANZ/jarvis/issues/147). Phase 0 and Phase 3's
-> evaluation-extraction slice are built. Phase 1 is the next implementation slice; the remaining
-> phases describe the reviewed destination, not shipped behavior.
+> [issue #147](https://github.com/JINGBANZ/jarvis/issues/147). Phase 0, Phase 3's
+> evaluation-extraction slice, and Phase 4's screen-capture adapter move are built. Phase 1 is the
+> next implementation slice; the remaining phases describe the reviewed destination, not shipped
+> behavior.
 
 > **Owner review result:** This contract supersedes the issue body's proposed independent Activity,
 > audit, diagnostic, and continuity-telemetry stacks and its earlier phase ordering. The issue remains
@@ -186,7 +187,7 @@ editing.
 | 1 — Evidence foundation | **Next slice** | Generalize the settled audit transport into `SessionEvidence` and route diagnostics through it without another worker | Activity remains on its existing path until Phase 2 |
 | 2 — Activity projection | Approved destination | Render and persist Activity through `SessionEvent`, show incomplete evidence in the Activity window, and remove Activity's independent persistence path | Human copy remains a closed safe projection; no debug detail enters Activity |
 | 3 — Offline work | Evaluation extraction **built** in [#202](https://github.com/JINGBANZ/jarvis/issues/202); compaction and pruning remain the approved destination | Give evaluation a shared compiler boundary when justified by the app and `EvalPrep`; make history compaction preemptible and move pruning off Start | Failure keeps full history and surviving session evidence |
-| 4 — Plans and adapters | Approved destination | Use immutable plan revisions at explicit between-attempt boundaries and move provider, process, screen, and file adapters outward | Live setting changes and fresh-attempt routing semantics remain intact |
+| 4 — Plans and adapters | Screen-capture adapter move **built** in [#204](https://github.com/JINGBANZ/jarvis/issues/204); plan revisions and the provider/file adapter moves remain the approved destination | Use immutable plan revisions at explicit between-attempt boundaries and move provider, process, screen, and file adapters outward | Live setting changes and fresh-attempt routing semantics remain intact |
 | 5 — Decomposition | Approved destination | Split the `CoachDriver` facade and `AppDelegate` only after ports and state ownership settle | Structure changes; observable coaching and lifecycle behavior do not |
 
 ## Phase 1 Implementation Contract
@@ -318,6 +319,77 @@ their own contract before implementation.
   for the same session directory before and after the move, verified offline without an agent run.
 - The Gate passes: `swift build && ./scripts/run-tests.sh`. The live Evaluate-click check stays in
   the standard app smoke, not in this slice's gate.
+
+## Phase 4 Implementation Contract — Screen-capture adapter move
+
+The first Phase 4 slice ([issue #204](https://github.com/JINGBANZ/jarvis/issues/204)) moves the
+`screencapture` helper process, the transient session-local JPEG, and the cleanup-verification
+latch out of `JarvisCore` to the macOS edge, behind the existing `ScreenCapturing` port. Core keeps
+the model-facing screen tool contract, the `ScreenSnapshot` model, and the pure window-selection
+and recognized-text-layout logic — Foundation-only and unit-testable without spawning a process —
+which lets the kernel dependency guard cover `Sources/JarvisCore/Screen/` and reject `Process` and
+`FileManager` there outright. Immutable plan revisions and the provider/file adapter moves are the
+rest of Phase 4 and freeze their own contracts before implementation.
+
+### Target shape
+
+- `JarvisScreenCapture` is the OS-bound adapter library: `ScreenCaptureRunner` (the cancellable
+  helper process, the transient owner-only JPEG, TERM→KILL escalation gated on the helper's
+  PID/start-time identity, verified deletion, and the cleanup-failure latch) and
+  `ScreenCaptureCLI` (entire-display targeting with the main-display reshoot). It depends inward
+  on `JarvisCore` only. It clears the architecture contract's bar for a new target through an
+  isolated test boundary: `JarvisApp` is verified only by live smoke, so leaving the runner in the
+  executable would orphan the headless cancellation/cleanup/latch regression tests that prove the
+  privacy contract; they run in `JarvisScreenCaptureTests` instead.
+- `Sources/JarvisCore/Screen/` keeps `ScreenCapturing`, `ScreenSnapshot`, `FrontWindowSelector`,
+  `WindowCandidate`, `TextFragment`, and `RecognizedTextLayout`.
+- `WindowScopedScreenCapture` in `JarvisApp` still composes the window-scoped shot, Vision OCR,
+  and display fallback from the adapter pieces; `AppDelegate` wiring is unchanged.
+- The ghost-mode scan covers `Sources/JarvisScreenCapture`, keeping its scan set equal to the
+  OS-bound targets.
+
+### Expected behavior
+
+- A pure move: capture arguments, scope and display selection read at capture time, the
+  window→display fallback order, OCR attachment, outcome classification, and Activity/debug
+  emissions are unchanged.
+- Cancellation still owns both helper teardown and file cleanup: a cancelled `capture()` returns
+  only after the helper has exited and the transient JPEG's absence has been verified, so a
+  coaching attempt can never outlive an unaccounted-for screen-derived file. A cancellation that
+  loses the race with the helper's exit is still reported by the capture it was issued against and
+  never survives to a later capture.
+- Screen-derived files still land only in the owner-only live session directory, never `/tmp`, and
+  the transient JPEG is owner-only (`0600`) from its first write.
+
+### Failure and accepted degradation
+
+- A capture whose cleanup cannot be proven still returns `cleanupFailed` and latches the
+  session-local runner: no later capture — and no display fallback — starts while a screen-derived
+  file is unaccounted for. The latch never self-clears; a fresh session builds a fresh runner.
+- Local capture failure, cancellation, and the cleanup latch still end the screen tool call
+  without a screenshot and still do not count as provider failures; no retry, recovery, or new
+  failure mode is added.
+
+### Non-goals
+
+- The rest of Phase 4: immutable plan revisions and moving the Brain provider adapters
+  (`Brain/Adapters/`) or remaining file adapters outward.
+- Changing the screen tool contract, capture scopes, Settings behavior, OCR behavior, or any
+  cancellation, cleanup, or latch semantics.
+- New Core-visible capture abstractions beyond the existing `ScreenCapturing` port, and any
+  Phase 1/2 `SessionEvidence` work.
+
+### Completion criteria
+
+- `JarvisCore` contains no `Process` and no file I/O for screen capture;
+  `scripts/check-coaching-kernel.sh` covers `Sources/JarvisCore/Screen/`, so a reintroduced
+  `Process`/`FileManager` fails the Gate.
+- The runner's cancellation, cleanup-verification, latch, and owner-only-permission tests run
+  unchanged (imports aside) in `JarvisScreenCaptureTests`; Core's screen tests are pure
+  Foundation-only unit tests.
+- The Gate passes: `swift build && ./scripts/run-tests.sh`.
+- Live smoke verification of a screen-tool coaching turn and a cancelled capture in the signed
+  app — App-bound behavior stays on the live smoke checklist, not in the offline gate.
 
 ## Source Handoff
 

--- a/wiki/overlay-invisibility.md
+++ b/wiki/overlay-invisibility.md
@@ -13,7 +13,7 @@ That caption must be invisible to two distinct audiences:
 1. **Other apps capturing the screen** — the interviewer's Zoom/Meet/Teams share, a QuickTime/OBS
    recording, the macOS screenshot tool.
 2. **Jarvis's own `capture_screen`** — otherwise the brain would read its own coaching text back in
-   the next screenshot (a feedback loop). See [`ScreenCapture.swift`](../Sources/JarvisCore/Screen/ScreenCapture.swift).
+   the next screenshot (a feedback loop). See [`ScreenCaptureCLI.swift`](../Sources/JarvisScreenCapture/ScreenCaptureCLI.swift).
 
 Both are solved by the *same* single flag.
 

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -349,7 +349,7 @@ Both values, their keys, and the main-display floor are declared in
 | `Sources/JarvisCore/Config/BrainPreferences.swift` | UserDefaults persistence + route validation |
 | `Sources/JarvisCore/Coach/CoachDriver.swift` | Between-attempt route application and attempt orchestration |
 | `Sources/JarvisCore/Config/ScreenCapturePreferences.swift` | Capture scope + display persistence + clamping |
-| `Sources/JarvisCore/Screen/ScreenCapture.swift` | `ScreenCaptureCLI` — reads the selection at capture time, falls back to the main display |
+| `Sources/JarvisScreenCapture/ScreenCaptureCLI.swift` | `ScreenCaptureCLI` — reads the selection at capture time, falls back to the main display |
 | `Sources/JarvisCore/Overlay/OverlayAppearance.swift` | UserDefaults persistence; `OverlayCaptionApplying` + `OverlayBoxApplying` protocols |
 | `Sources/JarvisCore/Config/TranscriptionPreferences.swift` | Persisted transcription selection + validation |
 | `Sources/JarvisCore/Overlay/BroadcastOverlay.swift` | Fans one `render` out to the caption + box |

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -160,11 +160,13 @@ credential leak; current-tree machine-specific instructions were generalized ins
 repository identity and provenance.
 
 The [lean coaching core architecture](./lean-coaching-core.md) is approved for issue #147. Its
-Phase 0 audit foundation and Phase 3 evaluation extraction (the `JarvisEvaluation` target) are
-built; the unified `SessionEvidence` stack, diagnostic migration, Activity projection, offline
-maintenance (preemptible compaction and pruning), adapter direction, and coordinator decomposition
-are not yet implemented. The approved next slice is diagnostics-only and preserves the current
-coaching, routing, Activity, evaluator, and artifact behavior.
+Phase 0 audit foundation, Phase 3 evaluation extraction (the `JarvisEvaluation` target), and Phase
+4's screen-capture adapter move (the `JarvisScreenCapture` target) are built; the unified
+`SessionEvidence` stack, diagnostic migration, Activity projection, offline maintenance
+(preemptible compaction and pruning), plan revisions with the remaining provider/file adapter
+moves, and coordinator decomposition are not yet implemented. The approved next slice is
+diagnostics-only and preserves the current coaching, routing, Activity, evaluator, and artifact
+behavior.
 
 ## Next action
 
@@ -233,8 +235,8 @@ playback, remains in
 
 ## Built
 
-Tested `JarvisCore` + `JarvisOverlay` harness is green (`./scripts/run-tests.sh`); `JarvisApp` is the
-thin OS shell, verified by the smoke run.
+Tested `JarvisCore` + `JarvisEvaluation` + `JarvisOverlay` + `JarvisScreenCapture` harness is green
+(`./scripts/run-tests.sh`); `JarvisApp` is the thin OS shell, verified by the smoke run.
 
 - `Sources/JarvisCore/Audio/` — transactional PCM + utterance buffering, bounded speech pre-roll, adaptive content-free activity detection, stable frame-decision endpoints, non-destructive AEC reference alignment, and system-audio timeline preservation (`PCMBuffer`, `SpeechGatedAudioBuffer`, `UtteranceBuffer`, `PCM16Framer`, `SpeechEndpointDetector`, `AudioDownmix`, `AdaptiveAudioActivityDetector`, `PCM16SpeechActivityTracker`, `EchoReferenceAlignment`, `SystemAudioTimeline`).
 - `Sources/JarvisCore/Transcription/` — provider-neutral session/provider contracts and immutable Start configuration, selectable OpenAI model/expected-language values, the OpenAI Realtime wire contract, reconnect-safe Jarvis-managed turn coordinator and recovery state, per-item ledger, analyzer-finalization state, and the single spoken-time ordering policy used by the rolling transcript and Activity (`TranscriptionSession`, `TranscriptionProvider`, `TranscriptionConfiguration`, `OpenAITranscriptionModel`, `OpenAITranscriptionLanguage`, `RealtimeSession`, `RealtimeJarvisManagedTurnCoordinator`, `RealtimeReconnectTranscriptionRecovery`, `RealtimeTranscriptionLedger`, `TranscriptionFinalizationState`, `ConversationChronology`, `Transcript`, `NoiseReduction`).
@@ -242,7 +244,8 @@ thin OS shell, verified by the smoke run.
 - `Sources/JarvisCore/Brain/` — provider-neutral `BrainClient`/attempt-scoped `BrainConversation` contracts and models stay at the root. `Adapters/OpenAI/` owns the Responses transport; `Adapters/LocalAgent/` owns CLI detection, `CLIBrainClient`, the Claude Code and Codex runtimes, and the bounded shared process edge. `LocalAgentRuntimeSet` encapsulates provider-specific coach/summarizer ownership. `AgentCLIProcessRunner` remains only for the explicit completed-session evaluator. The subsystem also owns provider-boundary failure classification (`BrainFailure`), immutable `BrainTarget`/`BrainRoute`, `BrainProvider`, `BrainModelCatalog` (first per-provider entry is the default), and `ReasoningEffort`.
 - `Sources/JarvisCore/Coach/` — the event loop: `CoachDriver` (fresh-attempt scheduling, transcription-settlement admission, and one-target tool-loop orchestration), the pure forward-only `BrainRouteSession`, `TranscriptionSettlementGate`, `CoachHistory` (client-managed session memory), and `ToolDefs` (coach tool schemas).
 - `Sources/JarvisCore/Triggers/` — turn/silence trigger detection, substance classification, and silence backoff (`Trigger`, `TurnSubstance`, `SilenceBackoff`).
-- `Sources/JarvisCore/Screen/` — the model-triggered screen-capture tool contract + window-scoped capture logic, plus `ScreenCaptureRunner`, which owns each cancellable `screencapture` helper and the transient JPEG it writes into the owner-only session directory: it verifies that file is gone before returning, and a capture whose cleanup can't be proven latches the runner so no later capture (or display fallback) starts while a screen-derived file is unaccounted for (`ScreenCapture`, `ScreenCaptureRunner`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout`).
+- `Sources/JarvisCore/Screen/` — the model-facing screen port and the pure, Foundation-only capture logic: the `ScreenCapturing` contract, the `ScreenSnapshot` model, front-window selection over window-server candidates, and reading-order OCR layout (`ScreenCapturing`, `ScreenSnapshot`, `FrontWindowSelector`, `WindowCandidate`, `TextFragment`, `RecognizedTextLayout`). No process or file I/O; the kernel dependency guard rejects `Process`/`FileManager` here.
+- `Sources/JarvisScreenCapture/` — the OS-bound screen-capture adapter behind that port ([lean-coaching-core.md → Phase 4 contract](./lean-coaching-core.md#phase-4-implementation-contract--screen-capture-adapter-move)): `ScreenCaptureRunner` owns each cancellable `screencapture` helper and the transient JPEG it writes into the owner-only session directory — it verifies that file is gone before returning, and a capture whose cleanup can't be proven latches the runner so no later capture (or display fallback) starts while a screen-derived file is unaccounted for — and `ScreenCaptureCLI` shoots the Settings-chosen or main display. Depends inward on `JarvisCore`; composed by `WindowScopedScreenCapture` in `JarvisApp`; tested headlessly in `JarvisScreenCaptureTests`.
 - `Sources/JarvisCore/Overlay/` — overlay text model + length-proportional timing + fan-out (`OverlayRendering`, `OverlayTiming`, `OverlayAppearance`, `BroadcastOverlay`).
 - `Sources/JarvisCore/Config/` — config + owner-only secrets + transcription/brain/screen preferences (`Config`, `Secrets`, `TranscriptionPreferences`, `BrainPreferences`, `ScreenCapturePreferences`, `ScreenCaptureScope`).
 - `Sources/JarvisCore/Support/` — small shared runtime primitives (`Clock`, `TurnTaskBox`, `RetrySchedule`, `RetryIncident`).
@@ -267,9 +270,9 @@ thin OS shell, verified by the smoke run.
 ## Not yet built
 
 - **Lean coaching core Phases 1–5** — the approved destination and slice contracts are in
-  [lean-coaching-core.md](./lean-coaching-core.md). Phase 0 audit isolation and Phase 3's
-  evaluation extraction are built; unified diagnostics, the Activity projection, compaction and
-  pruning maintenance, plan/adapter direction, and final coordinator decomposition remain future
-  work.
+  [lean-coaching-core.md](./lean-coaching-core.md). Phase 0 audit isolation, Phase 3's evaluation
+  extraction, and Phase 4's screen-capture adapter move are built; unified diagnostics, the
+  Activity projection, compaction and pruning maintenance, plan revisions with the remaining
+  provider/file adapter moves, and final coordinator decomposition remain future work.
 - **Universal binary** — `Sources/CJarvisAEC/lib/libjarvis-aec.a` is arm64-only; `lipo` in an x86_64 slice if Intel is ever needed.
 - **Neural double-talk canceller** (DTLN / Muesli-style on the same aligned streams) — the escalation if AEC3 over-attenuates the user under loud far audio in practice.


### PR DESCRIPTION
Implements #204 — the first Phase 4 slice of the [lean coaching core roadmap](https://github.com/JINGBANZ/jarvis/blob/main/wiki/lean-coaching-core.md#phased-roadmap).

## What moved where

- **New `JarvisScreenCapture` library target** (depends inward on `JarvisCore` only): `ScreenCaptureRunner` — the cancellable `screencapture` helper, the transient owner-only JPEG, TERM→KILL escalation gated on PID/start-time identity, verified deletion, and the cleanup-failure latch — and `ScreenCaptureCLI` (display targeting + main-display reshoot). Both moved verbatim apart from imports and a boundary doc comment; the module-visible `Command` reasoning for driving the cancel-after-exit window in tests is preserved.
- **`Sources/JarvisCore/Screen/` keeps** `ScreenCapturing` (the existing port, file renamed from `ScreenCapture.swift`), `ScreenSnapshot`, `FrontWindowSelector`, `WindowCandidate`, `TextFragment`, `RecognizedTextLayout` — Foundation-only, no `Process`, no file I/O.
- **`WindowScopedScreenCapture` (JarvisApp)** gains one `import JarvisScreenCapture`. **`AppDelegate.swift` is untouched** — it only constructs `WindowScopedScreenCapture`, so no composition wiring changed.
- A library target rather than `JarvisApp` code because `JarvisApp` is verified only by live smoke: leaving the runner in the executable would orphan the headless cancellation/cleanup/latch regression tests that prove the privacy contract. This is the architecture contract's isolated-test-boundary trigger (mirrors `JarvisOverlay`).

## Acceptance criteria → how each is met

| Criterion | Status |
|---|---|
| Scope contract recorded in `wiki/lean-coaching-core.md` in this PR | Done — new "Phase 4 Implementation Contract — Screen-capture adapter move" section mirroring the Phase 1 contract's structure (expected behavior / failure and accepted degradation / non-goals / completion criteria, plus a Phase 3-style target shape); roadmap row, `status.md`, `decisions.md` (2026-08-27 entry), `settings-window.md`, `build-and-run.md`, and `overlay-invisibility.md` pointers updated in the same change |
| `JarvisCore` contains no `Process` or file I/O for screen capture | Done — the runner and CLI left Core; enforced by the tightened kernel guard (below) |
| Screen tool contract, snapshot model, window selection, recognized-text layout stay in Core, Foundation-only unit-testable | Done — `ToolDefs`/prompts untouched; `ScreenCapturing`, `ScreenSnapshot`, `FrontWindowSelector`, `RecognizedTextLayout` unchanged in Core; their tests stay in `JarvisCoreTests` and spawn no process |
| Cancellation semantics, cleanup verification, cleanup-failure latch behave exactly as today, incl. no-fallback-while-unaccounted | Done — `ScreenCaptureRunner` moved verbatim (diff-verified: only an import and a doc comment added); all eight regression tests moved unchanged apart from imports and pass in `JarvisScreenCaptureTests`, including `cleanupFailurePoisonsRunnerAndPreventsDisplayFallback` |
| Screen-derived files land only in the owner-only session directory | Done — capture-directory wiring unchanged (`AppDelegate` passes the session directory as before); the umask-077 launch and `0600` test moved unchanged |
| Kernel guard tightened to reject `Process` and `FileManager` in the kernel | Done — `Sources/JarvisCore/Screen` joined `kernel_paths` and the header's "excluded until this ticket lands" paragraph is removed; negative-tested (a `FileManager` line added to a Screen file fails the guard with exit 1). The `--exclude-dir=Adapters` basename shape did not get in the way (no `Adapters` dir exists under any covered path except `Brain/`), so per the ticket it was left alone |
| Gate passes | `swift build && ./scripts/run-tests.sh` → exit 0: all five guard scripts pass, `Test run with 777 tests in 90 suites passed` (incl. `ScreenCaptureRunnerTests` in its new target). Live smoke remains — see below |

Also: `scripts/check-ghost-mode.sh` now scans `Sources/JarvisScreenCapture`, keeping its scan set equal to the OS-bound targets (the invariant the Phase 3 contract named).

## Live smoke verification still required (human)

This ticket is App-bound; the offline gate cannot exercise TCC or a real capture. Someone needs to run, in the signed app (`./scripts/build-app.sh --run`):

1. **A screen-tool coaching turn** — ask a question whose answer depends on visible context; confirm exactly one `capture_screen` then a screen-specific tip, and that no `capture-*.jpg` remains in the session directory afterwards.
2. **A cancelled capture** — Stop the session while a capture is in flight; confirm the session tears down promptly, no `screencapture` helper survives, and no `capture-*.jpg` remains in the session directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
