### PR TITLE
feat(menu): add a Clear Overlay menu item

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -199,6 +199,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         ]
         settingsWindow = SettingsWindow(sections: sections)
         menuBar.onOpenSettings = { [weak self] in self?.settingsWindow.show() }
+        menuBar.onClearOverlayBox = { [weak self] in self?.overlayBox.clear() }
 
         // The menu drives the pipeline lifecycle. Jarvis does NOT auto-start; the user presses Start.
         menuBar.onStart = { [weak self] in self?.start() ?? false }

--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -22,6 +22,10 @@ final class MenuBarController: NSObject {
     var onStop: (() -> Void)?
     /// Fired when the user picks "Settings". Opens the unified Settings window.
     var onOpenSettings: (() -> Void)?
+    /// Fired when the user picks "Clear Overlay". Wipes the Overlay Box's logged history — the
+    /// persistent panel only clears itself on the next Start, so this is the only way to dismiss its
+    /// content without starting a new session.
+    var onClearOverlayBox: (() -> Void)?
     /// Fired when the user picks "Check for Updates". Answers whether Sparkle can start a check, so
     /// the item can render its own availability without this adapter importing Sparkle.
     /// Not private for the same reason as `updateItem`.
@@ -48,6 +52,8 @@ final class MenuBarController: NSObject {
             startStopItem,
             .standard("Settings", symbol: "gearshape",
                       action: #selector(openSettings), target: self, keyEquivalent: ","),
+            .standard("Clear Overlay", symbol: "eraser",
+                      action: #selector(clearOverlayBox), target: self),
         ]
         if let updateItem { menu.items.append(updateItem) }
         menu.items.append(contentsOf: [
@@ -118,6 +124,8 @@ final class MenuBarController: NSObject {
     }
 
     @objc private func openSettings() { onOpenSettings?() }
+
+    @objc private func clearOverlayBox() { onClearOverlayBox?() }
 
     @objc private func checkForUpdates() { onCheckForUpdates?() }
 


### PR DESCRIPTION
## Summary

- Adds a "Clear Overlay" item (eraser icon) to the menu-bar dropdown, between "Settings…" and
  "Check for Updates" / "Quit Jarvis".
- Calls the existing `OverlayBoxPanel.clear()` on click — no new panel logic, just menu wiring
  (`MenuBarController` gets a new `onClearOverlayBox` closure, `AppDelegate` wires it to
  `overlayBox.clear()`).
- **Why**: the Overlay Box (the persistent, movable log of everything Jarvis has said) only clears
  itself on the *next* Start. After Stop, its content just sits on screen with no way to dismiss it
  short of starting a new session. This gives a direct way to clear it on demand.
- **Scope**: deliberately limited to the Box overlay only. The Caption overlay (the transient,
  one-line-at-a-time tip) already auto-clears itself and isn't touched here — confirmed with the repo
  owner before implementing.

## Test plan

- [x] Gate (`swift build && ./scripts/run-tests.sh`) passes — 872 tests, 102 suites.
- [x] `./scripts/check-ghost-mode.sh` passes — this only hides/clears content, no new presentation API,
      so no `ghost-mode-allowed` annotation is needed.
- [x] `OverlayBoxPanel.clear()` itself already has test coverage
      (`Tests/JarvisOverlayTests/OverlayBoxPanelTests.swift`); this change adds only thin AppKit menu
      glue with no new logic to unit-test, consistent with the project convention that `JarvisApp` UI
      is verified live rather than via swift-testing.
- [ ] **Live UI verification was not completed** — I was not able to cleanly confirm the item renders
      correctly in the running app's menu bar dropdown before opening this PR. A manual check
      (`./scripts/build-app.sh --run`, open the menu bar dropdown, confirm "Clear Overlay" appears and
      clears the Box) is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a menu-bar option to clear persistent overlay response history.
  - The new “Clear Overlay” command is available alongside existing menu options and immediately removes stored overlay content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->