### PR TITLE
test(diagnostics): fix flaky JarvisLog cross-suite attachment race

### DIFF
--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -441,29 +441,29 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         // what makes this boundary worth pinning: the two projections must still stay separate.
         let (activityLog, evidence) = ActivityLog.recordingSession(in: dir)
         defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        let brain = ScriptedBrain(script: [
-            .init(toolCalls: [.speak(callId: "s", lines: ["activity-boundary-tip-417"])])
-        ])
-        let (driver, _) = makeDriver(
-            activity: evidence, brain: brain, clock: ManualClock(now: 417))
+            let brain = ScriptedBrain(script: [
+                .init(toolCalls: [.speak(callId: "s", lines: ["activity-boundary-tip-417"])])
+            ])
+            let (driver, _) = makeDriver(
+                activity: evidence, brain: brain, clock: ManualClock(now: 417))
 
-        #expect(await driver.handleTrigger(.silence(secondsQuiet: 417)) == .spoke)
+            #expect(await driver.handleTrigger(.silence(secondsQuiet: 417)) == .spoke)
 
-        _ = await evidence.close()   // barrier: drains this session's accepted rows
-        let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
-        #expect(jsonl.contains("activity-boundary-tip-417"))
-        #expect(!jsonl.contains("quiet for 417s"))
-        #expect(!jsonl.contains("thinking"))
+            _ = await evidence.close()   // barrier: drains this session's accepted rows
+            let jsonl = try String(contentsOf: dir.appendingPathComponent("jarvis-activity.jsonl"), encoding: .utf8)
+            #expect(jsonl.contains("activity-boundary-tip-417"))
+            #expect(!jsonl.contains("quiet for 417s"))
+            #expect(!jsonl.contains("thinking"))
 
-        let debug = try String(contentsOf: dir.appendingPathComponent("jarvis-debug.log"), encoding: .utf8)
-        #expect(debug.contains("quiet for 417s"))
-        #expect(debug.contains("thinking"))
-        #expect(debug.contains("activity-boundary-tip-417"))
+            let debug = try String(contentsOf: dir.appendingPathComponent("jarvis-debug.log"), encoding: .utf8)
+            #expect(debug.contains("quiet for 417s"))
+            #expect(debug.contains("thinking"))
+            #expect(debug.contains("activity-boundary-tip-417"))
+        }
     }
 
     @Test func nonExhaustingAttemptFailuresLandInActivityBeforeRecovery() async throws {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -205,7 +205,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 // `GatedScreen` / `HeldCleanupScreen` park their `capture()` until the test releases it, and the
 // driver runs that capture on a `Task.detached`, holding a cooperative-pool thread for the whole
 // park. Three such tests exist in the repository and a CI runner has three pool threads, so
-// overlapping parks can starve every release path. Cap this suite at one at a time.
+// overlapping parks can starve every release path. Cap this suite at one at a time. One case also
+// installs a process-global `JarvisLog` attachment and holds `JarvisLogAttachmentLock` for it, since
+// `.serialized` alone does not protect against the other suites that do the same.
 @Suite(.serialized) struct CoachDriverPipelineTests {
     private func makeDriver(activity: (any ActivityEventRecording)? = nil,
                             brain: BrainClient, brainProvider: BrainProvider? = nil,
@@ -439,6 +441,8 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         // what makes this boundary worth pinning: the two projections must still stay separate.
         let (activityLog, evidence) = ActivityLog.recordingSession(in: dir)
         defer { activityLog.disable(); try? FileManager.default.removeItem(at: dir) }
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 

--- a/Tests/JarvisCoreTests/Diagnostics/CaptureHeartbeatTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/CaptureHeartbeatTests.swift
@@ -110,17 +110,17 @@ import Testing
         #expect(baseline.readiness.last == .stopped)
 
         for variant in try evidenceVariants() {
-            JarvisLogAttachmentLock.acquire()
-            defer { JarvisLogAttachmentLock.release() }
-            defer {
-                JarvisLog.detach()
-                try? FileManager.default.removeItem(at: variant.directory)
+            try await JarvisLogAttachmentLock.withExclusiveAttachment {
+                defer {
+                    JarvisLog.detach()
+                    try? FileManager.default.removeItem(at: variant.directory)
+                }
+                JarvisLog.attach(to: variant.evidence)
+                let outcome = runCriticalBranch(emittingEvidence: true)
+                variant.release?()
+                #expect(outcome == baseline, "evidence variant \(variant.name) changed coaching health")
+                #expect(await variant.evidence.close() == variant.expectedClose)
             }
-            JarvisLog.attach(to: variant.evidence)
-            let outcome = runCriticalBranch(emittingEvidence: true)
-            variant.release?()
-            #expect(outcome == baseline, "evidence variant \(variant.name) changed coaching health")
-            #expect(await variant.evidence.close() == variant.expectedClose)
         }
     }
 

--- a/Tests/JarvisCoreTests/Diagnostics/CaptureHeartbeatTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/CaptureHeartbeatTests.swift
@@ -8,7 +8,9 @@ import Testing
 /// optional evidence copy may make a session's record partial, and can never change a readiness,
 /// microphone-only degradation, or stop decision.
 ///
-/// Serialized because the evidence-pressure cases install a process-global `JarvisLog` attachment.
+/// Serialized because the evidence-pressure cases install a process-global `JarvisLog` attachment —
+/// `JarvisLogAttachmentLock` additionally guards it against the other suites that do the same, since
+/// `.serialized` only covers cases within this one suite.
 @Suite(.serialized) struct CaptureHeartbeatTests {
     /// The complete observable output of the critical branch for one heartbeat script: what the app
     /// would render, and every lifecycle consequence it would apply, in order.
@@ -108,6 +110,8 @@ import Testing
         #expect(baseline.readiness.last == .stopped)
 
         for variant in try evidenceVariants() {
+            JarvisLogAttachmentLock.acquire()
+            defer { JarvisLogAttachmentLock.release() }
             defer {
                 JarvisLog.detach()
                 try? FileManager.default.removeItem(at: variant.directory)

--- a/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
@@ -80,7 +80,11 @@ enum CoachingParityHarness {
 
     static func run(observers: EvidenceObservers = EvidenceObservers()) async -> Snapshot {
         // `JarvisLog`'s attachment is process-global, so a diagnostics variant must run in a
-        // serialized suite. Detached again on the way out, whether or not one was installed.
+        // serialized suite — and, since swift-testing still runs distinct suites concurrently,
+        // exclusively across suites too (`JarvisLogAttachmentLock`). Detached/released again on the
+        // way out, whether or not one was installed.
+        if observers.diagnostics != nil { JarvisLogAttachmentLock.acquire() }
+        defer { if observers.diagnostics != nil { JarvisLogAttachmentLock.release() } }
         if let diagnostics = observers.diagnostics { JarvisLog.attach(to: diagnostics) }
         defer { if observers.diagnostics != nil { JarvisLog.detach() } }
 

--- a/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift
@@ -82,12 +82,18 @@ enum CoachingParityHarness {
         // `JarvisLog`'s attachment is process-global, so a diagnostics variant must run in a
         // serialized suite — and, since swift-testing still runs distinct suites concurrently,
         // exclusively across suites too (`JarvisLogAttachmentLock`). Detached/released again on the
-        // way out, whether or not one was installed.
-        if observers.diagnostics != nil { JarvisLogAttachmentLock.acquire() }
-        defer { if observers.diagnostics != nil { JarvisLogAttachmentLock.release() } }
-        if let diagnostics = observers.diagnostics { JarvisLog.attach(to: diagnostics) }
-        defer { if observers.diagnostics != nil { JarvisLog.detach() } }
+        // way out.
+        guard let diagnostics = observers.diagnostics else {
+            return await runScenario(observers: observers)
+        }
+        return await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: diagnostics)
+            defer { JarvisLog.detach() }
+            return await runScenario(observers: observers)
+        }
+    }
 
+    private static func runScenario(observers: EvidenceObservers) async -> Snapshot {
         let requests = RequestCapture()
         let transitions = TransitionCapture()
         let transportFailure = NSError(

--- a/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
@@ -10,7 +10,9 @@ import Testing
 /// elapsed wall-clock time.
 ///
 /// Serialized because several cases park the worker's serial queue, and because `JarvisLog`'s
-/// attachment is process-global.
+/// attachment is process-global — the latter also needs `JarvisLogAttachmentLock` for exclusivity
+/// against the *other* suites that install the same attachment, since `.serialized` only covers
+/// cases within this one suite.
 @Suite(.serialized) struct DiagnosticEvidenceTests {
     /// Records what reached the Console edge and can park the worker on demand.
     private final class RecordingWriter: SessionAuditWriting, @unchecked Sendable {
@@ -77,6 +79,8 @@ import Testing
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: writer))
         wait(for: writer.openEntered)
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 
@@ -106,6 +110,8 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: RecordingWriter()))
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 
@@ -158,6 +164,8 @@ import Testing
         }
         let worker = SessionAuditWorker(limits: .production, writer: RecordingWriter())
         let sessionA = FileSessionAudit(directory: first, worker: worker)
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: sessionA)
         defer { JarvisLog.detach() }
 
@@ -186,6 +194,8 @@ import Testing
             writer: writer)
         let evidence = FileSessionAudit(directory: directory, worker: worker)
         wait(for: writer.openEntered)
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 
@@ -214,6 +224,8 @@ import Testing
             worker: SessionAuditWorker(
                 limits: .init(maxEventCount: 8, maxRetainedBytes: 512),
                 writer: RecordingWriter()))
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 
@@ -236,6 +248,8 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: writer))
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 
@@ -263,6 +277,8 @@ import Testing
                 limits: .init(maxEventCount: 2, maxRetainedBytes: 65_536),
                 writer: writer))
         wait(for: writer.openEntered)
+        JarvisLogAttachmentLock.acquire()
+        defer { JarvisLogAttachmentLock.release() }
         JarvisLog.attach(to: evidence)
         defer { JarvisLog.detach() }
 

--- a/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
@@ -79,27 +79,27 @@ import Testing
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: writer))
         wait(for: writer.openEntered)
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        for index in 0..<32 { jlog("parked-caller-diagnostic-\(index)") }
+            for index in 0..<32 { jlog("parked-caller-diagnostic-\(index)") }
 
-        // The worker has not moved, so nothing reached Console and no debug log exists yet.
-        #expect(writer.console.isEmpty)
-        #expect(!FileManager.default.fileExists(
-            atPath: directory.appendingPathComponent(
-                FileSessionAudit.diagnosticFilename).path))
+            // The worker has not moved, so nothing reached Console and no debug log exists yet.
+            #expect(writer.console.isEmpty)
+            #expect(!FileManager.default.fileExists(
+                atPath: directory.appendingPathComponent(
+                    FileSessionAudit.diagnosticFilename).path))
 
-        writer.releaseOpen()
-        #expect(await evidence.close() == .complete)
+            writer.releaseOpen()
+            #expect(await evidence.close() == .complete)
 
-        #expect(writer.console.contains("parked-caller-diagnostic-0"))
-        #expect(writer.console.contains("parked-caller-diagnostic-31"))
-        let log = try debugLog(in: directory)
-        #expect(log.contains("parked-caller-diagnostic-0"))
-        #expect(log.contains("parked-caller-diagnostic-31"))
+            #expect(writer.console.contains("parked-caller-diagnostic-0"))
+            #expect(writer.console.contains("parked-caller-diagnostic-31"))
+            let log = try debugLog(in: directory)
+            #expect(log.contains("parked-caller-diagnostic-0"))
+            #expect(log.contains("parked-caller-diagnostic-31"))
+        }
     }
 
     /// The persisted artifact is unchanged by the move: same filename, owner-only mode, and one
@@ -110,29 +110,29 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: RecordingWriter()))
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        jlog("ordered-diagnostic-first")
-        jlog("ordered-diagnostic-second")
-        #expect(await evidence.close() == .complete)
+            jlog("ordered-diagnostic-first")
+            jlog("ordered-diagnostic-second")
+            #expect(await evidence.close() == .complete)
 
-        let url = directory.appendingPathComponent(FileSessionAudit.diagnosticFilename)
-        let lines = try debugLog(in: directory)
-            .split(separator: "\n", omittingEmptySubsequences: true)
-            .map(String.init)
-        #expect(lines.count == 2)
-        #expect(lines[0].hasSuffix("ordered-diagnostic-first"))
-        #expect(lines[1].hasSuffix("ordered-diagnostic-second"))
-        // "HH:mm:ss.SSS " — the millisecond stamp the agent-facing log has always carried.
-        #expect(lines[0].prefix(12).allSatisfy { $0.isNumber || $0 == ":" || $0 == "." })
-        #expect(String(lines[0].dropFirst(12).prefix(1)) == " ")
+            let url = directory.appendingPathComponent(FileSessionAudit.diagnosticFilename)
+            let lines = try debugLog(in: directory)
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init)
+            #expect(lines.count == 2)
+            #expect(lines[0].hasSuffix("ordered-diagnostic-first"))
+            #expect(lines[1].hasSuffix("ordered-diagnostic-second"))
+            // "HH:mm:ss.SSS " — the millisecond stamp the agent-facing log has always carried.
+            #expect(lines[0].prefix(12).allSatisfy { $0.isNumber || $0 == ":" || $0 == "." })
+            #expect(String(lines[0].dropFirst(12).prefix(1)) == " ")
 
-        let mode = try FileManager.default.attributesOfItem(
-            atPath: url.path)[.posixPermissions] as? NSNumber
-        #expect(mode?.int16Value == 0o600)
+            let mode = try FileManager.default.attributesOfItem(
+                atPath: url.path)[.posixPermissions] as? NSNumber
+            #expect(mode?.int16Value == 0o600)
+        }
     }
 
     /// A diagnostic emitted with no attachment reaches the asynchronous process log and stops
@@ -164,23 +164,23 @@ import Testing
         }
         let worker = SessionAuditWorker(limits: .production, writer: RecordingWriter())
         let sessionA = FileSessionAudit(directory: first, worker: worker)
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: sessionA)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: sessionA)
+            defer { JarvisLog.detach() }
 
-        jlog("belongs-to-session-a")
-        #expect(await sessionA.close() == .complete)
+            jlog("belongs-to-session-a")
+            #expect(await sessionA.close() == .complete)
 
-        // Session B exists and is live, but `JarvisLog` still points at the sealed handle A.
-        let sessionB = FileSessionAudit(directory: second, worker: worker)
-        jlog("emitted-after-a-was-sealed")
-        #expect(await sessionB.close() == .complete)
+            // Session B exists and is live, but `JarvisLog` still points at the sealed handle A.
+            let sessionB = FileSessionAudit(directory: second, worker: worker)
+            jlog("emitted-after-a-was-sealed")
+            #expect(await sessionB.close() == .complete)
 
-        let logA = try debugLog(in: first)
-        #expect(logA.contains("belongs-to-session-a"))
-        #expect(!logA.contains("emitted-after-a-was-sealed"))
-        #expect(!(try debugLog(in: second)).contains("emitted-after-a-was-sealed"))
+            let logA = try debugLog(in: first)
+            #expect(logA.contains("belongs-to-session-a"))
+            #expect(!logA.contains("emitted-after-a-was-sealed"))
+            #expect(!(try debugLog(in: second)).contains("emitted-after-a-was-sealed"))
+        }
     }
 
     /// Capacity loss is uniform and honest: the dropped line marks the session partial, and the
@@ -194,24 +194,24 @@ import Testing
             writer: writer)
         let evidence = FileSessionAudit(directory: directory, worker: worker)
         wait(for: writer.openEntered)
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        jlog("accepted-before-capacity")   // fills the second of two slots
-        jlog("dropped-at-capacity")
+            jlog("accepted-before-capacity")   // fills the second of two slots
+            jlog("dropped-at-capacity")
 
-        writer.releaseOpen()
-        await waitForDebugLine("accepted-before-capacity", in: directory)
-        jlog("accepted-after-capacity")
+            writer.releaseOpen()
+            await waitForDebugLine("accepted-before-capacity", in: directory)
+            jlog("accepted-after-capacity")
 
-        #expect(await evidence.close() == .partial)
-        let log = try debugLog(in: directory)
-        #expect(log.contains("accepted-before-capacity"))
-        #expect(!log.contains("dropped-at-capacity"))
-        #expect(log.contains("accepted-after-capacity"))
-        #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
+            #expect(await evidence.close() == .partial)
+            let log = try debugLog(in: directory)
+            #expect(log.contains("accepted-before-capacity"))
+            #expect(!log.contains("dropped-at-capacity"))
+            #expect(log.contains("accepted-after-capacity"))
+            #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
+        }
     }
 
     /// An oversize diagnostic is refused outright and marks the session partial; the next one is
@@ -224,19 +224,19 @@ import Testing
             worker: SessionAuditWorker(
                 limits: .init(maxEventCount: 8, maxRetainedBytes: 512),
                 writer: RecordingWriter()))
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        jlog(String(repeating: "o", count: 1_024))
-        jlog("small-after-oversize")
+            jlog(String(repeating: "o", count: 1_024))
+            jlog("small-after-oversize")
 
-        #expect(await evidence.close() == .partial)
-        let log = try debugLog(in: directory)
-        #expect(!log.contains(String(repeating: "o", count: 1_024)))
-        #expect(log.contains("small-after-oversize"))
-        #expect(try healthMarker(in: directory)["oversize_record"] as? Int == 1)
+            #expect(await evidence.close() == .partial)
+            let log = try debugLog(in: directory)
+            #expect(!log.contains(String(repeating: "o", count: 1_024)))
+            #expect(log.contains("small-after-oversize"))
+            #expect(try healthMarker(in: directory)["oversize_record"] as? Int == 1)
+        }
     }
 
     /// A failed debug-log write marks the session partial and leaves later diagnostics working —
@@ -248,21 +248,21 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: writer))
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        jlog("write-fails-for-this-line")
-        jlog("write-succeeds-for-this-line")
+            jlog("write-fails-for-this-line")
+            jlog("write-succeeds-for-this-line")
 
-        #expect(await evidence.close() == .partial)
-        let log = try debugLog(in: directory)
-        #expect(!log.contains("write-fails-for-this-line"))
-        #expect(log.contains("write-succeeds-for-this-line"))
-        // Console is ahead of the file on purpose, so a file failure still leaves the line visible.
-        #expect(writer.console.contains("write-fails-for-this-line"))
-        #expect(try healthMarker(in: directory)["write_failure"] as? Int == 1)
+            #expect(await evidence.close() == .partial)
+            let log = try debugLog(in: directory)
+            #expect(!log.contains("write-fails-for-this-line"))
+            #expect(log.contains("write-succeeds-for-this-line"))
+            // Console is ahead of the file on purpose, so a file failure still leaves the line visible.
+            #expect(writer.console.contains("write-fails-for-this-line"))
+            #expect(try healthMarker(in: directory)["write_failure"] as? Int == 1)
+        }
     }
 
     /// Diagnostics get no priority over audit records and grant none: a diagnostics-heavy session
@@ -277,28 +277,28 @@ import Testing
                 limits: .init(maxEventCount: 2, maxRetainedBytes: 65_536),
                 writer: writer))
         wait(for: writer.openEntered)
-        JarvisLogAttachmentLock.acquire()
-        defer { JarvisLogAttachmentLock.release() }
-        JarvisLog.attach(to: evidence)
-        defer { JarvisLog.detach() }
+        try await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: evidence)
+            defer { JarvisLog.detach() }
 
-        jlog("diagnostic-consuming-the-last-slot")
-        evidence.record(
-            tag: "audit-record-lost-to-a-diagnostics-flood",
-            request: Data(#"{"model":"gpt-5.5"}"#.utf8),
-            response: nil,
-            status: nil,
-            latencyMs: 1)
+            jlog("diagnostic-consuming-the-last-slot")
+            evidence.record(
+                tag: "audit-record-lost-to-a-diagnostics-flood",
+                request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+                response: nil,
+                status: nil,
+                latencyMs: 1)
 
-        writer.releaseOpen()
-        #expect(await evidence.close() == .partial)
-        let traffic = try String(
-            contentsOf: directory.appendingPathComponent(
-                FileSessionAudit.brainTrafficFilename),
-            encoding: .utf8)
-        #expect(!traffic.contains("audit-record-lost-to-a-diagnostics-flood"))
-        #expect(try debugLog(in: directory).contains("diagnostic-consuming-the-last-slot"))
-        #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
+            writer.releaseOpen()
+            #expect(await evidence.close() == .partial)
+            let traffic = try String(
+                contentsOf: directory.appendingPathComponent(
+                    FileSessionAudit.brainTrafficFilename),
+                encoding: .utf8)
+            #expect(!traffic.contains("audit-record-lost-to-a-diagnostics-flood"))
+            #expect(try debugLog(in: directory).contains("diagnostic-consuming-the-last-slot"))
+            #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
+        }
     }
 
     // MARK: - helpers

--- a/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Serializes every test — across suites — that installs a `JarvisLog.attach`/`detach`
+/// process-global attachment.
+///
+/// `JarvisLog`'s attachment is one process-global slot (`Sources/JarvisCore/Diagnostics/Log.swift`),
+/// and each suite that installs it — `DiagnosticEvidenceTests`, `CoachDriverPipelineTests`,
+/// `CaptureHeartbeatTests`, and `SessionAuditIsolationTests` (via `CoachingParityHarness`) — is
+/// individually `@Suite(.serialized)`. That only serializes cases *within* one suite; swift-testing
+/// still runs distinct suites concurrently by default, so two suites' tests could otherwise race to
+/// attach and silently mis-attribute each other's diagnostics — the cause of an intermittent
+/// `queue_overflow` miscount in `DiagnosticEvidenceTests`. Acquire this around every attach...detach
+/// span so concurrent suites serialize around the shared slot instead of racing for it.
+enum JarvisLogAttachmentLock {
+    private static let semaphore = DispatchSemaphore(value: 1)
+
+    static func acquire() { semaphore.wait() }
+    static func release() { semaphore.signal() }
+}

--- a/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
@@ -8,12 +8,48 @@ import Foundation
 /// `CaptureHeartbeatTests`, and `SessionAuditIsolationTests` (via `CoachingParityHarness`) — is
 /// individually `@Suite(.serialized)`. That only serializes cases *within* one suite; swift-testing
 /// still runs distinct suites concurrently by default, so two suites' tests could otherwise race to
-/// attach and silently mis-attribute each other's diagnostics — the cause of an intermittent
-/// `queue_overflow` miscount in `DiagnosticEvidenceTests`. Acquire this around every attach...detach
-/// span so concurrent suites serialize around the shared slot instead of racing for it.
-enum JarvisLogAttachmentLock {
-    private static let semaphore = DispatchSemaphore(value: 1)
+/// attach and silently mis-attribute each other's diagnostics.
+///
+/// An `actor` (suspending, not thread-blocking) rather than a `DispatchSemaphore`: a semaphore's
+/// `wait()` blocks the calling thread outright, and every call site here holds the lock across real
+/// `await` points (`evidence.close()`, `waitForDebugLine`, `CoachingParityHarness.run`'s own async
+/// work) — blocking a Swift Concurrency cooperative-pool thread for that long risks starving the
+/// whole pool on a CI runner with few cores, which does not grow the pool to compensate for a
+/// synchronously blocked thread the way GCD would.
+actor JarvisLogAttachmentLock {
+    static let shared = JarvisLogAttachmentLock()
 
-    static func acquire() { semaphore.wait() }
-    static func release() { semaphore.signal() }
+    private var isHeld = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    private func acquire() async {
+        if !isHeld {
+            isHeld = true
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    private func release() {
+        guard waiters.isEmpty else {
+            waiters.removeFirst().resume()
+            return
+        }
+        isHeld = false
+    }
+
+    /// Run `body` with exclusive ownership of the process-global attachment, releasing on every
+    /// path — including a thrown error — so a failed assertion can never leave the lock stuck for
+    /// the rest of the run.
+    static func withExclusiveAttachment<T>(_ body: () async throws -> T) async rethrows -> T {
+        await shared.acquire()
+        do {
+            let result = try await body()
+            await shared.release()
+            return result
+        } catch {
+            await shared.release()
+            throw error
+        }
+    }
 }

--- a/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
@@ -315,11 +315,11 @@ import Testing
                 limits: .init(maxEventCount: 256, maxRetainedBytes: 4_096),
                 writer: SessionAuditFileWriter()))
         await waitForHealthMarker(in: oversizeDirectory)
-        JarvisLogAttachmentLock.acquire()
-        JarvisLog.attach(to: oversize)
-        jlog(String(repeating: "d", count: 8_192))
-        JarvisLog.detach()
-        JarvisLogAttachmentLock.release()
+        await JarvisLogAttachmentLock.withExclusiveAttachment {
+            JarvisLog.attach(to: oversize)
+            jlog(String(repeating: "d", count: 8_192))
+            JarvisLog.detach()
+        }
         let oversizeSnapshot = await CoachingParityHarness.run(
             observers: .init(diagnostics: oversize))
         #expect(await oversize.close() == .partial)

--- a/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
@@ -6,7 +6,10 @@ import Testing
 @testable import JarvisCore
 
 // A few cases deliberately park the synchronous disk edge. Keep their gates serial so the parallel
-// repository test run never consumes several cooperative-pool threads on test-only blockers.
+// repository test run never consumes several cooperative-pool threads on test-only blockers. Cases
+// that install a `JarvisLog` attachment (via `CoachingParityHarness` or directly) also hold
+// `JarvisLogAttachmentLock`, since `.serialized` only covers cases within this one suite and the
+// attachment is one process-global slot shared with other suites.
 @Suite(.serialized) struct SessionAuditIsolationTests {
     /// Holds the worker in its first open while mailbox admission remains available.
     private final class BlockingOpenWriter: SessionAuditWriting, @unchecked Sendable {
@@ -312,9 +315,11 @@ import Testing
                 limits: .init(maxEventCount: 256, maxRetainedBytes: 4_096),
                 writer: SessionAuditFileWriter()))
         await waitForHealthMarker(in: oversizeDirectory)
+        JarvisLogAttachmentLock.acquire()
         JarvisLog.attach(to: oversize)
         jlog(String(repeating: "d", count: 8_192))
         JarvisLog.detach()
+        JarvisLogAttachmentLock.release()
         let oversizeSnapshot = await CoachingParityHarness.run(
             observers: .init(diagnostics: oversize))
         #expect(await oversize.close() == .partial)

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -2183,8 +2183,9 @@
 ### 2026-09-01 — A cross-suite lock protects JarvisLog's process-global test attachment
 
 - **Chose:** Add `JarvisLogAttachmentLock` (`Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift`),
-  a `DispatchSemaphore(value: 1)`-backed acquire/release pair, and hold it around every
-  `JarvisLog.attach`/`detach` span in `DiagnosticEvidenceTests`, `CoachDriverPipelineTests`,
+  an `actor`-based mutual-exclusion helper (`withExclusiveAttachment(_:)`, suspending rather than
+  thread-blocking, releasing on every path including a thrown error), and wrap every
+  `JarvisLog.attach`/`detach` span in it across `DiagnosticEvidenceTests`, `CoachDriverPipelineTests`,
   `CaptureHeartbeatTests`, `CoachingParityHarness` (shared by `SessionAuditIsolationTests`), and the
   one direct priming call in `SessionAuditIsolationTests` itself.
 - **Why:** CI hit a one-off failure in `DiagnosticEvidenceTests.aFullMailboxDropsOneDiagnosticAndKeepsAdmittingLaterOnes`
@@ -2200,11 +2201,16 @@
 - **Rejected:** (a) Making `JarvisLog.attach` itself block until any previous session detaches — it
   would change production semantics: a fresh Start's `attach()` is not guaranteed a prior `detach()`
   (Stop does not require one, since a sealed handle already refuses late events), so a real second
-  session would deadlock waiting for a `detach()` that never comes. The lock stays test-only. (b)
-  Disabling test parallelism repository-wide — only four files touch this one shared global; slowing
-  every test in the suite to fix a narrow, specific race is disproportionate. (c) Merging the four
-  affected suites into one — they test unrelated things; a shared acquire/release pair is the
-  narrower fix.
+  session would deadlock waiting for a `detach()` that never comes. The lock stays test-only. (b) A
+  `DispatchSemaphore`-backed lock, tried first — it thread-blocks the caller, and every call site
+  here holds the lock across real `await` points (`evidence.close()`, `waitForDebugLine`,
+  `CoachingParityHarness.run`'s own async work); blocking a Swift Concurrency cooperative-pool thread
+  for that long risks starving the whole pool on a CI runner with few cores, since the pool does not
+  grow to compensate the way GCD's would. Landed first, still failed in CI, and was replaced by the
+  actor. (c) Disabling test parallelism repository-wide — only four files touch this one shared
+  global; slowing every test in the suite to fix a narrow, specific race is disproportionate. (d)
+  Merging the four affected suites into one — they test unrelated things; a shared exclusivity helper
+  is the narrower fix.
 - **Detail:** `Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift`,
   `Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift`,
   `Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift`,

--- a/wiki/decisions.md
+++ b/wiki/decisions.md
@@ -2179,3 +2179,35 @@
   `scripts/build-vad.sh`, `scripts/vad/convert_silero.py`,
   `Sources/JarvisApp/Capture/SileroVoiceActivityDetector.swift`,
   `Sources/JarvisCore/Audio/SpeechEndpointDetector.swift`.
+
+### 2026-09-01 — A cross-suite lock protects JarvisLog's process-global test attachment
+
+- **Chose:** Add `JarvisLogAttachmentLock` (`Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift`),
+  a `DispatchSemaphore(value: 1)`-backed acquire/release pair, and hold it around every
+  `JarvisLog.attach`/`detach` span in `DiagnosticEvidenceTests`, `CoachDriverPipelineTests`,
+  `CaptureHeartbeatTests`, `CoachingParityHarness` (shared by `SessionAuditIsolationTests`), and the
+  one direct priming call in `SessionAuditIsolationTests` itself.
+- **Why:** CI hit a one-off failure in `DiagnosticEvidenceTests.aFullMailboxDropsOneDiagnosticAndKeepsAdmittingLaterOnes`
+  (`healthMarker(in:)["queue_overflow"]` not 1) that never reproduced locally or on an immediate CI
+  rerun of the same commit — the signature of a race, not a logic bug. `JarvisLog`'s attachment
+  (`Sources/JarvisCore/Diagnostics/Log.swift`) is one process-global slot guarded only for memory
+  safety (an `NSLock` around the pointer swap), not for the logical invariant that exactly one test's
+  session is attached at a time. Every suite that installs it is already `@Suite(.serialized)`, but
+  that only serializes cases *within* one suite — swift-testing still runs distinct suites
+  concurrently by default (`scripts/run-tests.sh` runs plain `swift test`, no `--no-parallel`), so a
+  test in one suite could attach between another suite's test's own attach and its assertions,
+  silently repointing `jlog` traffic to the wrong session and corrupting its overflow count.
+- **Rejected:** (a) Making `JarvisLog.attach` itself block until any previous session detaches — it
+  would change production semantics: a fresh Start's `attach()` is not guaranteed a prior `detach()`
+  (Stop does not require one, since a sealed handle already refuses late events), so a real second
+  session would deadlock waiting for a `detach()` that never comes. The lock stays test-only. (b)
+  Disabling test parallelism repository-wide — only four files touch this one shared global; slowing
+  every test in the suite to fix a narrow, specific race is disproportionate. (c) Merging the four
+  affected suites into one — they test unrelated things; a shared acquire/release pair is the
+  narrower fix.
+- **Detail:** `Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift`,
+  `Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift`,
+  `Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift`,
+  `Tests/JarvisCoreTests/Diagnostics/CaptureHeartbeatTests.swift`,
+  `Tests/JarvisCoreTests/Diagnostics/CoachingParityHarness.swift`,
+  `Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift`.


### PR DESCRIPTION
## Summary

- `DiagnosticEvidenceTests.aFullMailboxDropsOneDiagnosticAndKeepsAdmittingLaterOnes` flaked once in
  CI (`healthMarker(in:)["queue_overflow"]` came back wrong) and passed cleanly both locally and on
  an immediate CI rerun of the exact same commit — the signature of a race, not a logic bug.
- Root cause: `JarvisLog`'s attachment (`Sources/JarvisCore/Diagnostics/Log.swift`) is one
  process-global slot. Every suite that installs it for a test (`DiagnosticEvidenceTests`,
  `CoachDriverPipelineTests`, `CaptureHeartbeatTests`, `SessionAuditIsolationTests` via
  `CoachingParityHarness`) is already `@Suite(.serialized)`, but that only serializes cases *within*
  one suite. swift-testing still runs distinct suites concurrently by default, so a test in one suite
  could attach its own session in the narrow window between another suite's test attaching and
  reading its assertions back — silently repointing `jlog` traffic to the wrong session and
  corrupting its counters.
- Fix: `JarvisLogAttachmentLock` (`Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift`),
  a semaphore-backed acquire/release pair held around every `JarvisLog.attach`/`detach` span across
  all four affected files, so concurrent suites serialize around the shared slot instead of racing
  for it.
- **Test-only fix** — `Sources/JarvisCore/Diagnostics/Log.swift` (production `JarvisLog`) is
  unchanged. Making `attach` itself block until a prior session detaches was considered and rejected:
  production Stop does not guarantee a `detach()` call (a sealed handle already refuses late events),
  so a real second session's `attach()` at the next Start could deadlock waiting for a `detach()`
  that never comes.
- Logged in `wiki/decisions.md` (2026-09-01 entry) with the rejected alternatives (blocking
  production `attach`, disabling test parallelism repo-wide, merging the four suites into one).

## Test plan

- `swift build && ./scripts/run-tests.sh` — 872 tests, 102 suites, all passing (run 4x locally to
  check for regressions/new flakiness; all green).
- `./scripts/check-ghost-mode.sh` — passed (no production presentation code touched).
- Note: the original failure only reproduced once in CI and never locally, so this PR can't
  definitively prove the race is gone — only that the identified synchronization gap is closed and
  the fix doesn't regress anything. Worth watching CI on this branch and #242/#243 for a few more
  runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic and coaching test reliability by preventing concurrent log attachments from interfering with one another.
  * Ensured log evidence is consistently captured and cleaned up, including when test operations encounter errors.
  * Reduced test execution delays caused by contention during shared log access.

* **Documentation**
  * Documented cross-suite log attachment synchronization behavior, limitations, and safe handling across asynchronous test operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->