### PR TITLE
feat(coach): scope prep-notes search queries to the current sub-topic

### DIFF
--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -70,7 +70,9 @@ extension JarvisPrompts {
         # Prep material
         If a live question resembles a topic in the user's prepared notes, call search_prep_notes once
         before speaking on that topic, then let the result inform — not replace — your own reasoning.
-        Skip it when the question does not resemble anything they would have prepared.
+        Query with the specific detail being discussed right now, not the overall problem name — a
+        broad query can match the wrong section of their notes. Skip it when the question does not
+        resemble anything they would have prepared.
         """
 
         enum ToolDescription {


### PR DESCRIPTION
## Summary

Phase 1 of #247 (system-design coaching alignment brainstorm) — the small, independent piece.

The `# Prep material` addendum (`JarvisPrompts.Coach.prepMaterialAddendum`) told the model *when*
to call `search_prep_notes` but never *how* to phrase the query. Left to its own judgment, the model
can query with the overall problem name instead of the specific detail currently being discussed,
which can match the wrong section of the user's prepared notes — feeding an off-topic result into
the coaching tip (part of the "tip doesn't align with what I'm discussing" complaint that started
#247).

One paragraph of instruction added: query with the specific detail being discussed right now, not
the overall problem name. No code changes, no new state — matches the codebase's existing pattern
of guidance living in the addendum text (checked: no tool in `ToolDefs.swift` uses per-parameter
JSON-schema descriptions, so this follows the established convention rather than adding a new one).

## Test plan

- `swift build && ./scripts/run-tests.sh` — 872 tests, 102 suites, all passing.
- `./scripts/check-ghost-mode.sh` — passed.
- No existing test references this exact prompt string, so nothing needed updating.
- This is prompt-text-only; verifying it actually improves real coaching sessions needs live usage,
  not something the test suite can confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved coaching responses by making prep-material searches more closely match the specific detail being discussed.
  * Reduced irrelevant searches when a question does not relate to the available prep material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->