### PR TITLE
feat(coach): give question meaning before strategy when the user hasn't engaged

### DIFF
--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -45,15 +45,26 @@ extension JarvisPrompts {
         4. "me" is making steady progress: call stay_silent.
         5. Progress is unclear, especially after silence: call capture_screen unless a fresh result is already
            available. Then speak only if the user seems stuck; otherwise call stay_silent.
-        6. "me" is stuck: call speak with the next concrete step. Build on earlier tips instead of repeating
-           them.
+        6. "me" is stuck: call speak, following the Tip style guidance below. Build on earlier tips
+           instead of repeating them.
 
         A fresh capture result satisfies the screen gate for that request. Use it; do not capture again for
         the same request.
 
         # Tip style
         Lead with the most useful point. Be brief, concrete, encouraging, and easy to read and
-        understand under pressure. Prefer one pointed question or next step.
+        understand under pressure.
+
+        If "me" has not yet engaged with an approach — no attempt visible in the code, speech, or
+        notes — lead with orientation, not a step. If the question itself is long or dense, spend
+        the first tip entirely on its meaning: what is given, what the output is, and what each rule
+        or case decides — as if paraphrasing it to someone who has not read the prompt. Say nothing
+        yet about how to detect, parse, or scan for those cases; that is strategy, not meaning, and
+        belongs in a later tip. A misread question makes any strategy worthless, and the overlay is
+        too short to do both at once. Once "me" has that restatement (from an earlier tip or their own
+        words), the next tip can name one viable overall strategy. A "next step" means nothing without
+        a plan to hang it on. Once an approach is underway, prefer one pointed question or next step
+        that builds on it.
         Give a full solution only when "me" explicitly asks for it.
 
         Name things with the words already in front of "me" — on the captured screen, or in what


### PR DESCRIPTION
## Summary
- When "me" hasn't engaged with an approach yet (nothing in code/speech/notes), the coach's stuck-tip previously jumped straight to a next step or strategy, even for long/dense questions the user likely hadn't fully parsed yet.
- The first tip in that situation now spends its entire overlay budget restating the question's *meaning* in plain terms (what's given, what the output is, what each rule/case decides) — explicitly deferring detection/parsing strategy to a later tip, since the overlay is too short to do both and a misread question makes any strategy worthless.
- Iterated live against a real problem (a template-string formatter with nested plural blocks): the coach's tips moved from pure algorithm/parsing detail ("track brace depth...", "advance `i` past the matched expression...") toward explaining what the constructs mean before how to detect them.

## Test plan
- [x] `swift build` — clean
- [x] `./scripts/run-tests.sh` — 881 tests / 103 suites passed
- [x] Manually verified live in `Jarvis Dev` against a real coding-interview question, iterating on the prompt wording across several rebuild/relaunch cycles until the first stuck-tip led with plain-language meaning rather than parsing strategy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved coaching responses when users are stuck by encouraging spoken guidance in the recommended style.
  - Added clearer guidance for handling questions without an active approach.
  - Improved explanations for complex questions by prioritizing meaning before strategy.
  - Ensured responses provide a strategy before suggesting the next step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->