### PR TITLE
fix(capture): make LocalTurnDetector Sendable so the build is warning-free

### DIFF
--- a/Sources/JarvisApp/Capture/LocalTurnDetector.swift
+++ b/Sources/JarvisApp/Capture/LocalTurnDetector.swift
@@ -13,7 +13,12 @@ import JarvisCore
 /// **Never call `speechEvents` from a Core Audio IOProc.** Silero runs a Core ML prediction, which
 /// allocates and takes locks, so it belongs on the serial queue that delivers audio rather than the
 /// realtime callback. Confine one instance per stream to that queue; it is not thread-safe.
-final class LocalTurnDetector {
+///
+/// `@unchecked Sendable` covers only that hand-off: a capture builds the detector on its own thread
+/// and then passes the reference to its serial delivery queue, which is the sole caller from then on.
+/// It is not a claim that the three pieces of stream state tolerate concurrent access, so never
+/// call into an instance from a second queue.
+final class LocalTurnDetector: @unchecked Sendable {
     private let resampler: Resampler
     private let voiceActivityDetector: SileroVoiceActivityDetector
     private var endpointDetector: SpeechEndpointDetector

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -68,7 +68,7 @@ import Foundation
 
     @Test func closingTheHandlePersistsEveryPreviouslyRecordedEvent() async throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
-        let (log, evidence) = ActivityLog.recordingSession(in: dir)
+        let (_, evidence) = ActivityLog.recordingSession(in: dir)
 
         evidence.record(.sessionEnded(reason: .stoppedByUser))
         _ = await evidence.close()
@@ -139,7 +139,7 @@ import Foundation
 
     @Test func eventFormattingKeepsDiagnosticDetailsOut() async throws {
         let dir = Self.tmp(); defer { try? FileManager.default.removeItem(at: dir) }
-        let (log, evidence) = ActivityLog.recordingSession(in: dir)
+        let (_, evidence) = ActivityLog.recordingSession(in: dir)
         evidence.record(.heard(speaker: .them, text: "How would you optimize it?"))
         _ = await evidence.close()
 


### PR DESCRIPTION
## What

Clears every compiler warning from the build. `swift build`, `swift build -c release`, and the test targets are now all warning-free.

### 1. Three `SendableClosureCaptures` warnings (`LocalTurnDetector`)

Introduced by #238. Both capture paths hand a `LocalTurnDetector` to their serial delivery queue, but the type was never marked `Sendable`:

- `SystemAudioBenchmarkCapture.swift:191` — `deliveryQueue.async { [turnDetector] in ... }`
- `AggregateEchoCapture.swift:308,309` — `deliveryQueue.async { [micTurnDetector, systemTurnDetector] in ... }`

The confinement contract was already documented on both sides, and `AggregateEchoCapture` already asserted the detectors are "confined to that queue, which is what `@unchecked Sendable` is covering for them". Only the conformance was missing. Added it with a justification scoped to the hand-off, matching how `AggregateEchoCapture`, `SystemAudioBenchmarkCapture`, `RealtimeContinuityReporter`, and the other confined audio types in this target are annotated.

Deliberately **not** a claim that the detector is thread-safe. It holds three pieces of stream state (resampler filter history, Silero LSTM state, endpoint counters) that still tolerate exactly one caller.

### 2. Two `no-usage` warnings (`ActivityLogTests`)

`let (log, evidence) = ...` where only `evidence` is used. Bound to `_`.

## Not fixed here

`ld: warning: search path '/usr/local/lib' is not a directory` is environmental, not a repo issue. On the affected machine `/usr/local/lib` is a *file* (a stray copy of Homebrew's `libaacs.0.dylib`) where clang expects a directory, so it reproduces with a bare `clang hello.c`. Nothing to change in this repo.

## Test plan

- [x] `swift build` — 0 warnings
- [x] `swift build -c release` — 0 warnings
- [x] `./scripts/run-tests.sh` — 872 tests in 102 suites passed, 0 warnings
- [x] `./scripts/build-app.sh release` — signs and validates

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtfGmekCxHhvmG43znvefp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal concurrency handling for local voice turn detection without changing its behavior.

* **Tests**
  * Updated diagnostic activity log tests to correctly handle unused results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->