### PR TITLE
feat(activity): export session history to Markdown, plain text, or HTML

### DIFF
--- a/Sources/JarvisApp/Viewer/ActivityExportSheet.swift
+++ b/Sources/JarvisApp/Viewer/ActivityExportSheet.swift
@@ -1,0 +1,246 @@
+import AppKit
+import JarvisCore
+
+/// Presents the "Export…" flow for `ActivityViewer`: a scrollable, checkable list of sessions (so
+/// an arbitrarily long history never distorts the dialog's layout), an export-format choice, and
+/// two content toggles — then a destination-folder panel, then writes one file (plus an
+/// `images/` subfolder when applicable) per selected session. The picker window and both panels
+/// run as blocking modal loops, the same explicit-user-action style as
+/// `PrepMaterialSection.addSource()` and `ActivityViewer`'s own `clearHistoryTapped()`.
+@MainActor
+enum ActivityExportSheet {
+    static func present(sessions: [SessionStore.Session], store: SessionStore) {
+        guard !sessions.isEmpty else { return }
+        let picker = SessionPickerWindow(sessions: sessions)
+        var selectedSessions: [SessionStore.Session] = []
+        // Loop on an empty selection: reopen the same picker (preserving whatever format/toggle
+        // choices were already made) instead of ending the whole flow on a simple mistake.
+        while true {
+            guard picker.runModal() else { return } // ghost-mode-allowed: explicit user action in Settings
+            selectedSessions = picker.selectedSessions
+            guard selectedSessions.isEmpty else { break }
+            inform("Select at least one session",
+                   "Choose at least one session to export, then click Export again.")
+        }
+        let format = picker.selectedFormat
+        let includeScreenshots = picker.includeScreenshots
+        let jarvisResponsesOnly = picker.jarvisResponsesOnly
+
+        let panel = NSOpenPanel() // ghost-mode-allowed: explicit user action in Settings
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Export Here"
+        panel.message = "Choose a destination folder for the exported session history."
+        guard panel.runModal() == .OK, let destination = panel.url else { return } // ghost-mode-allowed: explicit user action in Settings
+
+        do {
+            for session in selectedSessions {
+                try write(
+                    session: session, store: store, format: format,
+                    includeScreenshots: includeScreenshots, jarvisResponsesOnly: jarvisResponsesOnly,
+                    into: destination)
+            }
+            inform("Export complete", "Exported \(selectedSessions.count) "
+                + "session\(selectedSessions.count == 1 ? "" : "s") to \(destination.path).")
+        } catch {
+            inform("Couldn't export history", error.localizedDescription)
+        }
+    }
+
+    private static func write(
+        session: SessionStore.Session,
+        store: SessionStore,
+        format: ActivityHistoryExporter.ExportFormat,
+        includeScreenshots: Bool,
+        jarvisResponsesOnly: Bool,
+        into destination: URL
+    ) throws {
+        let export = ActivityHistoryExporter.export(
+            session: session, entries: store.entries(for: session), format: format,
+            includeScreenshots: includeScreenshots, jarvisResponsesOnly: jarvisResponsesOnly)
+        let sessionDir = destination.appendingPathComponent(session.id)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        try export.text.write(
+            to: sessionDir.appendingPathComponent(export.filename), atomically: true, encoding: .utf8)
+        guard !export.images.isEmpty else { return }
+        let imagesDir = sessionDir.appendingPathComponent("images")
+        try FileManager.default.createDirectory(at: imagesDir, withIntermediateDirectories: true)
+        for (relativePath, data) in export.images {
+            let name = (relativePath as NSString).lastPathComponent
+            try data.write(to: imagesDir.appendingPathComponent(name))
+        }
+    }
+
+    private static func inform(_ title: String, _ message: String) {
+        let alert = NSAlert() // ghost-mode-allowed: explicit user action in Settings
+        alert.messageText = title
+        alert.informativeText = message
+        alert.runModal() // ghost-mode-allowed: explicit user action in Settings
+    }
+}
+
+/// The session-selection window: a fixed-height scrollable checkbox list (so history length
+/// changes the scroll region, never the window), a format radio group, and two toggles, with
+/// Export/Cancel buttons. Runs as a classic blocking modal loop rather than a sheet, matching
+/// every other Settings confirmation in this file.
+@MainActor
+private final class SessionPickerWindow: NSObject, NSTableViewDataSource, NSTableViewDelegate,
+    NSWindowDelegate {
+    private let sessions: [SessionStore.Session]
+    private var checkedRows: [Bool]
+    private let window: NSWindow
+    private let tableView = NSTableView()
+    private var formatButtons: [(NSButton, ActivityHistoryExporter.ExportFormat)] = []
+    private let screenshotsCheckbox =
+        NSButton(checkboxWithTitle: "Include screenshots", target: nil, action: nil)
+    private let responsesOnlyCheckbox =
+        NSButton(checkboxWithTitle: "Jarvis responses only", target: nil, action: nil)
+    private var confirmed = false
+
+    var selectedSessions: [SessionStore.Session] {
+        zip(sessions, checkedRows).filter(\.1).map(\.0)
+    }
+    var selectedFormat: ActivityHistoryExporter.ExportFormat {
+        formatButtons.first { $0.0.state == .on }?.1 ?? .markdown
+    }
+    var includeScreenshots: Bool { screenshotsCheckbox.state == .on }
+    var jarvisResponsesOnly: Bool { responsesOnlyCheckbox.state == .on }
+
+    init(sessions: [SessionStore.Session]) {
+        self.sessions = sessions
+        self.checkedRows = Array(repeating: false, count: sessions.count)
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 380, height: 440),
+            styleMask: [.titled, .closable],
+            backing: .buffered, defer: false)
+        window.title = "Export Activity History"
+        window.isReleasedWhenClosed = false
+        super.init()
+        window.delegate = self
+        window.contentView = makeContentView()
+    }
+
+    /// Blocks until Export/Cancel/the window's close button is used; returns whether the user
+    /// confirmed Export.
+    func runModal() -> Bool {
+        window.center()
+        NSApp.runModal(for: window) // ghost-mode-allowed: explicit user action in Settings
+        window.orderOut(nil)
+        return confirmed
+    }
+
+    private func makeContentView() -> NSView {
+        let content = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 440))
+
+        let scrollView = NSScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.borderType = .bezelBorder
+
+        tableView.headerView = nil
+        tableView.rowHeight = 22
+        tableView.selectionHighlightStyle = .none
+        tableView.dataSource = self
+        tableView.delegate = self
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("session"))
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+        scrollView.documentView = tableView
+
+        let formatStack = NSStackView()
+        formatStack.orientation = .horizontal
+        formatStack.spacing = 12
+        let formats: [(String, ActivityHistoryExporter.ExportFormat)] =
+            [("Markdown", .markdown), ("Plain text", .plainText), ("HTML", .html)]
+        for (title, format) in formats {
+            let radio = NSButton(
+                radioButtonWithTitle: title, target: self, action: #selector(formatRadioTapped(_:)))
+            formatStack.addArrangedSubview(radio)
+            formatButtons.append((radio, format))
+        }
+        formatButtons[0].0.state = .on
+
+        let cancelButton = NSButton(title: "Cancel", target: self, action: #selector(cancelTapped))
+        cancelButton.bezelStyle = .rounded
+        cancelButton.keyEquivalent = "\u{1b}"
+        let exportButton = NSButton(title: "Export", target: self, action: #selector(exportTapped))
+        exportButton.bezelStyle = .rounded
+        exportButton.keyEquivalent = "\r"
+        let buttonRow = NSStackView(views: [cancelButton, exportButton])
+        buttonRow.orientation = .horizontal
+        buttonRow.spacing = 8
+
+        let root = NSStackView(views: [
+            Self.sectionLabel("Sessions to export"), scrollView,
+            Self.sectionLabel("Format"), formatStack,
+            screenshotsCheckbox, responsesOnlyCheckbox, buttonRow,
+        ])
+        root.orientation = .vertical
+        root.alignment = .leading
+        root.spacing = 10
+        root.edgeInsets = NSEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        root.translatesAutoresizingMaskIntoConstraints = false
+        content.addSubview(root)
+
+        NSLayoutConstraint.activate([
+            root.topAnchor.constraint(equalTo: content.topAnchor),
+            root.leadingAnchor.constraint(equalTo: content.leadingAnchor),
+            root.trailingAnchor.constraint(equalTo: content.trailingAnchor),
+            root.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            scrollView.heightAnchor.constraint(equalToConstant: 180),
+            buttonRow.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -16),
+        ])
+        return content
+    }
+
+    @objc private func exportTapped() {
+        confirmed = true
+        NSApp.stopModal()
+    }
+
+    @objc private func cancelTapped() {
+        confirmed = false
+        NSApp.stopModal()
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        cancelTapped()
+        return true
+    }
+
+    // MARK: - NSTableViewDataSource / NSTableViewDelegate
+
+    func numberOfRows(in tableView: NSTableView) -> Int { sessions.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let identifier = NSUserInterfaceItemIdentifier("session-checkbox")
+        let checkbox = (tableView.makeView(withIdentifier: identifier, owner: nil) as? NSButton)
+            ?? NSButton(checkboxWithTitle: "", target: self, action: #selector(sessionCheckboxToggled(_:)))
+        checkbox.identifier = identifier
+        let session = sessions[row]
+        checkbox.title = session.isCurrent ? "\(session.label) (current)" : session.label
+        checkbox.tag = row
+        checkbox.state = checkedRows[row] ? .on : .off
+        return checkbox
+    }
+
+    @objc private func sessionCheckboxToggled(_ sender: NSButton) {
+        checkedRows[sender.tag] = sender.state == .on
+    }
+
+    /// Plain sibling `NSButton`s (not an `NSMatrix`) don't deselect each other automatically —
+    /// enforce single-selection explicitly so picking a different format actually sticks.
+    @objc private func formatRadioTapped(_ sender: NSButton) {
+        for (button, _) in formatButtons {
+            button.state = button === sender ? .on : .off
+        }
+    }
+
+    private static func sectionLabel(_ text: String) -> NSTextField {
+        let field = NSTextField(labelWithString: text)
+        field.font = .boldSystemFont(ofSize: NSFont.smallSystemFontSize)
+        field.textColor = .secondaryLabelColor
+        return field
+    }
+}

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -32,6 +32,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
     private var copySessionIDButton: NSButton?
     private var evaluateButton: NSButton?
     private var clearHistoryButton: NSButton?
+    private var exportButton: NSButton?
     /// Survives a Settings close/reopen because the viewer itself lives for the whole app run.
     private var isEvaluating = false
     /// Retained so Quit can cancel the direct CLI child instead of leaving an orphaned paid run.
@@ -106,6 +107,13 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         header.addSubview(clear)
         self.clearHistoryButton = clear
 
+        let export = NSButton(title: "Export…", target: self, action: #selector(exportTapped))
+        export.translatesAutoresizingMaskIntoConstraints = false
+        export.bezelStyle = .rounded
+        export.toolTip = "Export one or more sessions' history to a file"
+        header.addSubview(export)
+        self.exportButton = export
+
         let preferredPickerWidth = pop.widthAnchor.constraint(equalToConstant: 230)
         // Prefer the full picker width, but let window resizing compress it.
         preferredPickerWidth.priority = .init(rawValue: 490)
@@ -123,7 +131,10 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
             evaluate.trailingAnchor.constraint(equalTo: clear.leadingAnchor, constant: -8),
             clear.centerYAnchor.constraint(equalTo: header.centerYAnchor),
             clear.widthAnchor.constraint(equalToConstant: 110),
-            clear.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -12),
+            clear.trailingAnchor.constraint(equalTo: export.leadingAnchor, constant: -8),
+            export.centerYAnchor.constraint(equalTo: header.centerYAnchor),
+            export.widthAnchor.constraint(equalToConstant: 90),
+            export.trailingAnchor.constraint(equalTo: header.trailingAnchor, constant: -12),
         ])
 
         let wv = WKWebView(frame: NSRect(x: 0, y: 0,
@@ -149,6 +160,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         copySessionIDButton = nil
         evaluateButton = nil
         clearHistoryButton = nil
+        exportButton = nil
         loaded = false
         pending = []
         snapshotRows = []
@@ -444,6 +456,16 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
         alert.messageText = title
         alert.informativeText = message
         alert.runModal() // ghost-mode-allowed: guarded explicit Activity action
+    }
+
+    // MARK: - Export
+
+    @objc private func exportTapped() {
+        guard isCoachingRunning?() != true else {
+            jlog("Jarvis: suppressed Activity export presentation while coaching is running.")
+            return
+        }
+        ActivityExportSheet.present(sessions: sessions, store: store)
     }
 
     // MARK: - Clear history

--- a/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Turns one session's already-decoded Activity entries into an exportable document, for the
+/// "Export…" action in `ActivityViewer` (JarvisApp). Foundation-only and pure — this type never
+/// touches disk; the caller decides where to write `text` and each `images` pair.
+public enum ActivityHistoryExporter {
+    public enum ExportFormat: String, CaseIterable, Sendable {
+        case markdown, plainText, html
+    }
+
+    public struct Export: Sendable {
+        public let filename: String
+        public let text: String
+        public let images: [(filename: String, data: Data)]
+    }
+
+    public static func export(
+        session: SessionStore.Session,
+        entries: [(ActivityLog.Entry, Data?)],
+        format: ExportFormat,
+        includeScreenshots: Bool,
+        jarvisResponsesOnly: Bool
+    ) -> Export {
+        let kept = jarvisResponsesOnly ? responsesOnly(entries) : entries
+
+        switch format {
+        case .markdown:
+            return Export(
+                filename: "activity.md",
+                text: markdown(session: session, entries: kept, includeScreenshots: includeScreenshots),
+                images: images(for: kept, includeScreenshots: includeScreenshots))
+        case .plainText:
+            return Export(
+                filename: "activity.txt",
+                text: plainText(session: session, entries: kept, includeScreenshots: includeScreenshots),
+                images: images(for: kept, includeScreenshots: includeScreenshots))
+        case .html:
+            return Export(
+                filename: "activity.html",
+                text: html(session: session, entries: kept, includeScreenshots: includeScreenshots),
+                images: [])
+        }
+    }
+
+    /// The `ActivityLog.cssClass` values counted as "Jarvis's own actions" for the
+    /// responses-only filter — today, its spoken tips (💬 `say`) and its screen views (👁 `see`).
+    /// Add another class here to broaden the filter later; nothing else needs to change.
+    private static let jarvisResponseClasses: Set<String> = ["say", "see"]
+
+    /// Keeps only Jarvis's own actions (`jarvisResponseClasses`), dropping heard speech and
+    /// system/lifecycle notices. Independent of `includeScreenshots`: whether a kept screen-view
+    /// row's own image is actually exported is decided later, purely by that other toggle, with
+    /// no cross-referencing here.
+    private static func responsesOnly(
+        _ entries: [(ActivityLog.Entry, Data?)]
+    ) -> [(ActivityLog.Entry, Data?)] {
+        entries.filter { jarvisResponseClasses.contains(ActivityLog.cssClass(for: $0.0.message)) }
+    }
+
+    private static func images(
+        for entries: [(ActivityLog.Entry, Data?)],
+        includeScreenshots: Bool
+    ) -> [(filename: String, data: Data)] {
+        guard includeScreenshots else { return [] }
+        return entries.compactMap { entry, data in
+            guard let imageFile = entry.imageFile, let data else { return nil }
+            return ("images/\(imageFile)", data)
+        }
+    }
+
+    private static func markdown(
+        session: SessionStore.Session,
+        entries: [(ActivityLog.Entry, Data?)],
+        includeScreenshots: Bool
+    ) -> String {
+        var lines = ["# Jarvis session — \(session.label)", "", "Session ID: \(session.id)", ""]
+        for (entry, data) in entries {
+            lines.append("**\(entry.time)** — \(entry.message)")
+            if includeScreenshots, let imageFile = entry.imageFile, data != nil {
+                lines.append("")
+                lines.append("![screenshot](images/\(imageFile))")
+            }
+            lines.append("")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func plainText(
+        session: SessionStore.Session,
+        entries: [(ActivityLog.Entry, Data?)],
+        includeScreenshots: Bool
+    ) -> String {
+        var lines = ["Jarvis session — \(session.label)", "Session ID: \(session.id)", ""]
+        for (entry, data) in entries {
+            lines.append("\(entry.time)  \(entry.message)")
+            if includeScreenshots, let imageFile = entry.imageFile, data != nil {
+                lines.append("[screenshot: images/\(imageFile)]")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func html(
+        session: SessionStore.Session,
+        entries: [(ActivityLog.Entry, Data?)],
+        includeScreenshots: Bool
+    ) -> String {
+        func escape(_ s: String) -> String {
+            s.replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+        }
+        var rows = ""
+        for (entry, data) in entries {
+            rows += "<div class=\"row\"><span class=\"t\">\(escape(entry.time))</span>"
+            rows += "<span class=\"m\">\(escape(entry.message))"
+            if includeScreenshots, let data {
+                rows += "<img src=\"data:image/jpeg;base64,\(data.base64EncodedString())\">"
+            }
+            rows += "</span></div>\n"
+        }
+        return """
+        <!doctype html><html lang="en"><head><meta charset="utf-8">
+        <title>Jarvis session — \(escape(session.label))</title>
+        <style>
+          body { font: 13px/1.5 -apple-system, sans-serif; margin: 24px; }
+          .row { display: grid; grid-template-columns: 70px 1fr; gap: 12px; padding: 6px 0; }
+          .t { color: #888; }
+          img { display: block; max-width: 480px; margin-top: 8px; border-radius: 6px; }
+        </style></head><body>
+        <h1>Jarvis session — \(escape(session.label))</h1>
+        <p>Session ID: \(escape(session.id))</p>
+        \(rows)
+        </body></html>
+        """
+    }
+}

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
@@ -1,0 +1,131 @@
+import Testing
+import Foundation
+@testable import JarvisCore
+
+@Suite struct ActivityHistoryExporterTests {
+    private func session(id: String = "2026-06-16_10-00-00_aaaa") -> SessionStore.Session {
+        SessionStore.Session(
+            id: id, label: "2026-06-16 10:00:00",
+            url: URL(fileURLWithPath: "/tmp/\(id)"), isCurrent: false, evidenceIsComplete: true)
+    }
+
+    @Test func markdownOmitsImagesWhenScreenshotsExcluded() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:00", message: "🗣 heard (them): hi", imageFile: nil), nil),
+            (ActivityLog.Entry(time: "10:00:05", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .markdown,
+            includeScreenshots: false, jarvisResponsesOnly: false)
+        #expect(export.filename == "activity.md")
+        #expect(!export.text.contains("![screenshot]"))
+        #expect(export.images.isEmpty)
+    }
+
+    @Test func markdownEmbedsScreenshotsAsRelativeLinksWhenIncluded() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:05", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .markdown,
+            includeScreenshots: true, jarvisResponsesOnly: false)
+        #expect(export.text.contains("![screenshot](images/shot-1.jpg)"))
+        #expect(export.images.count == 1)
+        #expect(export.images[0].filename == "images/shot-1.jpg")
+        #expect(export.images[0].data == Data([0xFF, 0xD8, 0xFF, 0xD9]))
+    }
+
+    @Test func plainTextReferencesScreenshotFilenameWithoutEmbedding() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:05", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .plainText,
+            includeScreenshots: true, jarvisResponsesOnly: false)
+        #expect(export.filename == "activity.txt")
+        #expect(export.text.contains("[screenshot: images/shot-1.jpg]"))
+        #expect(!export.text.contains("!["))
+        #expect(export.images.count == 1)
+    }
+
+    @Test func htmlInlinesScreenshotsAsBase64AndWritesNoSeparateImages() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:05", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .html,
+            includeScreenshots: true, jarvisResponsesOnly: false)
+        #expect(export.filename == "activity.html")
+        #expect(export.text.contains("data:image/jpeg;base64,"))
+        #expect(export.images.isEmpty)
+    }
+
+    @Test func jarvisResponsesOnlyKeepsTipsAndScreenViewsButDropsHeardSpeechAndSystemRows() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:00", message: "🗣 heard (them): hi", imageFile: nil), nil),
+            (ActivityLog.Entry(time: "10:00:01", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+            (ActivityLog.Entry(time: "10:00:02", message: "💬 try rephrasing that", imageFile: nil), nil),
+            (ActivityLog.Entry(time: "10:00:03", message: "⏹ session ended by user", imageFile: nil), nil),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .plainText,
+            includeScreenshots: false, jarvisResponsesOnly: true)
+        #expect(export.text.contains("looking at your screen"))
+        #expect(export.text.contains("try rephrasing that"))
+        #expect(!export.text.contains("heard (them)"))
+        #expect(!export.text.contains("session ended"))
+    }
+
+    /// The two toggles are independent: "Jarvis responses only" only decides which rows survive;
+    /// "Include screenshots" only decides whether a surviving row's own image is exported. Since a
+    /// screen-view row is itself one of Jarvis's own actions, its screenshot comes along for free
+    /// with no cross-referencing between the two options.
+    @Test func jarvisResponsesOnlyExportsScreenshotsFromKeptScreenViewRowsWhenIncluded() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:00", message: "🗣 heard (them): hi", imageFile: nil), nil),
+            (ActivityLog.Entry(time: "10:00:01", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .markdown,
+            includeScreenshots: true, jarvisResponsesOnly: true)
+        #expect(export.text.contains("![screenshot](images/shot-1.jpg)"))
+        #expect(export.images.count == 1)
+        #expect(export.images[0].filename == "images/shot-1.jpg")
+    }
+
+    @Test func jarvisResponsesOnlyOmitsScreenViewImageWhenScreenshotsExcluded() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:00", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
+             Data([0xFF, 0xD8, 0xFF, 0xD9])),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .markdown,
+            includeScreenshots: false, jarvisResponsesOnly: true)
+        #expect(!export.text.contains("![screenshot]"))
+        #expect(export.images.isEmpty)
+    }
+
+    @Test func emptyEntriesStillProduceHeaderOnlyDocument() {
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: [], format: .markdown,
+            includeScreenshots: false, jarvisResponsesOnly: false)
+        #expect(export.text.contains("2026-06-16 10:00:00"))
+    }
+
+    @Test func jarvisResponsesOnlyFilteringToZeroStillProducesHeaderOnlyDocument() {
+        let entries: [(ActivityLog.Entry, Data?)] = [
+            (ActivityLog.Entry(time: "10:00:00", message: "🗣 heard (them): hi", imageFile: nil), nil),
+        ]
+        let export = ActivityHistoryExporter.export(
+            session: session(), entries: entries, format: .markdown,
+            includeScreenshots: false, jarvisResponsesOnly: true)
+        #expect(export.text.contains("2026-06-16 10:00:00"))
+        #expect(!export.text.contains("heard (them)"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an "Export…" action to the Activity settings tab (next to Copy ID / Evaluate / Clear history) that opens a picker window listing past sessions with checkboxes, so an arbitrarily long history scrolls instead of distorting the dialog.
- Export format is chosen per export: Markdown, plain text, or self-contained HTML. Markdown/plain text copy screenshots into an `images/` folder alongside `activity.<ext>`; HTML inlines them as base64 `data:` URIs since it's a single file.
- Two independent toggles: **Include screenshots** (off by default) and **Jarvis responses only** (off by default), which keeps only Jarvis's own actions — tips (💬) and screen views (👁) — via an easily-extensible `jarvisResponseClasses` set, dropping heard speech and system/lifecycle notices.
- New Foundation-only `ActivityHistoryExporter` in `JarvisCore` (pure, no disk I/O) backs the format/filter logic; `ActivityExportSheet` in `JarvisApp` owns the AppKit picker window and file writing.

## Test plan
- [x] `swift build && ./scripts/run-tests.sh` passes (833 tests)
- [x] Unit tests for `ActivityHistoryExporter` cover all three formats, both toggles independently and combined, and edge cases (empty entries, filtering to zero)
- [x] Manual smoke: built and ran `Jarvis Dev.app`, exercised Export… with multiple sessions selected, each format, and both toggles on/off, confirming output files and screenshot placement

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>