### PR TITLE
test(diagnostics): stop transport tests from attaching the process-global jlog sink

### DIFF
--- a/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/DiagnosticEvidenceTests.swift
@@ -9,10 +9,14 @@ import Testing
 /// byte-starved mailbox, an injected write failure, an explicit session rotation. None asserts on
 /// elapsed wall-clock time.
 ///
-/// Serialized because several cases park the worker's serial queue, and because `JarvisLog`'s
-/// attachment is process-global — the latter also needs `JarvisLogAttachmentLock` for exclusivity
-/// against the *other* suites that install the same attachment, since `.serialized` only covers
-/// cases within this one suite.
+/// Serialized because several cases park the worker's serial queue.
+///
+/// Only the two cases whose claim is `jlog`'s own routing install the process-global `JarvisLog`
+/// attachment, under `JarvisLogAttachmentLock` so no other attaching suite can re-point it. Every
+/// transport-contract case admits diagnostics through `FileSessionAudit.recordDiagnostic` directly
+/// instead: with the attachment installed, any `jlog` from a concurrently running suite lands in
+/// the same mailbox, and the exact-count cases below then flaked in CI (#239). The lock cannot
+/// prevent that, since the emitting suites never take it.
 @Suite(.serialized) struct DiagnosticEvidenceTests {
     /// Records what reached the Console edge and can park the worker on demand.
     private final class RecordingWriter: SessionAuditWriting, @unchecked Sendable {
@@ -110,29 +114,25 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: RecordingWriter()))
-        try await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: evidence)
-            defer { JarvisLog.detach() }
 
-            jlog("ordered-diagnostic-first")
-            jlog("ordered-diagnostic-second")
-            #expect(await evidence.close() == .complete)
+        admit("ordered-diagnostic-first", into: evidence)
+        admit("ordered-diagnostic-second", into: evidence)
+        #expect(await evidence.close() == .complete)
 
-            let url = directory.appendingPathComponent(FileSessionAudit.diagnosticFilename)
-            let lines = try debugLog(in: directory)
-                .split(separator: "\n", omittingEmptySubsequences: true)
-                .map(String.init)
-            #expect(lines.count == 2)
-            #expect(lines[0].hasSuffix("ordered-diagnostic-first"))
-            #expect(lines[1].hasSuffix("ordered-diagnostic-second"))
-            // "HH:mm:ss.SSS " — the millisecond stamp the agent-facing log has always carried.
-            #expect(lines[0].prefix(12).allSatisfy { $0.isNumber || $0 == ":" || $0 == "." })
-            #expect(String(lines[0].dropFirst(12).prefix(1)) == " ")
+        let url = directory.appendingPathComponent(FileSessionAudit.diagnosticFilename)
+        let lines = try debugLog(in: directory)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init)
+        #expect(lines.count == 2)
+        #expect(lines[0].hasSuffix("ordered-diagnostic-first"))
+        #expect(lines[1].hasSuffix("ordered-diagnostic-second"))
+        // "HH:mm:ss.SSS " — the millisecond stamp the agent-facing log has always carried.
+        #expect(lines[0].prefix(12).allSatisfy { $0.isNumber || $0 == ":" || $0 == "." })
+        #expect(String(lines[0].dropFirst(12).prefix(1)) == " ")
 
-            let mode = try FileManager.default.attributesOfItem(
-                atPath: url.path)[.posixPermissions] as? NSNumber
-            #expect(mode?.int16Value == 0o600)
-        }
+        let mode = try FileManager.default.attributesOfItem(
+            atPath: url.path)[.posixPermissions] as? NSNumber
+        #expect(mode?.int16Value == 0o600)
     }
 
     /// A diagnostic emitted with no attachment reaches the asynchronous process log and stops
@@ -194,24 +194,20 @@ import Testing
             writer: writer)
         let evidence = FileSessionAudit(directory: directory, worker: worker)
         wait(for: writer.openEntered)
-        try await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: evidence)
-            defer { JarvisLog.detach() }
 
-            jlog("accepted-before-capacity")   // fills the second of two slots
-            jlog("dropped-at-capacity")
+        admit("accepted-before-capacity", into: evidence)   // fills the second of two slots
+        admit("dropped-at-capacity", into: evidence)
 
-            writer.releaseOpen()
-            await waitForDebugLine("accepted-before-capacity", in: directory)
-            jlog("accepted-after-capacity")
+        writer.releaseOpen()
+        await waitForDebugLine("accepted-before-capacity", in: directory)
+        admit("accepted-after-capacity", into: evidence)
 
-            #expect(await evidence.close() == .partial)
-            let log = try debugLog(in: directory)
-            #expect(log.contains("accepted-before-capacity"))
-            #expect(!log.contains("dropped-at-capacity"))
-            #expect(log.contains("accepted-after-capacity"))
-            #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
-        }
+        #expect(await evidence.close() == .partial)
+        let log = try debugLog(in: directory)
+        #expect(log.contains("accepted-before-capacity"))
+        #expect(!log.contains("dropped-at-capacity"))
+        #expect(log.contains("accepted-after-capacity"))
+        #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
     }
 
     /// An oversize diagnostic is refused outright and marks the session partial; the next one is
@@ -224,19 +220,15 @@ import Testing
             worker: SessionAuditWorker(
                 limits: .init(maxEventCount: 8, maxRetainedBytes: 512),
                 writer: RecordingWriter()))
-        try await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: evidence)
-            defer { JarvisLog.detach() }
 
-            jlog(String(repeating: "o", count: 1_024))
-            jlog("small-after-oversize")
+        admit(String(repeating: "o", count: 1_024), into: evidence)
+        admit("small-after-oversize", into: evidence)
 
-            #expect(await evidence.close() == .partial)
-            let log = try debugLog(in: directory)
-            #expect(!log.contains(String(repeating: "o", count: 1_024)))
-            #expect(log.contains("small-after-oversize"))
-            #expect(try healthMarker(in: directory)["oversize_record"] as? Int == 1)
-        }
+        #expect(await evidence.close() == .partial)
+        let log = try debugLog(in: directory)
+        #expect(!log.contains(String(repeating: "o", count: 1_024)))
+        #expect(log.contains("small-after-oversize"))
+        #expect(try healthMarker(in: directory)["oversize_record"] as? Int == 1)
     }
 
     /// A failed debug-log write marks the session partial and leaves later diagnostics working —
@@ -248,21 +240,17 @@ import Testing
         let evidence = FileSessionAudit(
             directory: directory,
             worker: SessionAuditWorker(limits: .production, writer: writer))
-        try await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: evidence)
-            defer { JarvisLog.detach() }
 
-            jlog("write-fails-for-this-line")
-            jlog("write-succeeds-for-this-line")
+        admit("write-fails-for-this-line", into: evidence)
+        admit("write-succeeds-for-this-line", into: evidence)
 
-            #expect(await evidence.close() == .partial)
-            let log = try debugLog(in: directory)
-            #expect(!log.contains("write-fails-for-this-line"))
-            #expect(log.contains("write-succeeds-for-this-line"))
-            // Console is ahead of the file on purpose, so a file failure still leaves the line visible.
-            #expect(writer.console.contains("write-fails-for-this-line"))
-            #expect(try healthMarker(in: directory)["write_failure"] as? Int == 1)
-        }
+        #expect(await evidence.close() == .partial)
+        let log = try debugLog(in: directory)
+        #expect(!log.contains("write-fails-for-this-line"))
+        #expect(log.contains("write-succeeds-for-this-line"))
+        // Console is ahead of the file on purpose, so a file failure still leaves the line visible.
+        #expect(writer.console.contains("write-fails-for-this-line"))
+        #expect(try healthMarker(in: directory)["write_failure"] as? Int == 1)
     }
 
     /// Diagnostics get no priority over audit records and grant none: a diagnostics-heavy session
@@ -277,31 +265,33 @@ import Testing
                 limits: .init(maxEventCount: 2, maxRetainedBytes: 65_536),
                 writer: writer))
         wait(for: writer.openEntered)
-        try await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: evidence)
-            defer { JarvisLog.detach() }
 
-            jlog("diagnostic-consuming-the-last-slot")
-            evidence.record(
-                tag: "audit-record-lost-to-a-diagnostics-flood",
-                request: Data(#"{"model":"gpt-5.5"}"#.utf8),
-                response: nil,
-                status: nil,
-                latencyMs: 1)
+        admit("diagnostic-consuming-the-last-slot", into: evidence)
+        evidence.record(
+            tag: "audit-record-lost-to-a-diagnostics-flood",
+            request: Data(#"{"model":"gpt-5.5"}"#.utf8),
+            response: nil,
+            status: nil,
+            latencyMs: 1)
 
-            writer.releaseOpen()
-            #expect(await evidence.close() == .partial)
-            let traffic = try String(
-                contentsOf: directory.appendingPathComponent(
-                    FileSessionAudit.brainTrafficFilename),
-                encoding: .utf8)
-            #expect(!traffic.contains("audit-record-lost-to-a-diagnostics-flood"))
-            #expect(try debugLog(in: directory).contains("diagnostic-consuming-the-last-slot"))
-            #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
-        }
+        writer.releaseOpen()
+        #expect(await evidence.close() == .partial)
+        let traffic = try String(
+            contentsOf: directory.appendingPathComponent(
+                FileSessionAudit.brainTrafficFilename),
+            encoding: .utf8)
+        #expect(!traffic.contains("audit-record-lost-to-a-diagnostics-flood"))
+        #expect(try debugLog(in: directory).contains("diagnostic-consuming-the-last-slot"))
+        #expect(try healthMarker(in: directory)["queue_overflow"] as? Int == 1)
     }
 
     // MARK: - helpers
+
+    /// The admission `JarvisLog.emit` performs for an attached session, made on the handle itself
+    /// so the process-global attachment stays untouched.
+    private func admit(_ message: String, into evidence: FileSessionAudit) {
+        _ = evidence.recordDiagnostic(DiagnosticAuditEvent(message: message))
+    }
 
     private func debugLog(in directory: URL) throws -> String {
         let url = directory.appendingPathComponent(FileSessionAudit.diagnosticFilename)

--- a/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/JarvisLogAttachmentLock.swift
@@ -10,6 +10,12 @@ import Foundation
 /// still runs distinct suites concurrently by default, so two suites' tests could otherwise race to
 /// attach and silently mis-attribute each other's diagnostics.
 ///
+/// The lock covers attaching only. It cannot stop the other suites from *emitting*: while an
+/// attachment is installed, every `jlog` anywhere in the process lands in the attached session, and
+/// the emitting suites never take this lock. So attach only for a claim about `jlog`'s routing, and
+/// only with presence/absence assertions. A test that asserts an exact count or a tiny mailbox must
+/// admit through `FileSessionAudit.recordDiagnostic` directly instead (#239).
+///
 /// An `actor` (suspending, not thread-blocking) rather than a `DispatchSemaphore`: a semaphore's
 /// `wait()` blocks the calling thread outright, and every call site here holds the lock across real
 /// `await` points (`evidence.close()`, `waitForDebugLine`, `CoachingParityHarness.run`'s own async

--- a/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/SessionAuditIsolationTests.swift
@@ -7,9 +7,10 @@ import Testing
 
 // A few cases deliberately park the synchronous disk edge. Keep their gates serial so the parallel
 // repository test run never consumes several cooperative-pool threads on test-only blockers. Cases
-// that install a `JarvisLog` attachment (via `CoachingParityHarness` or directly) also hold
+// that install a `JarvisLog` attachment (via `CoachingParityHarness`) also hold
 // `JarvisLogAttachmentLock`, since `.serialized` only covers cases within this one suite and the
-// attachment is one process-global slot shared with other suites.
+// attachment is one process-global slot shared with other suites. The oversize variant is primed
+// through the handle directly rather than through `jlog`, so no other suite's lines can share it.
 @Suite(.serialized) struct SessionAuditIsolationTests {
     /// Holds the worker in its first open while mailbox admission remains available.
     private final class BlockingOpenWriter: SessionAuditWriting, @unchecked Sendable {
@@ -315,11 +316,8 @@ import Testing
                 limits: .init(maxEventCount: 256, maxRetainedBytes: 4_096),
                 writer: SessionAuditFileWriter()))
         await waitForHealthMarker(in: oversizeDirectory)
-        await JarvisLogAttachmentLock.withExclusiveAttachment {
-            JarvisLog.attach(to: oversize)
-            jlog(String(repeating: "d", count: 8_192))
-            JarvisLog.detach()
-        }
+        _ = oversize.recordDiagnostic(
+            DiagnosticAuditEvent(message: String(repeating: "d", count: 8_192)))
         let oversizeSnapshot = await CoachingParityHarness.run(
             observers: .init(diagnostics: oversize))
         #expect(await oversize.close() == .partial)

--- a/wiki/session-audit.md
+++ b/wiki/session-audit.md
@@ -101,6 +101,13 @@ is attached, `jlog` lines are that session's; with no attachment, or once the at
 sealed, they reach the asynchronous process log only. A diagnostic is never guessed into whichever
 session happens to be newest — a mis-attributed diagnostic is worse evidence than a missing one.
 
+The attachment is one process-global slot, and the test suite runs concurrently in one process. A
+test of the transport's capacity or loss accounting therefore admits diagnostics through the session
+handle (`FileSessionAudit.recordDiagnostic`, the call `jlog` itself makes for an attached session)
+rather than attaching it, since any `jlog` from another suite would otherwise share the mailbox under
+assertion. Only a claim about `jlog`'s routing attaches, one suite at a time, and asserts presence or
+absence rather than counts.
+
 ## Privacy and Verification
 
 Evidence stays in the owner-only session directory under the existing retention policy. Request


### PR DESCRIPTION
## Root cause

`DiagnosticEvidenceTests.aFullMailboxDropsOneDiagnosticAndKeepsAdmittingLaterOnes` failed 15 times in CI over the last ten days (15 of the 19 logged test-step failures), always on the exact `queue_overflow == 1` count and sometimes also on a missing `accepted-after-capacity` line, and passed on every same-SHA rerun.

`JarvisLog.emit` (`Sources/JarvisCore/Diagnostics/Log.swift`) routes every `jlog` in the process to whichever `FileSessionAudit` is attached. SwiftPM runs all test targets in one process with suites in parallel, and production code has 191 `jlog` call sites. While this test held a 2-slot mailbox under `JarvisLog.attach`, any `jlog` from a concurrently running suite took a slot or added a second overflow. The CI logs show it directly:

- Run 33495086738: `ScreenCaptureRunner`'s "transient JPEG deletion failed" line (from `ScreenCaptureRunnerTests`, a different target) lands in the same millisecond as the test's own `dropped-at-capacity`.
- Run 33406910472: a coaching suite's `🗣 heard (me): "usable" (test)` and `… coaching turn waiting for transcription to settle` appear inside the test's own `jarvis-debug.log`, occupying its two slots.

#244's `JarvisLogAttachmentLock` serializes the four suites that *attach*. It cannot stop the other ~870 tests from *emitting*, since they never take it. The failure recurred an hour after #244 merged, on a branch head 14 commits ahead of it, and reproduces locally on `main` (4 of 8 full runs under CPU saturation).

## Fix

Test-side only, no production change, no serialization, no weakened assertion (per #133 and #217):

- The transport-contract cases in `DiagnosticEvidenceTests` (mailbox capacity, oversize refusal, write failure, uniform loss, persisted format) admit diagnostics through `FileSessionAudit.recordDiagnostic`, the exact call `JarvisLog.emit` makes for an attached session, and never touch the global attachment. Foreign `jlog` traffic then goes to the process log, not into the mailbox under assertion.
- Only the two cases whose claim is `jlog`'s own routing still attach, under the lock, with presence/absence assertions.
- `SessionAuditIsolationTests`' oversize priming does the same.
- `JarvisLogAttachmentLock`'s doc and `wiki/session-audit.md` (Attribution) record the rule. `wiki/decisions.md` is left untouched because #246 deletes it.

## Verification

| | `aFullMailbox…` family |
|---|---|
| `main`, 8 full Gate runs under 8-process CPU saturation | 4 / 8 failed |
| this branch, 16 full Gate runs under the same load + 5 runs of the four attaching suites | 0 / 21 failed |

Full Gate (`swift build && ./scripts/run-tests.sh`) passes.

## Not in this PR

Two separate wall-clock flakes showed up in the CI history and under saturation, each with its own cause and none involving the sink: `CLIBrainRuntimeTests.codexReplacesAPrewarmedThreadForAnotherTargetConfiguration` (2× CI, request counts exactly doubled), `TranscriptionSettlementGateTests.interruptionResumesARegisteredWaitWithoutChangingProviderState` (1× CI, 200 ms `completesBeforeTimeout`), and locally under 8-process saturation only, `CoachDriverPipelineTests.historyCompactsIntoSummaryPastThreshold` (3 of 16 runs; compaction is a `Task.detached(priority: .utility)` that can starve before the test's 22 scripted turns finish). Candidates for #217.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172QCV6KJVrf8tAYeXh5wmh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified diagnostic recording and attachment behavior for concurrent test execution.
  * Documented when to use routing assertions versus direct audit recording.

* **Tests**
  * Improved deterministic coverage for diagnostic ordering, capacity limits, oversized entries, write failures, and audit contention.
  * Reduced interference between tests that use process-wide diagnostic attachments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->