### PR TITLE
feat(coach): add behavioral interview skill

### DIFF
--- a/Sources/JarvisCore/Config/InterviewFormat.swift
+++ b/Sources/JarvisCore/Config/InterviewFormat.swift
@@ -22,10 +22,9 @@ public enum InterviewFormat: String, CaseIterable, Codable, Sendable {
     }
 
     /// Loaded from `Resources/Skills/<rawValue>.md` — a real Markdown file, not a Swift string
-    /// literal, so a skill's content reads and edits like prose. Only `system-design.md` exists
-    /// today: `.coding` and `.behavioral` are already reported as working well, so they stay empty
-    /// rather than getting new prompt guidance nobody asked for. Missing file → empty, not a crash —
-    /// an unwritten skill is a normal state, not an error.
+    /// literal, so a skill's content reads and edits like prose. Coding has no authored override;
+    /// Behavioral and System Design do. Missing file → empty, not a crash — an unwritten skill is
+    /// a normal state, not an error.
     public var promptAddendum: String {
         guard let url = Self.skillMarkdownURL(named: rawValue),
               let body = try? String(contentsOf: url, encoding: .utf8)

--- a/Sources/JarvisCore/Resources/Skills/behavioral.md
+++ b/Sources/JarvisCore/Resources/Skills/behavioral.md
@@ -12,15 +12,17 @@ could match the candidate's stories, company values, leadership principles, role
 behavioral requirements, search once before speaking. Use returned personal facts as the candidate's
 real story and returned criteria as the standard the answer should demonstrate.
 
-When a prep-note result says no personal story matches, or when the candidate says they cannot recall
-a story, asks for an example, or remains stuck without personal facts, construct a plausible
-mini-story using your own judgment. Label its first line “Illustrative example” so it cannot be
-mistaken for the candidate's history, then give a concrete situation/task, candidate-owned action,
-and result or lesson across at most three short lines. Shape it to any prepared company values,
-leadership principles, role expectations, or behavioral requirements. When the candidate supplied
-partial facts, instead turn only those facts into a coherent sample framing; do not invent personal
-details, outcomes, or metrics. Otherwise, a useful opening hint gives the story choice or angle, the
-candidate-owned action, and the result or lesson to land rather than explaining STAR abstractly.
+After prep search, distinguish excerpts containing candidate-owned events from excerpts containing
+criteria alone; company principles or role requirements are not a personal story. When no returned
+excerpt contains a personal story, or when the candidate says they cannot recall one, asks for an
+example, or remains stuck without personal facts, construct a plausible mini-story using your own
+judgment. Label its first line “Illustrative example” so it cannot be mistaken for the candidate's
+history, then give a concrete situation/task, candidate-owned action, and result or lesson across at
+most three short lines. Shape it to any prepared company values, leadership principles, role
+expectations, or behavioral requirements. When the candidate supplied partial facts, instead turn
+only those facts into a coherent sample framing; do not invent personal details, outcomes, or
+metrics. Otherwise, a useful opening hint gives the story choice or angle, the candidate-owned
+action, and the result or lesson to land rather than explaining STAR abstractly.
 
 As the candidate answers, infer the current STAR stage from the newest speech. Continue listening
 and call `speak` when one specific improvement would materially strengthen the answer: missing

--- a/Sources/JarvisCore/Resources/Skills/behavioral.md
+++ b/Sources/JarvisCore/Resources/Skills/behavioral.md
@@ -1,0 +1,31 @@
+# Interview format: behavioral
+
+This is a behavioral interview. Organize each answer as STAR: the Situation gives only the context
+needed to understand the stakes; the Task names the candidate's responsibility or goal; the Action
+shows the candidate's specific choices, reasoning, and influence; the Result gives the outcome and
+what the candidate learned. Treat STAR as an answer shape, not words the candidate must recite.
+
+A complete new question from the interviewer is itself a useful moment to coach: call `speak` with
+a compact answer direction before the candidate starts. Choose the story or example that best
+demonstrates the behavior the question tests. When `search_prep_notes` is available and the question
+could match the candidate's stories, company values, leadership principles, role expectations, or
+behavioral requirements, search once before speaking. Use returned personal facts as the candidate's
+real story and returned criteria as the standard the answer should demonstrate.
+
+When a prep-note result says no personal story matches, or when the candidate says they cannot recall
+a story, asks for an example, or remains stuck without personal facts, construct a plausible
+mini-story using your own judgment. Label its first line “Illustrative example” so it cannot be
+mistaken for the candidate's history, then give a concrete situation/task, candidate-owned action,
+and result or lesson across at most three short lines. Shape it to any prepared company values,
+leadership principles, role expectations, or behavioral requirements. When the candidate supplied
+partial facts, instead turn only those facts into a coherent sample framing; do not invent personal
+details, outcomes, or metrics. Otherwise, a useful opening hint gives the story choice or angle, the
+candidate-owned action, and the result or lesson to land rather than explaining STAR abstractly.
+
+As the candidate answers, infer the current STAR stage from the newest speech. Continue listening
+and call `speak` when one specific improvement would materially strengthen the answer: missing
+ownership, vague action, absent result, weak evidence, or misalignment with prepared company or role
+criteria. Stay on that gap and preserve the candidate's story. Call `stay_silent` when the answer is
+already concrete, candidate-owned, complete, and aligned. All four STAR parts, a specific action,
+and a concrete result are sufficient: do not speak merely to request extra detail, another metric,
+or a possible refinement. Do not praise or summarize the answer.

--- a/Tests/JarvisCoreTests/Coach/CoachDriverInterviewFormatTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverInterviewFormatTests.swift
@@ -50,15 +50,18 @@ import Testing
         })
     }
 
-    @Test func systemPromptOmitsFormatGuidanceForBehavioral() async {
+    @Test func systemPromptIncludesBehavioralGuidanceWhenExplicitlySelected() async {
         let brain = ScriptedBrain(script: staySilentScript())
         let (driver, transcript) = makeDriver(brain: brain, interviewFormat: .behavioral)
         transcript.append(.init(speaker: .me, text: "let me think out loud", at: 100))
 
         _ = await driver.handleTrigger(.turnEnd)
 
-        #expect(!brain.calls[0].contains {
-            $0.role == .system && ($0.text ?? "").contains("Interview format")
+        #expect(brain.calls[0].contains {
+            $0.role == .system
+                && ($0.text ?? "").hasPrefix(JarvisPrompts.Coach.system)
+                && ($0.text ?? "").contains("# Interview format: behavioral")
+                && ($0.text ?? "").contains("STAR")
         })
     }
 

--- a/Tests/JarvisCoreTests/Config/InterviewFormatTests.swift
+++ b/Tests/JarvisCoreTests/Config/InterviewFormatTests.swift
@@ -8,11 +8,13 @@ import Testing
         #expect(InterviewFormat.behavioral.displayName == "Behavioral")
     }
 
-    /// Coding and behavioral are already reported as working well, so they stay empty rather than
-    /// getting new prompt guidance nobody asked for — system design is the one reported problem.
-    @Test func onlySystemDesignHasContentToday() {
+    /// Missing skills remain a normal empty state, while each authored format becomes available
+    /// through the same resource lookup the Settings picker consumes.
+    @Test func authoredFormatsHaveExpectedContent() {
         #expect(InterviewFormat.coding.promptAddendum.isEmpty)
-        #expect(InterviewFormat.behavioral.promptAddendum.isEmpty)
+        #expect(InterviewFormat.behavioral.promptAddendum.contains(
+            "# Interview format: behavioral"))
+        #expect(InterviewFormat.behavioral.promptAddendum.contains("STAR"))
         #expect(!InterviewFormat.systemDesign.promptAddendum.isEmpty)
         #expect(InterviewFormat.systemDesign.promptAddendum.contains("functional requirements"))
         #expect(InterviewFormat.systemDesign.promptAddendum.contains("API"))

--- a/Tests/JarvisCoreTests/Config/InterviewFormatTests.swift
+++ b/Tests/JarvisCoreTests/Config/InterviewFormatTests.swift
@@ -15,6 +15,8 @@ import Testing
         #expect(InterviewFormat.behavioral.promptAddendum.contains(
             "# Interview format: behavioral"))
         #expect(InterviewFormat.behavioral.promptAddendum.contains("STAR"))
+        #expect(InterviewFormat.behavioral.promptAddendum.contains(
+            "candidate-owned events"))
         #expect(!InterviewFormat.systemDesign.promptAddendum.isEmpty)
         #expect(InterviewFormat.systemDesign.promptAddendum.contains("functional requirements"))
         #expect(InterviewFormat.systemDesign.promptAddendum.contains("API"))

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -431,13 +431,18 @@ rather than a per-turn screenshot.
   single-writer lock turns one slow turn into minutes of `conversation_locked` silence. Requests are sent `store:true`
   so they stay inspectable in the OpenAI dashboard for debugging — the retention tradeoff is
   documented in [sandbox.md](./sandbox.md).
-- **Interview format supplies optional coaching-prompt vocabulary (`InterviewFormat` in
+- **Interview format supplies optional specialist coaching (`InterviewFormat` in
   `Sources/JarvisCore/Config/`).** A Start-time picker (**None**, plus one entry per format that actually has
-  content — System Design today) adds a format-specific addendum to the coach system prompt — today, only System Design has real
-  content, added because the coach otherwise has zero system-design vocabulary (functional
-  requirements, API design, data model, etc.) and its tips can drift from whatever stage of that
-  discussion the candidate is actually in; Coding and Behavioral stay empty because no one has
-  reported a problem with them, not because the mechanism can't hold their content too. Each format's
+  content — Behavioral and System Design today) adds a format-specific addendum to the coach system
+  prompt. System Design supplies stage vocabulary so tips stay with the part of the design under
+  discussion. Behavioral treats a complete interviewer question as a useful proactive coaching
+  moment, shapes answers with STAR, and follows the newest answer stage to surface only material
+  gaps. When prep search is available it grounds the answer in the candidate's stories and uses
+  company values, leadership principles, role expectations, or behavioral requirements as answer
+  criteria. Without a matching personal story, it may supply a clearly labeled illustrative
+  mini-story; partial candidate facts may be organized but never embellished with invented personal
+  details, outcomes, or metrics. Coding stays empty because no specialist policy has been requested,
+  not because the mechanism cannot hold its content too. Each format's
   content is a real Markdown file (`Sources/JarvisCore/Resources/Skills/<rawValue>.md`), not a Swift
   string literal, so it reads and edits like prose; a missing file resolves to an empty addendum
   rather than an error, since an unwritten skill is a normal state. `InterviewFormat`'s private
@@ -782,11 +787,10 @@ Enforcement-first, not convention. See [sandbox.md](./sandbox.md) for the full m
 
 ## 6. Non-Goals (v1)
 
-- A tiered sensitivity dial, or genuinely separate coaching modes with different action-policy
-  gating, tool sets, or proactivity behavior. (One technical-interview coaching approach spans
-  behavioral, system-design, and coding questions; an optional Start-time interview-format selection
-  only supplies additional prompt *vocabulary* for the selected format — see [§ Models and
-  APIs](#models-and-apis) — never a different mode of operation.)
+- A tiered sensitivity dial, or code-level coaching modes with separate trigger gates, tool sets, or
+  runtime state. One harness spans behavioral, system-design, and coding questions; an optional
+  Start-time interview-format selection specializes the model's coaching policy inside that shared
+  loop — see [§ Models and APIs](#models-and-apis) — rather than creating another mode of operation.
 - Continuous OCR or recording the screen/audio to disk ("recall").
 - A dedicated wake-word engine. Direct address is just the word "Jarvis" (or a question) appearing
   in the transcript, which the brain reads and answers — there is no wake-word detector. (A global

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -214,8 +214,8 @@ per-thread `model_reasoning_effort`; both CLI scales start at `low`, so None cla
 three shared levels pass through.
 
 **Interview format.** A second Coaching-card picker (`InterviewFormat`: **None**, plus one entry per
-format that actually has content — System Design today) supplies additional coaching-prompt
-vocabulary for the selected format. **None** persists as no selection and resolves to no addendum at
+format that actually has content — Behavioral and System Design today) supplies specialist coaching
+for the selected format. **None** persists as no selection and resolves to no addendum at
 all, so a user who never opens this setting sees no behavior change; it is not a guess assembled
 from whatever formats happen to have content. Fixed for the whole session, like the transcription
 language/model choice: it applies on the next Start, never reclassified mid-conversation. See

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -9,7 +9,9 @@
 ## Current phase
 
 **General technical-interview coaching, audio reliability, and local CLI brain providers are
-implemented.** The coach covers behavioral, system-design, and coding questions. A direct request
+implemented.** The coach covers behavioral, system-design, and coding questions, with selectable
+Behavioral and System Design specialist skills under `Sources/JarvisCore/Resources/Skills/`; their
+policy is defined in [architecture.md → Models and APIs](./architecture.md#models-and-apis). A direct request
 whose specific answer depends on visible context missing from the conversation calls `capture_screen`
 before `speak`; a fresh screenshot/OCR satisfies that request, while a fully stated question can be
 answered without a reflexive capture. The independent Transcription setting keeps **OpenAI as the


### PR DESCRIPTION
## Summary

- add a bundled Behavioral interview skill that surfaces the existing Behavioral format in Settings
- proactively offer a compact STAR answer direction after a complete interviewer question
- ground coaching in candidate stories and company values, leadership principles, role expectations, or behavioral requirements from prep notes
- use clearly labeled illustrative mini-stories when no candidate-owned story is available, without inventing personal facts when partial facts exist
- follow the candidate's current STAR stage, coach material gaps, and stay silent after a complete concrete answer

## Validation

- resource and composed-system-prompt tests added
- no-skill control: 5/5 generic STAR outlines, 0/5 usable story examples
- illustrative fallback: 5/5 labeled examples when the candidate has no story
- candidate story plus company principles: 5/5 prep searches and grounded answer directions
- realistic criteria-only prep results: 5/5 labeled, principle-aligned illustrative examples after the review fix
- missing Result: 5/5 focused follow-up prompts
- complete STAR answer: 5/5 stay_silent after tightening the stop condition
- independent code review: no remaining actionable findings

Local Swift compilation is currently blocked before the manifest builds because this host has a Swift 6.3.3 compiler paired with a Swift 6.3.2 macOS SDK. The repository Gate is therefore left to hosted CI on this commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added specialized Behavioral interview coaching using STAR guidance, answer-stage tracking, and targeted follow-up prompts.
  - Behavioral coaching can optionally use preparation notes while avoiding invented candidate details.
  - Coding interview guidance remains unchanged and contains no specialized authored content.

- **Documentation**
  - Updated settings, architecture, and status documentation to describe Behavioral format support alongside System Design.

- **Tests**
  - Added coverage confirming Behavioral prompts include STAR guidance and expected format content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->