### PR TITLE
fix(brain): stop a codex prewarm from trading evictions with an attempt's open

### DIFF
--- a/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -104,6 +104,12 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         deadline: Date,
         opening: Bool
     ) async throws {
+        // Order requests by arrival, before the server-launch suspension. Two prewarms can both
+        // park here waiting for the launch and resume in either order; taking the sequence after
+        // that await would let the later arrival receive the lower number and be treated as older,
+        // so the newer target's thread would be evicted for a stale one.
+        latestThreadRequest += 1
+        let request = latestThreadRequest
         let preparedServer = try await prepareServer(
             for: configuration,
             deadline: deadline)
@@ -111,7 +117,8 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
             for: configuration,
             server: preparedServer,
             deadline: deadline,
-            opening: opening)
+            opening: opening,
+            request: request)
     }
 
     private func prepareServer(
@@ -178,10 +185,9 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         for configuration: LocalAgentConversationConfiguration,
         server: CodexAppServer,
         deadline: Date,
-        opening: Bool
+        opening: Bool,
+        request: Int
     ) async throws {
-        latestThreadRequest += 1
-        let request = latestThreadRequest
         while true {
             guard activeThreadID == nil else { return }
             let mayReplace = opening

--- a/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -210,6 +210,13 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
                 continue
             }
 
+            // Reaching here means no thread to adopt and none we may replace. A prewarm that is no
+            // longer the newest request, or that arrived while an attempt is opening, defers here
+            // too — this is the window, most likely of all in production, where both callers were
+            // still awaiting the server launch and neither a prepared nor a preparing thread exists
+            // yet. Starting one anyway would hand the opening attempt a stale thread to unsubscribe.
+            if !mayReplace { return }
+
             let staleThread = preparedThread
             preparedThread = nil
             let cleanupRequestID = staleThread.map { _ in takeRequestID() }

--- a/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
+++ b/Sources/JarvisBrainProviders/LocalAgent/Codex/CodexAppServerRuntime.swift
@@ -55,6 +55,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
 
     private struct ThreadPreparation: Sendable {
         let id: UUID
+        let configuration: LocalAgentConversationConfiguration
         let task: Task<PreparedThread, Error>
     }
 
@@ -73,6 +74,10 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
     private var preparingServer: ServerPreparation?
     private var preparedThread: PreparedThread?
     private var preparingThread: ThreadPreparation?
+    /// Ordering for `prepareThread`'s replacement rule: the newest thread request, and how many
+    /// attempts are opening a conversation right now.
+    private var latestThreadRequest = 0
+    private var openingConversations = 0
     private var nextRequestID = 0
     private var activeThreadID: String?
 
@@ -84,15 +89,20 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         self.supportedFeatures = supportedFeatures
     }
 
+    /// Opportunistic warm-up: prepares a thread for `configuration` unless an attempt is opening a
+    /// conversation or a newer request wants another configuration, in which case it leaves the
+    /// thread to them and returns.
     func prepare(for configuration: LocalAgentConversationConfiguration) async throws {
         try await prepare(
             for: configuration,
-            deadline: Date().addingTimeInterval(configuration.timeout))
+            deadline: Date().addingTimeInterval(configuration.timeout),
+            opening: false)
     }
 
     private func prepare(
         for configuration: LocalAgentConversationConfiguration,
-        deadline: Date
+        deadline: Date,
+        opening: Bool
     ) async throws {
         let preparedServer = try await prepareServer(
             for: configuration,
@@ -100,7 +110,8 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         try await prepareThread(
             for: configuration,
             server: preparedServer,
-            deadline: deadline)
+            deadline: deadline,
+            opening: opening)
     }
 
     private func prepareServer(
@@ -156,18 +167,31 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         }
     }
 
+    /// `opening` marks an attempt's open, which must end with a thread for its own configuration
+    /// and so may always replace one prepared for another. A prewarm may replace one only while it
+    /// is the newest request and no attempt is opening; otherwise it returns and leaves the thread
+    /// to whoever asked for it. Without that rule a prewarm and an open could trade evictions: each
+    /// resumed from a preparation the other had already installed, each finding the other's thread
+    /// stale, one thread/unsubscribe plus thread/start per round until the open happened to be
+    /// resumed first. CI saw it as request counts exactly doubled.
     private func prepareThread(
         for configuration: LocalAgentConversationConfiguration,
         server: CodexAppServer,
-        deadline: Date
+        deadline: Date,
+        opening: Bool
     ) async throws {
+        latestThreadRequest += 1
+        let request = latestThreadRequest
         while true {
             guard activeThreadID == nil else { return }
-            if let preparedThread, preparedThread.configuration == configuration {
-                return
+            let mayReplace = opening
+                || (request == latestThreadRequest && openingConversations == 0)
+            if let preparedThread {
+                if preparedThread.configuration == configuration || !mayReplace { return }
             }
 
             if let preparation = preparingThread {
+                if preparation.configuration != configuration && !mayReplace { return }
                 do {
                     let thread = try await awaitThreadPreparation(preparation)
                     // Background prewarm and the first attempt may await the same task. Only the
@@ -193,6 +217,7 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
             let supportedFeatures = self.supportedFeatures
             preparingThread = ThreadPreparation(
                 id: UUID(),
+                configuration: configuration,
                 task: Task.detached(priority: .utility) {
                     if let staleThread, let cleanupRequestID {
                         try await Self.unsubscribe(
@@ -216,7 +241,9 @@ actor CodexAppServerRuntime: LocalAgentRuntimeBackend {
         deadline: Date
     )
         async throws -> any LocalAgentConversation {
-        try await prepare(for: configuration, deadline: deadline)
+        openingConversations += 1
+        defer { openingConversations -= 1 }
+        try await prepare(for: configuration, deadline: deadline, opening: true)
         guard let server, server.isRunning else {
             throw Self.error("Codex app-server was not ready")
         }

--- a/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainRuntimeTests.swift
+++ b/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainRuntimeTests.swift
@@ -318,6 +318,102 @@ import JarvisCore
         runtime.terminateNow()
     }
 
+    /// A prewarm resumed after an attempt has installed its own thread must leave that thread
+    /// alone. It used to treat the attempt's thread as stale and replace it, the attempt then
+    /// replaced the prewarm's, and so on, one thread/unsubscribe plus thread/start per round,
+    /// until the attempt happened to be resumed first. The open runs at background priority and
+    /// the prewarm at utility, so the prewarm wins every resume race: exactly the order that
+    /// traded evictions.
+    @Test func aPrewarmDoesNotReplaceTheThreadAnAttemptIsOpening() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let trace = directory.appendingPathComponent("trace")
+        let gate = directory.appendingPathComponent("thread-start-gate")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(
+                trace: trace,
+                threadResult: Self.ephemeralThreadResult,
+                threadStartGate: gate))
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let attempt = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: false,
+            systemPrompt: "attempt coach prompt")
+        let leased = directory.appendingPathComponent("leased")
+        let opening = Task.detached(priority: .background) {
+            let conversation = try await attempt.makeConversation()
+            try Data().write(to: leased)
+            return conversation
+        }
+        // The attempt's thread/start is in the trace, and the fake will not answer it until the
+        // gate exists: the open is parked on its own preparation.
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+
+        let prewarming = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: true)
+        _ = prewarming
+        // Let the prewarm reach the parked preparation. Nothing observable marks that moment; a
+        // prewarm that only arrives after the gate opens finds the leased thread and returns, so a
+        // late one makes this case pass vacuously rather than fail.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        try Data().write(to: gate)
+
+        // Poll for the lease rather than awaiting the task: awaiting would escalate the open to
+        // this task's priority and hand it the resume race the case exists to lose.
+        try await waitForFile(leased)
+        let conversation = try await opening.value
+        #expect(requests(method: "thread/start", in: trace).count == 1)
+        #expect(requests(method: "thread/unsubscribe", in: trace).isEmpty)
+        await conversation.finish()
+        runtime.terminateNow()
+    }
+
+    /// A newer prewarm for another configuration still replaces an idle prepared thread, so a
+    /// route replacement or topology edit keeps its head start: the attempt that follows leases
+    /// the replacement's thread instead of starting one.
+    @Test func aNewerPrewarmReplacesAnIdleThreadPreparedForAnotherConfiguration() async throws {
+        let directory = try makeWorkDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let trace = directory.appendingPathComponent("trace")
+        let executable = try makeExecutable(
+            in: directory,
+            named: "fake-codex",
+            script: codexScript(trace: trace, threadResult: Self.ephemeralThreadResult))
+        let runtime = makeRuntime(provider: .codexCLI, directory: directory)
+        let firstTarget = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: true)
+        _ = firstTarget
+        try await waitForRequestCount(1, method: "thread/start", in: trace)
+
+        let replacementTarget = makeClient(
+            provider: .codexCLI,
+            executable: executable,
+            directory: directory,
+            runtime: runtime,
+            prewarm: true,
+            systemPrompt: "replacement coach prompt")
+        try await waitForRequestCount(2, method: "thread/start", in: trace)
+
+        let replacement = try await replacementTarget.makeConversation()
+        #expect(requests(method: "thread/start", in: trace).count == 2)
+        #expect(requests(method: "thread/unsubscribe", in: trace).count == 1)
+        await replacement.finish()
+        runtime.terminateNow()
+    }
+
     @Test func releasingPreparedCodexRuntimeStopsItsSessionProcess() async throws {
         let directory = try makeWorkDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -871,12 +967,14 @@ import JarvisCore
         #"{"thread":{"id":"thread-1","ephemeral":true,"path":null},"instructionSources":[]}"#
 
     /// A fake `codex app-server` that records its argv and every request it is sent, then answers
-    /// with a single `stay_silent` agent message.
+    /// with a single `stay_silent` agent message. With `threadStartGate` set, no `thread/start` is
+    /// answered until that file exists, which parks whoever is preparing a thread.
     private func codexScript(
         argumentsFile: URL? = nil,
         pidFile: URL? = nil,
         trace: URL,
         threadResult: String,
+        threadStartGate: URL? = nil,
         execReply: String? = nil,
         execItemType: String = "agent_message",
         execUsage: String = "{}"
@@ -886,6 +984,9 @@ import JarvisCore
         } ?? ""
         let recordPID = pidFile.map {
             "printf '%s\\n' \"$$\" > '\(shellQuoted($0.path))'\n"
+        } ?? ""
+        let threadStartGateWait = threadStartGate.map {
+            "while [ ! -e '\(shellQuoted($0.path))' ]; do sleep 0.01; done"
         } ?? ""
         // `codex exec --json` is a different program shape from the app-server: one shot, JSONL
         // events on stdout, and the reply written to the --output-last-message path.
@@ -914,6 +1015,7 @@ import JarvisCore
                   printf '{"id":%s,"result":{}}\\n' "$request_id"
                   ;;
                 thread/start)
+                  \(threadStartGateWait)
                   printf '{"id":%s,"result":%s}\\n' "$request_id" '\(shellQuoted(threadResult))'
                   ;;
                 thread/unsubscribe)

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -502,8 +502,9 @@ provider-route policy, and traffic recording are unchanged — only the transpor
   attempt leases that verified thread; each later attempt opens a fresh one and closes it when the
   lease ends. Coach and summarizer can share one runtime because model, prompt, and effort travel per
   `thread/start`, not in the launch identity. A changed target configuration replaces any unused
-  prepared thread before opening its own, and releasing the session or route runtime terminates the
-  app-server and every prepared, active, or preparing thread.
+  prepared thread before opening its own; a prewarm defers to an attempt that is opening and to
+  any newer request, so two callers never trade evictions. Releasing the session or route runtime
+  terminates the app-server and every prepared, active, or preparing thread.
   The isolation goal is to exclude user/project customization, constrain side effects, and reject
   provider-native actions outside Jarvis's coaching contract; the concrete launch and per-thread
   settings live in


### PR DESCRIPTION
## Root cause

`CLIBrainRuntimeTests.codexReplacesAPrewarmedThreadForAnotherTargetConfiguration` failed twice in CI ([33402791859](https://github.com/JINGBANZ/jarvis/actions/runs/33402791859), [32742346309](https://github.com/JINGBANZ/jarvis/actions/runs/32742346309)) with request counts exactly doubled: `thread/start` 4 instead of 2, `thread/unsubscribe` 3 instead of 1. Both logs show the runtime printing four "Codex target thread ready" lines instead of two. That's a production race, not a slow runner.

`CodexAppServerRuntime.prepareThread` is a loop on an actor, so a background prewarm and an attempt's `openConversation` can await the same `ThreadPreparation`. Whichever waiter is resumed first installs the thread; the other finds `preparingThread` changed, `continue`s, and, seeing a prepared thread for a *different* configuration, evicts it and starts its own. A superseded prewarm therefore replaced the attempt's thread, the attempt replaced the prewarm's, and so on, one `thread/unsubscribe` plus `thread/start` per round until the attempt happened to be resumed first. On a loaded 3-core runner the utility-priority prewarm wins that race often; on an idle Mac almost never, which is why it only showed in CI.

## Fix

One rule in `prepareThread`, no change to lease, deadline, or cancellation behavior:

- An attempt's open may always replace a thread prepared for another configuration (it must end with its own).
- A prewarm may replace one only while it is the newest thread request and no attempt is opening; otherwise it returns and leaves the thread to whoever asked for it.
- A newer prewarm still replaces an idle thread prepared for another configuration, so a route replacement (`CoachDriver` prewarming `activeReplacement`) or a topology edit keeps the head start the wiki's prewarm A/B measured.

`ThreadPreparation` now carries its configuration, and the runtime tracks the newest request and the number of opens in flight. `wiki/architecture.md`'s app-server paragraph records the rule.

## Tests

- `aPrewarmDoesNotReplaceTheThreadAnAttemptIsOpening` forces the losing order deterministically: the open runs at `.background` priority parked behind a gated `thread/start` in the fake codex, the prewarm runs at `.utility`, and the lease is observed by polling a marker file (awaiting the task would escalate its priority and hand it the race). **Old runtime: failed 3/3** with 3 starts and 2 unsubscribes. **New runtime: passes 3/3.**
- `aNewerPrewarmReplacesAnIdleThreadPreparedForAnotherConfiguration` pins the behavior the fix must keep.
- The existing `codexReplaces…` and `codexPrewarms…` cases pass 3/3.

Gate: `swift build && ./scripts/run-tests.sh` passes, 879 tests in 103 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172QCV6KJVrf8tAYeXh5wmh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation startup reliability when multiple requests arrive simultaneously.
  * Prevented background prewarming from replacing threads that are actively opening or prepared for newer requests.
  * Deferred stale prewarming when no suitable thread is available.
  * Ensured prepared and active conversation threads are released when the session ends.

* **Documentation**
  * Updated architecture guidance for thread prewarming and cleanup.

* **Tests**
  * Added coverage for concurrent preparation, replacement behavior, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->