### PR TITLE
fix(shortcuts): trace and harden the manual hint hotkey against silent drops

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -199,9 +199,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         hotkeys = HotkeyController()
         hotkeys?.onRequestHint = { [weak self] in
             guard let self, let fire = self.requestManualHint else {
+                jlog("Jarvis: hint hotkey ignored — no live session, beeping instead.")
                 NSSound.beep() // ghost-mode-allowed: explicit user hotkey while stopped
                 return
             }
+            jlog("Jarvis: hint hotkey routed into the coaching pipeline.")
             fire()
         }
 

--- a/Sources/JarvisApp/Shortcuts/HotkeyController.swift
+++ b/Sources/JarvisApp/Shortcuts/HotkeyController.swift
@@ -42,8 +42,12 @@ final class HotkeyController {
             guard let userData else { return noErr }
             let controller = Unmanaged<HotkeyController>.fromOpaque(userData).takeUnretainedValue()
             // Carbon delivers application-target hot-key events on the main thread, so it is safe to
-            // assert main-actor isolation here and call back synchronously.
-            MainActor.assumeIsolated { controller.onRequestHint?() }
+            // assert main-actor isolation here and call back synchronously. Logged unconditionally so
+            // a press that never reaches the coaching pipeline is still provably recorded here first.
+            MainActor.assumeIsolated {
+                jlog("Jarvis: hint hotkey ⌥⌘J pressed.")
+                controller.onRequestHint?()
+            }
             return noErr
         }, 1, &spec, selfPtr, &handlerRef)
         // A failed install leaves the hot key dead; without this line that failure is invisible.

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -525,6 +525,10 @@ public final class CoachDriver: @unchecked Sendable {
         while true {
             let step = takeBrainSelectionStep()
             if step.alreadyExhausted {
+                // The route exhausted between this trigger's claim and its first selection — the
+                // exhaustion notice itself was already delivered when it first happened, but a
+                // trigger landing here must still leave a trace rather than vanish silently.
+                jlog("… provider route already exhausted")
                 return nil
             }
             if let diagnostic = step.diagnostic {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverManualHintTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverManualHintTests.swift
@@ -133,4 +133,40 @@ private final class FailingScreen: ScreenCapturing, @unchecked Sendable {
         #expect(overlay.rendered.isEmpty)        // ...but never rendered a tip after Stop
         #expect(brain.calls.isEmpty)             // and the guard fires before any brain.respond call
     }
+
+    /// Regression for a hint press that lands while another trigger's attempt is already in flight
+    /// (issue #231): `claimOrPend` must coalesce it into the pending trigger rather than drop it, and
+    /// the SAME `handleTrigger(.turnEnd)` call — not a new one — must go on to run the forced hint
+    /// once the in-flight attempt completes, since the hint's own call only ever reports `.busy`.
+    @Test func manualHintPressedWhileAnAttemptIsInFlightStillExecutesAfterItCompletes() async {
+        let gate = AsyncGate()
+        let brain = GatedBrain(gate: gate, script: [
+            .init(toolCalls: [.speak(callId: "turnEnd", lines: ["in-flight turn-end tip"])],
+                  rawToolCalls: [RawToolCall(id: "turnEnd", name: "speak",
+                                             argumentsJSON: #"{"lines":["in-flight turn-end tip"]}"#)]),
+            .init(toolCalls: [.speak(callId: "hint", lines: ["forced hint tip"])],
+                  rawToolCalls: [RawToolCall(id: "hint", name: "speak",
+                                             argumentsJSON: #"{"lines":["forced hint tip"]}"#)]),
+        ])
+        let screen = FakeScreen()
+        let overlay = FakeOverlay()
+        let (driver, transcript) = makeDriver(brain: brain, screen: screen, overlay: overlay, clock: ManualClock(now: 0))
+        transcript.append(.init(speaker: .me, text: "walking through the approach", at: 0))
+
+        async let turnEndOutcome = driver.handleTrigger(.turnEnd)   // parks inside the brain call
+        await gate.waitUntilEntered()
+
+        let hintOutcome = await driver.handleTrigger(.manualHint)   // pends behind the in-flight attempt
+        #expect(hintOutcome == .busy)
+
+        await gate.release()                                       // lets the turn-end attempt finish
+
+        #expect(await turnEndOutcome == .spoke)   // the ORIGINAL call carries the coalesced hint home
+        #expect(brain.calls.count == 2)
+        #expect(screen.captureCount == 1)                                // the hint captured the screen
+        #expect(brain.calls[1].contains { $0.imageBase64JPEG != nil })   // ...and it rode the forced request
+        let hintUserText = brain.calls[1].compactMap { $0.text }.joined(separator: " ")
+        #expect(hintUserText.contains("hint shortcut"))
+        #expect(overlay.rendered == [["in-flight turn-end tip"], ["forced hint tip"]])
+    }
 }


### PR DESCRIPTION
## Summary

Investigates #231 — the manual hint hotkey (⌥⌘J) silently failing to fire mid-session, with zero trace at any logging layer.

I read through `HotkeyController`, the `AppDelegate` hotkey plumbing, `TurnTaskBox`, and `CoachDriver`'s trigger-coalescing/single-flight logic (`claimOrPend`, `selectBrainForAttempt`, `handleTrigger`) — the area #231 names as the suspect. That mechanism looks logically sound: every reachable branch of `claimOrPend` (`.claimed`, `.pending`, `.exhausted`) already `jlog`s, and a pended manual hint is correctly coalesced with priority and carried forward — a regression test below confirms it still executes once the in-flight attempt completes. I did **not** find a confirmed drop inside `CoachDriver`.

What I did find is a real gap: there was **no logging at all** between the Carbon hot-key callback firing and the press reaching (or not reaching) the coaching pipeline — exactly the blind spot #231's own step 1 called out. This PR closes that gap plus one theoretical (currently unreachable, but silent) path, and adds the regression test #231 asked for.

## Changes

- `HotkeyController`: log unconditionally the moment the Carbon callback fires — proves the OS-level event was delivered, before it depends on `onRequestHint` being wired up correctly.
- `AppDelegate`: log which of the two outcomes the press took — routed into the running session, or beeped because no session is live.
- `CoachDriver.selectBrainForAttempt`: log the one branch that could still return silently (a trigger claimed the instant before the route exhausts) with the same "route already exhausted" message used elsewhere, so a hotkey press can never fall through without a trace anywhere.
- `CoachDriverManualHintTests`: new regression test — a manual hint pressed while a turn-end attempt is in flight returns `.busy` immediately, then the *original* `handleTrigger` call goes on to run the forced hint (screenshot + forced `speak`) once the in-flight attempt completes.

## Why not more?

#231's completion criteria is satisfied: a press now always either executes, beeps, or is logged as pended — never silently disappears — and that's provable in the logs. Since I couldn't reproduce or definitively root-cause the original drop from static reading alone, the honest move was to add the missing instrumentation rather than guess at a fix for a mechanism that already looks correct. If it recurs, the new `HotkeyController`/`AppDelegate` logs will show whether the drop is before or after the app boundary.

## Test plan

- [x] `swift build && ./scripts/run-tests.sh` — 858 tests pass, including the new `manualHintPressedWhileAnAttemptIsInFlightStillExecutesAfterItCompletes`.
- [ ] Live smoke: press ⌥⌘J during a live session and confirm the two new log lines appear in `jarvis-debug.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)