### PR TITLE
refactor(coach): assemble the coaching system prompt in one builder

### DIFF
--- a/Sources/JarvisApp/App/BrainComposition.swift
+++ b/Sources/JarvisApp/App/BrainComposition.swift
@@ -73,9 +73,9 @@ final class BrainComposition {
     /// by the App before the first `makeConfiguredRoute` call) and reused by every later hot
     /// reapply — `applyBrainPreferencesToRunningSession` never re-reads `preferences.interviewFormat`
     /// live, so a Settings edit mid-session cannot retroactively change a value that was meant to be
-    /// fixed for the whole session. Baked into the CLI system prompt identically to what
-    /// `CoachAttemptRunner` computes per turn — `CLIBrainClient` asserts its instructions never
-    /// change after construction, so the two must never drift.
+    /// fixed for the whole session. Baked into the CLI system prompt through the same
+    /// `JarvisPrompts.Coach.system(prepMaterial:formatAddendum:)` builder `CoachAttemptRunner`
+    /// calls per turn.
     var interviewFormatAddendum = ""
 
     /// The two clients that move together with one provider/model route target.
@@ -141,8 +141,12 @@ final class BrainComposition {
                                        workDirectory: sessionDir,
                                        timeout: BrainWorkloadTimeout.liveCoaching,
                                        traffic: host.liveSessionEvidence, trafficTag: "coach",
-                                       systemPrompt: JarvisPrompts.Coach.system
-                                           + interviewFormatAddendum,
+                                       // No prep material: it is indexed off the Start path and
+                                       // installed on the driver later, so a prompt fixed at
+                                       // construction cannot describe it.
+                                       systemPrompt: JarvisPrompts.Coach.system(
+                                           prepMaterial: false,
+                                           formatAddendum: interviewFormatAddendum),
                                        tools: coachTools,
                                        toolChoice: .required,
                                        runtime: runtimes.coach,

--- a/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
+++ b/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
@@ -210,11 +210,11 @@ final class CoachAttemptRunner: @unchecked Sendable {
             return AttemptExecution(id: attemptID, result: .skipped(.skippedFillerOnly))
         }
         // Describing search_prep_notes when it isn't actually offered invites the model to call a
-        // tool it doesn't have — and that call is a hard attempt failure (below), so this must track
-        // the real tool set exactly, not just hint at it.
-        let systemPrompt = (attempt.prepMaterial != nil
-            ? JarvisPrompts.Coach.system + JarvisPrompts.Coach.prepMaterialAddendum
-            : JarvisPrompts.Coach.system) + interviewFormatAddendum
+        // tool it doesn't have — and that call is a hard attempt failure (below), so `prepMaterial`
+        // must track the real tool set (`tools`, below) exactly, not just hint at it.
+        let systemPrompt = JarvisPrompts.Coach.system(
+            prepMaterial: attempt.prepMaterial != nil,
+            formatAddendum: interviewFormatAddendum)
         let historyBase: [ChatMessage] = [.system(systemPrompt)] + history.snapshot()
 
         if reason == .manualHint && !work.manualHintPrepared {

--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -62,10 +62,26 @@ extension JarvisPrompts {
         accuracy outranks brevity.
         """
 
-        /// Appended to `system` only for a session where `search_prep_notes` is actually offered
-        /// (see `CoachAttemptRunner.runAttempt`) — describing a tool the model doesn't have invites
-        /// exactly the hallucinated call the tool-loop guard turns into a hard attempt failure.
-        static let prepMaterialAddendum = """
+        /// The complete coaching system prompt. Every site that sends one assembles it here, so the
+        /// per-turn prompt `CoachAttemptRunner` builds and the one `BrainComposition` bakes into a
+        /// CLI provider's persistent process at Start cannot drift. `CLIBrainClient` asserts its
+        /// instructions never change after construction, so drift would fail every CLI turn.
+        ///
+        /// - `prepMaterial`: whether `search_prep_notes` is actually in this prompt's tool set (see
+        ///   `prepMaterialAddendum`).
+        /// - `formatAddendum`: the interview-format guidance, resolved to a `String` once at Start
+        ///   rather than passed as an `InterviewFormat?`. That is deliberate, not something to
+        ///   clean up: `promptAddendum` reads its bundled file on every access and this builder
+        ///   runs per coaching turn, so the pre-resolved string keeps that a single file read
+        ///   instead of one per turn.
+        public static func system(prepMaterial: Bool, formatAddendum: String) -> String {
+            (prepMaterial ? system + prepMaterialAddendum : system) + formatAddendum
+        }
+
+        /// Appended by `system(prepMaterial:formatAddendum:)` only when `search_prep_notes` is
+        /// actually offered: describing a tool the model doesn't have invites exactly the
+        /// hallucinated call the tool-loop guard turns into a hard attempt failure.
+        private static let prepMaterialAddendum = """
 
         # Prep material
         If a live question resembles a topic in the user's prepared notes, call search_prep_notes once

--- a/Tests/JarvisCoreTests/Coach/CoachSystemPromptTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachSystemPromptTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import JarvisCore
+
+/// The one builder every assembly site calls: `CoachAttemptRunner` per turn, and `BrainComposition`
+/// once at Start for a CLI provider whose instructions are fixed after construction.
+@Suite struct CoachSystemPromptTests {
+    @Test func bareBuilderIsTheBasePrompt() {
+        #expect(JarvisPrompts.Coach.system(prepMaterial: false, formatAddendum: "")
+            == JarvisPrompts.Coach.system)
+    }
+
+    @Test func prepMaterialGuidanceIsDescribedOnlyWhenOffered() {
+        let offered = JarvisPrompts.Coach.system(prepMaterial: true, formatAddendum: "")
+        let withheld = JarvisPrompts.Coach.system(prepMaterial: false, formatAddendum: "")
+        #expect(offered.hasPrefix(JarvisPrompts.Coach.system))
+        #expect(offered.contains("search_prep_notes"))
+        #expect(!withheld.contains("search_prep_notes"))
+    }
+
+    /// Base prompt, then prep guidance, then format guidance: the layout every site sends.
+    @Test func formatAddendumIsAppendedLast() {
+        let format = "\n\n# Interview format\nSystem design."
+        let prompt = JarvisPrompts.Coach.system(prepMaterial: true, formatAddendum: format)
+        #expect(prompt.hasSuffix(format))
+        guard let prep = prompt.range(of: "search_prep_notes"),
+              let formatRange = prompt.range(of: "# Interview format") else {
+            Issue.record("expected both the prep and format sections in the prompt")
+            return
+        }
+        #expect(prep.lowerBound < formatRange.lowerBound)
+    }
+}

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -468,7 +468,14 @@ rather than a per-turn screenshot.
   so the resolved addendum must be computed once (`BrainComposition.interviewFormatAddendum`, set
   before every route construction or reapply, including a live provider hot-switch) and reused
   identically by both the per-turn OpenAI-style prompt (`CoachAttemptRunner`) and the CLI-provider
-  construction (`BrainComposition`).
+  construction (`BrainComposition`). Both sites assemble the prompt through one builder,
+  `JarvisPrompts.Coach.system(prepMaterial:formatAddendum:)` in `JarvisCore`, so the two cannot
+  drift. The builder takes the addendum as an already-resolved string rather than an
+  `InterviewFormat?` because `promptAddendum` reads its bundled file on every access and the
+  per-turn site would otherwise read it on every coaching turn. The CLI site passes
+  `prepMaterial: false`: prep material is indexed off the Start path and installed later, so its
+  `search_prep_notes` guidance cannot be baked into a process whose instructions are fixed at
+  construction.
 - **Transcription has its own provider, model, and language settings.** OpenAI remains the provider
   default and `gpt-4o-transcribe` remains its model default; `gpt-transcribe` and
   `gpt-live-transcribe` are opt-in comparison choices. All use the GA Realtime API, but keep their


### PR DESCRIPTION
## Summary

Closes #253. Builds on #252, which has merged; this branch is rebased onto `main`.

- `JarvisPrompts.Coach.system(prepMaterial:formatAddendum:)` is the one builder for the coaching system prompt. `CoachAttemptRunner` calls it per turn with the real tool-set state. `BrainComposition` calls it once at Start for a CLI provider with `prepMaterial: false`, and the call site says why: prep material is indexed off the Start path and installed on the driver later, so a prompt fixed at construction cannot describe it.
- `prepMaterialAddendum` is now `private`, so the builder is the only assembly point, and the comments that asked readers to keep the two sites in sync by hand are gone.
- The format addendum stays a pre-resolved `String`. The builder's doc comment says why, so it does not read as something to clean up: `promptAddendum` reads its bundled file on every access and the builder runs per coaching turn.
- `wiki/architecture.md` points the interview-format paragraph at the builder.

No behavior change: the assembled prompt is byte-identical at both sites, base prompt, then prep guidance when offered, then format guidance.

## Observation, out of scope

With a CLI target and prep material configured, `CoachAttemptRunner` already sends `system + prepMaterialAddendum` plus `searchPrepNotesTool`, while `CLIBrainClient` was constructed with the bare prompt and `coachTools`. `CLIBrainClient.respond` re-composes its instructions from the system messages and tools on every call and throws `local-agent instructions changed after runtime initialization` on any mismatch, so that combination looks like it fails every CLI turn today. The issue asks for no behavior change, so this PR leaves it as is. Worth its own issue if a live check confirms it.

## Test plan

- `swift build && ./scripts/run-tests.sh` on the rebased tree: 896 tests in 106 suites, all passing, all five guard scripts passing.
- New `CoachSystemPromptTests` (3 tests): the bare builder equals the base prompt, prep guidance is present only when offered, and the format addendum is appended last. Written first and failed to compile before the builder existed.
- Existing `CoachDriverPrepMaterialTests` and `CoachDriverInterviewFormatTests` cover the runner site end to end. The App site has no unit test; it belongs to the live smoke checklist, which was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ken8PKzjRsfnTjkNStwRgr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized coach prompt construction across supported coaching experiences.
  * Coach sessions now apply interview-format guidance consistently.
  * Preparation guidance is included only when relevant to the session.

* **Documentation**
  * Updated architecture documentation to describe shared coach prompt behavior and session setup.

* **Tests**
  * Added coverage for prompt content, optional preparation guidance, and instruction ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->