### PR TITLE
feat(prep): add local prep-material source configuration to Settings

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -28,6 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let brainPreferences = BrainPreferences()
     private let transcriptionPreferences = TranscriptionPreferences()
     private let screenPreferences = ScreenCapturePreferences()
+    private let prepMaterialPreferences = PrepMaterialPreferences()
     private var activityViewer: ActivityViewer!    // embedded as the Settings Activity tab
     /// Two provider sessions feeding one shared transcript: mic → `.me`, system audio → `.them`.
     private var transcriber: (any TranscriptionSession)?       // "me" (mic)
@@ -176,6 +177,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             connectionsSection,
             OverlaySection(appearance: appearance, caption: overlayCaption, box: overlayBox),
             DisplaySection(preferences: screenPreferences),
+            PrepMaterialSection(preferences: prepMaterialPreferences),
             ActivitySection(viewer: activityViewer),
         ]
         settingsWindow = SettingsWindow(sections: sections)

--- a/Sources/JarvisApp/Settings/BrainTargetRowView.swift
+++ b/Sources/JarvisApp/Settings/BrainTargetRowView.swift
@@ -226,26 +226,3 @@ final class BrainTargetRowView: NSView {
         onModelChanged(models[index])
     }
 }
-
-/// A tiny target/action adapter used only by the icon buttons in `BrainTargetRowView`.
-@MainActor
-private final class ClosureButton: NSButton {
-    private let closure: () -> Void
-
-    init(title: String, action: @escaping () -> Void) {
-        self.closure = action
-        super.init(frame: .zero)
-        self.title = title
-        target = self
-        self.action = #selector(performAction)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func performAction() {
-        closure()
-    }
-}

--- a/Sources/JarvisApp/Settings/ClosureButton.swift
+++ b/Sources/JarvisApp/Settings/ClosureButton.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+/// A tiny target/action adapter that lets a button's tap be a plain Swift closure instead of AppKit's
+/// target/action selector pair. Shared by every Settings row that needs a lightweight per-row action
+/// button — a fallback route's move/remove controls, a prep-material source's remove.
+@MainActor
+final class ClosureButton: NSButton {
+    private let closure: () -> Void
+
+    init(title: String, action: @escaping () -> Void) {
+        self.closure = action
+        super.init(frame: .zero)
+        self.title = title
+        target = self
+        self.action = #selector(performAction)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func performAction() {
+        closure()
+    }
+}

--- a/Sources/JarvisApp/Settings/PrepMaterialSection.swift
+++ b/Sources/JarvisApp/Settings/PrepMaterialSection.swift
@@ -1,0 +1,227 @@
+import AppKit
+import JarvisCore
+import UniformTypeIdentifiers
+
+/// Settings panel for the local files/folders of prepared interview notes the coach can reference.
+///
+/// Jarvis stores only these paths, never a copy of their contents, and reads them fresh when needed —
+/// so removing a source here only forgets it; the underlying file is untouched. Nothing here is ever
+/// uploaded: the list is persisted the same way every other setting is, in this macOS account's own
+/// UserDefaults domain.
+@MainActor
+final class PrepMaterialSection: NSObject, SettingsSection {
+    let title = "Prep Material"
+    let fillsTab = true
+
+    private static let rowHeight: CGFloat = 56
+    private static let addRowHeight: CGFloat = 42
+    private static let emptyStateHeight: CGFloat = 44
+
+    private let preferences: PrepMaterialPreferences
+    private let card = SettingsCardView(frame: NSRect(x: 0, y: 0, width: 712, height: 200))
+    private let addButton = NSButton(title: "＋ Add Files or Folders…", target: nil, action: nil)
+    private var rows: [SettingsRowView] = []
+    private var emptyLabel: NSTextField?
+
+    init(preferences: PrepMaterialPreferences) {
+        self.preferences = preferences
+    }
+
+    func makeView() -> NSView {
+        let body = NSView(frame: NSRect(x: 0, y: 0, width: 712, height: 432))
+
+        let scrollView = SettingsScrollView(frame: NSRect(x: 0, y: 0, width: 712, height: 350))
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        card.autoresizingMask = [.width]
+        card.setHeader(title: "Prep material", detail: "Local only — never uploaded")
+        addButton.target = self
+        addButton.action = #selector(addSource)
+        addButton.bezelStyle = .rounded
+        addButton.setAccessibilityLabel("Add prep material")
+        card.contentView?.addSubview(addButton)
+        card.onLayout = { [weak self] in self?.layoutRows() }
+        scrollView.documentView = card
+
+        render()
+
+        let callout = makeCallout()
+        callout.translatesAutoresizingMaskIntoConstraints = false
+        body.addSubview(scrollView)
+        body.addSubview(callout)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: body.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: body.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: body.trailingAnchor),
+            callout.topAnchor.constraint(equalTo: scrollView.bottomAnchor, constant: SettingsStyle.sectionSpacing),
+            callout.leadingAnchor.constraint(equalTo: body.leadingAnchor),
+            callout.trailingAnchor.constraint(equalTo: body.trailingAnchor),
+            callout.bottomAnchor.constraint(equalTo: body.bottomAnchor),
+            callout.heightAnchor.constraint(equalToConstant: 68),
+        ])
+
+        return SettingsPageView(
+            title: "Prep Material",
+            summary: "Point Jarvis at notes you've already prepared, so it can draw on them live.",
+            bodyView: body)
+    }
+
+    func didBecomeActive() {
+        // A source's file may have moved or been deleted since the tab was last open.
+        render()
+    }
+
+    private func makeCallout() -> NSBox {
+        let callout = NSBox()
+        callout.boxType = .custom
+        callout.borderWidth = 1
+        callout.cornerRadius = 10
+        callout.borderColor = NSColor.systemBlue.withAlphaComponent(0.18)
+        callout.fillColor = NSColor.systemBlue.withAlphaComponent(0.07)
+        callout.contentViewMargins = .zero
+
+        guard let content = callout.contentView else { return callout }
+        let icon = NSImageView()
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.image = NSImage(systemSymbolName: "info.circle.fill", accessibilityDescription: nil)
+        icon.contentTintColor = .systemBlue
+        content.addSubview(icon)
+
+        let note = NSTextField(wrappingLabelWithString:
+            "Jarvis only reads these files and folders — it never copies, edits, or uploads them. "
+            + "Removing a source here does not delete anything on disk.")
+        note.translatesAutoresizingMaskIntoConstraints = false
+        note.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        note.textColor = .secondaryLabelColor
+        content.addSubview(note)
+
+        NSLayoutConstraint.activate([
+            icon.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 14),
+            icon.topAnchor.constraint(equalTo: content.topAnchor, constant: 14),
+            icon.widthAnchor.constraint(equalToConstant: 22),
+            icon.heightAnchor.constraint(equalToConstant: 22),
+            note.leadingAnchor.constraint(equalTo: icon.trailingAnchor, constant: 10),
+            note.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -14),
+            note.centerYAnchor.constraint(equalTo: content.centerYAnchor),
+        ])
+        return callout
+    }
+
+    private var preferredHeight: CGFloat {
+        let listHeight = rows.isEmpty
+            ? Self.emptyStateHeight
+            : CGFloat(rows.count) * Self.rowHeight
+        return SettingsStyle.cardHeaderHeight + listHeight + Self.addRowHeight
+    }
+
+    private func render() {
+        rows.forEach { $0.removeFromSuperview() }
+        rows.removeAll()
+        emptyLabel?.removeFromSuperview()
+        emptyLabel = nil
+
+        let sources = preferences.sources
+        if sources.isEmpty {
+            let label = NSTextField(labelWithString: "No prep material added yet.")
+            label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+            label.textColor = .secondaryLabelColor
+            label.alignment = .center
+            card.contentView?.addSubview(label)
+            emptyLabel = label
+        } else {
+            for source in sources {
+                let removeButton = ClosureButton(title: "×") { [weak self] in
+                    self?.removeSource(id: source.id)
+                }
+                removeButton.bezelStyle = .rounded
+                removeButton.controlSize = .small
+                removeButton.setAccessibilityLabel("Remove \(source.displayName)")
+
+                let missing = !source.exists()
+                let row = SettingsRowView(
+                    title: source.displayName,
+                    detail: missing ? "⚠️ Not found — \(source.path)" : source.path,
+                    controlView: removeButton,
+                    controlSize: NSSize(width: 30, height: 30),
+                    preferredHeight: Self.rowHeight)
+                card.contentView?.addSubview(row)
+                rows.append(row)
+            }
+        }
+
+        card.frame.size.height = preferredHeight
+        layoutRows()
+    }
+
+    private func layoutRows() {
+        let width = card.bounds.width
+        var nextTop = preferredHeight - SettingsStyle.cardHeaderHeight
+        for row in rows {
+            nextTop -= Self.rowHeight
+            row.frame = NSRect(x: 0, y: nextTop, width: width, height: Self.rowHeight)
+        }
+        if let emptyLabel {
+            nextTop -= Self.emptyStateHeight
+            emptyLabel.frame = NSRect(
+                x: 16, y: nextTop, width: max(200, width - 32), height: Self.emptyStateHeight)
+        }
+        addButton.frame = NSRect(x: 16, y: 5, width: 220, height: 32)
+    }
+
+    /// Formats the indexing slice will actually be able to read: plain text/Markdown directly, PDF
+    /// via PDFKit, and Word documents via the stock `textutil` CLI. `UTType(filenameExtension:)`
+    /// synthesizes a type for ".md"/".docx", which have no dedicated system UTI, so the filter still
+    /// matches them by extension. Folders are unfiltered — their contents are filtered by the same
+    /// list at indexing time instead.
+    private static let allowedContentTypes: [UTType] = [
+        .plainText, .pdf, UTType(filenameExtension: "md"), UTType(filenameExtension: "docx"),
+    ].compactMap { $0 }
+
+    @objc private func addSource() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = true
+        panel.allowedContentTypes = Self.allowedContentTypes
+        panel.allowsMultipleSelection = true
+        panel.prompt = "Add"
+        panel.message = "Choose interview notes Jarvis can reference while coaching. Files stay in place."
+        guard panel.runModal() == .OK else { return } // ghost-mode-allowed: explicit user action in Settings
+
+        let fm = FileManager.default
+        for url in panel.urls {
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else { continue }
+            preferences.add(PrepMaterialSource(path: url.path, isDirectory: isDirectory.boolValue))
+        }
+        render()
+    }
+
+    private func removeSource(id: UUID) {
+        preferences.remove(id: id)
+        render()
+    }
+}
+
+/// A tiny target/action adapter for the per-row remove button. Mirrors the identical private helper
+/// in `BrainTargetRowView.swift`.
+@MainActor
+private final class ClosureButton: NSButton {
+    private let closure: () -> Void
+
+    init(title: String, action: @escaping () -> Void) {
+        self.closure = action
+        super.init(frame: .zero)
+        self.title = title
+        target = self
+        self.action = #selector(performAction)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func performAction() {
+        closure()
+    }
+}

--- a/Sources/JarvisApp/Settings/PrepMaterialSection.swift
+++ b/Sources/JarvisApp/Settings/PrepMaterialSection.swift
@@ -21,7 +21,11 @@ final class PrepMaterialSection: NSObject, SettingsSection {
     private let card = SettingsCardView(frame: NSRect(x: 0, y: 0, width: 712, height: 200))
     private let addButton = NSButton(title: "＋ Add Files or Folders…", target: nil, action: nil)
     private var rows: [SettingsRowView] = []
+    private var rowsBySourceID: [UUID: SettingsRowView] = [:]
     private var emptyLabel: NSTextField?
+    /// Guards a background existence check against a stale result landing after a newer `render()`
+    /// (a fast add/remove, or leaving and returning to the tab) already rebuilt the row list.
+    private var renderGeneration = 0
 
     init(preferences: PrepMaterialPreferences) {
         self.preferences = preferences
@@ -115,8 +119,12 @@ final class PrepMaterialSection: NSObject, SettingsSection {
     }
 
     private func render() {
+        renderGeneration += 1
+        let generation = renderGeneration
+
         rows.forEach { $0.removeFromSuperview() }
         rows.removeAll()
+        rowsBySourceID.removeAll()
         emptyLabel?.removeFromSuperview()
         emptyLabel = nil
 
@@ -137,20 +145,38 @@ final class PrepMaterialSection: NSObject, SettingsSection {
                 removeButton.controlSize = .small
                 removeButton.setAccessibilityLabel("Remove \(source.displayName)")
 
-                let missing = !source.exists()
                 let row = SettingsRowView(
                     title: source.displayName,
-                    detail: missing ? "⚠️ Not found — \(source.path)" : source.path,
+                    detail: source.path,
                     controlView: removeButton,
                     controlSize: NSSize(width: 30, height: 30),
                     preferredHeight: Self.rowHeight)
                 card.contentView?.addSubview(row)
                 rows.append(row)
+                rowsBySourceID[source.id] = row
             }
         }
 
         card.frame.size.height = preferredHeight
         layoutRows()
+
+        // Existence is a stat() per source, which can block on an unresponsive network volume or a
+        // sleeping external disk — never do it on the main thread. Rows show their plain path until
+        // this resolves, then a still-current render applies the ⚠️ warning to whichever are missing.
+        guard !sources.isEmpty else { return }
+        Task.detached(priority: .utility) { [sources] in
+            let missing = sources.filter { !$0.exists() }
+            await MainActor.run { [weak self] in
+                self?.applyMissingState(missing, generation: generation)
+            }
+        }
+    }
+
+    private func applyMissingState(_ missing: [PrepMaterialSource], generation: Int) {
+        guard generation == renderGeneration else { return }
+        for source in missing {
+            rowsBySourceID[source.id]?.setDetail("⚠️ Not found — \(source.path)")
+        }
     }
 
     private func layoutRows() {
@@ -188,40 +214,18 @@ final class PrepMaterialSection: NSObject, SettingsSection {
         guard panel.runModal() == .OK else { return } // ghost-mode-allowed: explicit user action in Settings
 
         let fm = FileManager.default
+        var newSources: [PrepMaterialSource] = []
         for url in panel.urls {
             var isDirectory: ObjCBool = false
             guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory) else { continue }
-            preferences.add(PrepMaterialSource(path: url.path, isDirectory: isDirectory.boolValue))
+            newSources.append(PrepMaterialSource(path: url.path, isDirectory: isDirectory.boolValue))
         }
+        preferences.add(newSources)
         render()
     }
 
     private func removeSource(id: UUID) {
         preferences.remove(id: id)
         render()
-    }
-}
-
-/// A tiny target/action adapter for the per-row remove button. Mirrors the identical private helper
-/// in `BrainTargetRowView.swift`.
-@MainActor
-private final class ClosureButton: NSButton {
-    private let closure: () -> Void
-
-    init(title: String, action: @escaping () -> Void) {
-        self.closure = action
-        super.init(frame: .zero)
-        self.title = title
-        target = self
-        self.action = #selector(performAction)
-    }
-
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    @objc private func performAction() {
-        closure()
     }
 }

--- a/Sources/JarvisCore/Config/Defaults.swift
+++ b/Sources/JarvisCore/Config/Defaults.swift
@@ -77,6 +77,16 @@ public enum Defaults {
         public static let displayIndexMinimum = 1
     }
 
+    // MARK: - Prep material
+
+    /// Local files/folders of interview notes the user has pointed Jarvis at, so the coach can draw
+    /// on prepared answers. Referenced in place — Jarvis never copies or edits the user's notes.
+    public enum PrepMaterial {
+        public static let sourcesKey = "prepMaterial.sources"
+        /// No material until the user adds it.
+        public static let sources: [PrepMaterialSource] = []
+    }
+
     // MARK: - Overlay
 
     /// The two capture-invisible coaching surfaces. Each has an on/off flag, a font size in points,

--- a/Sources/JarvisCore/Config/PrepMaterialPreferences.swift
+++ b/Sources/JarvisCore/Config/PrepMaterialPreferences.swift
@@ -3,8 +3,9 @@ import Foundation
 /// Persisted list of local files/folders the user has pointed Jarvis at as interview prep material.
 /// Backed by UserDefaults — the same per-macOS-account storage every other setting already uses, so
 /// this data is inherently local to the signed-in user with no separate tenant/isolation concept
-/// needed. Jarvis stores only the path, never a copy of the file's contents; it reads the live file
-/// at Session Start. Mirrors `BrainPreferences.fallbackTargets`.
+/// needed. Jarvis stores only the path, never a copy of the file's contents. Reading and indexing
+/// that content is a later slice; this type only manages the source list. Mirrors
+/// `BrainPreferences.fallbackTargets`.
 ///
 /// Foundation-only so it stays unit-testable in JarvisCore; inject a `UserDefaults(suiteName:)` in
 /// tests.
@@ -29,9 +30,19 @@ public final class PrepMaterialPreferences {
 
     /// Adds one source, unless its path is already present.
     public func add(_ source: PrepMaterialSource) {
+        add([source])
+    }
+
+    /// Adds every source not already present by path, skipping duplicates within the batch too, in
+    /// one read + one write — so a multi-select add costs one round-trip regardless of count instead
+    /// of one per source.
+    public func add(_ newSources: [PrepMaterialSource]) {
+        guard !newSources.isEmpty else { return }
         var current = sources
-        guard !current.contains(where: { $0.path == source.path }) else { return }
-        current.append(source)
+        var seenPaths = Set(current.map(\.path))
+        for source in newSources where seenPaths.insert(source.path).inserted {
+            current.append(source)
+        }
         persist(current)
     }
 

--- a/Sources/JarvisCore/Config/PrepMaterialPreferences.swift
+++ b/Sources/JarvisCore/Config/PrepMaterialPreferences.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Persisted list of local files/folders the user has pointed Jarvis at as interview prep material.
+/// Backed by UserDefaults — the same per-macOS-account storage every other setting already uses, so
+/// this data is inherently local to the signed-in user with no separate tenant/isolation concept
+/// needed. Jarvis stores only the path, never a copy of the file's contents; it reads the live file
+/// at Session Start. Mirrors `BrainPreferences.fallbackTargets`.
+///
+/// Foundation-only so it stays unit-testable in JarvisCore; inject a `UserDefaults(suiteName:)` in
+/// tests.
+public final class PrepMaterialPreferences {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    /// Every configured source, in the order the user added them. A malformed persisted entry (a
+    /// hand-edited or stale plist) is dropped rather than crashing or surfacing a broken row.
+    public var sources: [PrepMaterialSource] {
+        get {
+            guard let stored = defaults.array(forKey: Defaults.PrepMaterial.sourcesKey) else {
+                return Defaults.PrepMaterial.sources
+            }
+            return stored.compactMap(persistedSource(from:))
+        }
+        set { persist(newValue) }
+    }
+
+    /// Adds one source, unless its path is already present.
+    public func add(_ source: PrepMaterialSource) {
+        var current = sources
+        guard !current.contains(where: { $0.path == source.path }) else { return }
+        current.append(source)
+        persist(current)
+    }
+
+    /// Forgets one source. Never touches the underlying file — Jarvis only reads it.
+    public func remove(id: UUID) {
+        persist(sources.filter { $0.id != id })
+    }
+
+    private func persistedSource(from value: Any) -> PrepMaterialSource? {
+        guard let dictionary = value as? [String: Any],
+              let idString = dictionary["id"] as? String,
+              let id = UUID(uuidString: idString),
+              let path = dictionary["path"] as? String,
+              let isDirectory = dictionary["isDirectory"] as? Bool else {
+            return nil
+        }
+        return PrepMaterialSource(id: id, path: path, isDirectory: isDirectory)
+    }
+
+    private func persist(_ sources: [PrepMaterialSource]) {
+        defaults.set(sources.map {
+            ["id": $0.id.uuidString, "path": $0.path, "isDirectory": $0.isDirectory]
+        }, forKey: Defaults.PrepMaterial.sourcesKey)
+    }
+}

--- a/Sources/JarvisCore/Config/PrepMaterialSource.swift
+++ b/Sources/JarvisCore/Config/PrepMaterialSource.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// One local file or folder the user has pointed Jarvis at as interview prep material — prepared
+/// topics and answers the coach can draw on. Jarvis only reads this path; it never copies or
+/// modifies the user's notes.
+public struct PrepMaterialSource: Equatable, Sendable {
+    public let id: UUID
+    public let path: String
+    public let isDirectory: Bool
+
+    public init(id: UUID = UUID(), path: String, isDirectory: Bool) {
+        self.id = id
+        self.path = path
+        self.isDirectory = isDirectory
+    }
+
+    /// The last path component, for display — e.g. "system-design-notes.md" or "Interview Prep".
+    public var displayName: String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    /// Whether the path still resolves on disk. Checked live rather than cached: the user's notes
+    /// live outside Jarvis and can move or be deleted at any time.
+    public func exists(fileManager: FileManager = .default) -> Bool {
+        fileManager.fileExists(atPath: path)
+    }
+}

--- a/Tests/JarvisCoreTests/Config/PrepMaterialPreferencesTests.swift
+++ b/Tests/JarvisCoreTests/Config/PrepMaterialPreferencesTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import Foundation
+@testable import JarvisCore
+
+@Suite struct PrepMaterialPreferencesTests {
+    /// A fresh, isolated UserDefaults suite per test so nothing touches the real app domain.
+    private func freshDefaults() -> UserDefaults {
+        let suite = "PrepMaterialPreferencesTests.\(UUID().uuidString)"
+        let d = UserDefaults(suiteName: suite)!
+        d.removePersistentDomain(forName: suite)
+        return d
+    }
+
+    @Test func emptyWhenUnset() {
+        #expect(PrepMaterialPreferences(defaults: freshDefaults()).sources
+            == Defaults.PrepMaterial.sources)
+    }
+
+    @Test func roundTripsThroughDefaults() {
+        let d = freshDefaults()
+        let source = PrepMaterialSource(path: "/tmp/notes.md", isDirectory: false)
+        PrepMaterialPreferences(defaults: d).sources = [source]
+        #expect(PrepMaterialPreferences(defaults: d).sources == [source])
+    }
+
+    @Test func addAppendsInOrder() {
+        let p = PrepMaterialPreferences(defaults: freshDefaults())
+        let first = PrepMaterialSource(path: "/tmp/a.md", isDirectory: false)
+        let second = PrepMaterialSource(path: "/tmp/b", isDirectory: true)
+        p.add(first)
+        p.add(second)
+        #expect(p.sources.map(\.path) == ["/tmp/a.md", "/tmp/b"])
+    }
+
+    @Test func addIgnoresDuplicatePath() {
+        let p = PrepMaterialPreferences(defaults: freshDefaults())
+        p.add(PrepMaterialSource(path: "/tmp/a.md", isDirectory: false))
+        p.add(PrepMaterialSource(path: "/tmp/a.md", isDirectory: false))
+        #expect(p.sources.count == 1)
+    }
+
+    @Test func removeDropsOnlyTheMatchingId() {
+        let p = PrepMaterialPreferences(defaults: freshDefaults())
+        let keep = PrepMaterialSource(path: "/tmp/keep.md", isDirectory: false)
+        let drop = PrepMaterialSource(path: "/tmp/drop.md", isDirectory: false)
+        p.sources = [keep, drop]
+        p.remove(id: drop.id)
+        #expect(p.sources == [keep])
+    }
+
+    @Test func malformedPersistedEntryIsDropped() {
+        // A hand-edited or stale plist entry must never crash a read.
+        let d = freshDefaults()
+        d.set([["id": "not-a-uuid", "path": "/tmp/a.md", "isDirectory": false]],
+              forKey: "prepMaterial.sources")
+        #expect(PrepMaterialPreferences(defaults: d).sources.isEmpty)
+    }
+
+    @Test func displayNameIsLastPathComponent() {
+        let source = PrepMaterialSource(path: "/Users/me/Notes/system-design.md", isDirectory: false)
+        #expect(source.displayName == "system-design.md")
+    }
+
+    @Test func existsReflectsLiveFilesystemState() {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString).path
+        let source = PrepMaterialSource(path: path, isDirectory: false)
+        #expect(!source.exists())
+        FileManager.default.createFile(atPath: path, contents: Data())
+        #expect(source.exists())
+        try? FileManager.default.removeItem(atPath: path)
+    }
+}


### PR DESCRIPTION
## Summary
- Slice 1 of #219: a new "Prep Material" Settings tab lets the user point Jarvis at local files/folders of interview notes (text/Markdown/PDF/Word) it can later index and reference during coaching.
- `PrepMaterialSource`/`PrepMaterialPreferences` (JarvisCore, Foundation-only) store only the path, never a copy of file contents — mirrors `BrainPreferences`' fallback-target persistence pattern.
- Sources are added via a native `NSOpenPanel` (files + folders, filtered to `.txt`/`.md`/`.pdf`/`.docx`), removable individually, and flagged with a warning when a path no longer resolves on disk.
- Nothing is copied or uploaded: persistence uses this macOS account's own UserDefaults domain, the same as every other setting.
- Out of scope here: indexing/parsing file content and the `search_prep_notes` coaching tool — a follow-up slice.

## Test plan
- [x] `swift build` — clean
- [x] `./scripts/run-tests.sh` — 791/791 tests pass, including new `PrepMaterialPreferencesTests` (round-trip, dedup-on-add, remove-by-id, malformed-entry handling); ghost-mode presentation-API gate passes
- [x] Live-verified in `Jarvis Dev.app`: opened Settings → Prep Material, added a PDF and a Markdown file via the picker, confirmed both list correctly with working remove buttons and the file-type filter applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)