### PR TITLE
feat(coach): sequence core entities before API design in the system-design skill

### DIFF
--- a/Sources/JarvisCore/Resources/Skills/system-design.md
+++ b/Sources/JarvisCore/Resources/Skills/system-design.md
@@ -1,9 +1,14 @@
 # Interview format: system design
 
-This is a system-design interview. The discussion typically moves through: clarifying
-functional requirements, non-functional requirements (scale, latency, consistency), API
-design, data model, high-level architecture, then a deep dive into specific components
-and their trade-offs — but the candidate may revisit an earlier stage at any point. Infer
-which stage the candidate is currently addressing from what they just said, and keep your
-tip scoped to that stage — a data-model tip is unhelpful while they are still defining the
-API contract, and vice versa.
+This is a system-design interview. The discussion moves through six stages: functional
+requirements (what the system does, for whom), non-functional requirements (scale, latency,
+availability, consistency, durability), core entities, API design, high-level architecture,
+and finally a deep dive into whichever component the non-functional requirements make
+hardest, ending on trade-offs — but the candidate may revisit an earlier stage at any point.
+Name core entities before the API: an interface is easiest to define in terms of objects
+that already have names, not vague fields.
+
+Infer which stage the candidate is currently addressing from what they just said or what's
+on screen, and keep your tip scoped to that stage — a caching tip is unhelpful while they
+are still naming entities, and a repeated requirements question once requirements are
+already named on the screen is stale.


### PR DESCRIPTION
## Summary
- Reorders the system-design interview-format skill's stage list so **core entities** come before **API design** — an interface is easiest to define in terms of objects that already have names, not vague fields.
- Expands the non-functional-requirements callout to name availability and durability alongside scale/latency/consistency.
- Rescopes the "stale tip" example to entities so it still matches the new stage order.

## Context
This corrects a mistake from an earlier session where the same reordering was drafted directly into the base coach system prompt (`JarvisPrompts+Coach.swift`), duplicating the interview-format skill architecture that had just landed in #252 as `Sources/JarvisCore/Resources/Skills/system-design.md`. That work has been discarded; this PR makes the fix in the correct place — the skill markdown, loaded only when "System Design" is selected as the interview format.

## Test plan
- [x] `swift build` — clean
- [x] `./scripts/run-tests.sh` — 890 tests / 105 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated system design interview guidance to follow a fixed sequence of six stages.
  * Clarified that core entities should be identified before API design.
  * Refined examples for applying tips according to the current interview stage.
  * Added a concluding focus on trade-offs after the deep dive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->