### PR TITLE
fix(viewer): tighten export sheet spacing, add export naming/image options

### DIFF
--- a/Sources/JarvisApp/Viewer/ActivityExportSheet.swift
+++ b/Sources/JarvisApp/Viewer/ActivityExportSheet.swift
@@ -118,7 +118,12 @@ private final class SessionPickerWindow: NSObject, NSTableViewDataSource, NSTabl
         window.isReleasedWhenClosed = false
         super.init()
         window.delegate = self
-        window.contentView = makeContentView()
+        let content = makeContentView()
+        window.contentView = content
+        // The stack's actual height (sessions list + format + toggles + buttons) is shorter than
+        // the placeholder frame above; shrink the window to fit instead of leaving whitespace.
+        content.layoutSubtreeIfNeeded()
+        window.setContentSize(NSSize(width: 380, height: content.fittingSize.height))
     }
 
     /// Blocks until Export/Cancel/the window's close button is used; returns whether the user
@@ -132,6 +137,7 @@ private final class SessionPickerWindow: NSObject, NSTableViewDataSource, NSTabl
 
     private func makeContentView() -> NSView {
         let content = NSView(frame: NSRect(x: 0, y: 0, width: 380, height: 440))
+        content.translatesAutoresizingMaskIntoConstraints = false
 
         let scrollView = NSScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -187,7 +193,8 @@ private final class SessionPickerWindow: NSObject, NSTableViewDataSource, NSTabl
             root.topAnchor.constraint(equalTo: content.topAnchor),
             root.leadingAnchor.constraint(equalTo: content.leadingAnchor),
             root.trailingAnchor.constraint(equalTo: content.trailingAnchor),
-            root.bottomAnchor.constraint(equalTo: content.bottomAnchor),
+            content.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            content.widthAnchor.constraint(equalToConstant: 380),
             scrollView.heightAnchor.constraint(equalToConstant: 180),
             buttonRow.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -16),
         ])

--- a/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
@@ -39,7 +39,7 @@ public enum ActivityHistoryExporter {
             return Export(
                 filename: "activity\(suffix).html",
                 text: html(session: session, entries: kept, includeScreenshots: includeScreenshots),
-                images: [])
+                images: images(for: kept, includeScreenshots: includeScreenshots))
         }
     }
 

--- a/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
@@ -22,21 +22,22 @@ public enum ActivityHistoryExporter {
         jarvisResponsesOnly: Bool
     ) -> Export {
         let kept = jarvisResponsesOnly ? responsesOnly(entries) : entries
+        let suffix = jarvisResponsesOnly ? "-jarvis-only" : ""
 
         switch format {
         case .markdown:
             return Export(
-                filename: "activity.md",
+                filename: "activity\(suffix).md",
                 text: markdown(session: session, entries: kept, includeScreenshots: includeScreenshots),
                 images: images(for: kept, includeScreenshots: includeScreenshots))
         case .plainText:
             return Export(
-                filename: "activity.txt",
+                filename: "activity\(suffix).txt",
                 text: plainText(session: session, entries: kept, includeScreenshots: includeScreenshots),
                 images: images(for: kept, includeScreenshots: includeScreenshots))
         case .html:
             return Export(
-                filename: "activity.html",
+                filename: "activity\(suffix).html",
                 text: html(session: session, entries: kept, includeScreenshots: includeScreenshots),
                 images: [])
         }

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
@@ -111,6 +111,18 @@ import Foundation
         #expect(export.images.isEmpty)
     }
 
+    @Test func jarvisResponsesOnlyAddsFilenameSuffixForEveryFormat() {
+        let cases: [(ActivityHistoryExporter.ExportFormat, String)] =
+            [(.markdown, "activity-jarvis-only.md"), (.plainText, "activity-jarvis-only.txt"),
+             (.html, "activity-jarvis-only.html")]
+        for (format, expectedFilename) in cases {
+            let export = ActivityHistoryExporter.export(
+                session: session(), entries: [], format: format,
+                includeScreenshots: false, jarvisResponsesOnly: true)
+            #expect(export.filename == expectedFilename)
+        }
+    }
+
     @Test func emptyEntriesStillProduceHeaderOnlyDocument() {
         let export = ActivityHistoryExporter.export(
             session: session(), entries: [], format: .markdown,

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityHistoryExporterTests.swift
@@ -51,7 +51,7 @@ import Foundation
         #expect(export.images.count == 1)
     }
 
-    @Test func htmlInlinesScreenshotsAsBase64AndWritesNoSeparateImages() {
+    @Test func htmlInlinesScreenshotsAsBase64AndAlsoWritesAnImagesFolder() {
         let entries: [(ActivityLog.Entry, Data?)] = [
             (ActivityLog.Entry(time: "10:00:05", message: "👁 looking at your screen", imageFile: "shot-1.jpg"),
              Data([0xFF, 0xD8, 0xFF, 0xD9])),
@@ -61,7 +61,9 @@ import Foundation
             includeScreenshots: true, jarvisResponsesOnly: false)
         #expect(export.filename == "activity.html")
         #expect(export.text.contains("data:image/jpeg;base64,"))
-        #expect(export.images.isEmpty)
+        #expect(export.images.count == 1)
+        #expect(export.images[0].filename == "images/shot-1.jpg")
+        #expect(export.images[0].data == Data([0xFF, 0xD8, 0xFF, 0xD9]))
     }
 
     @Test func jarvisResponsesOnlyKeepsTipsAndScreenViewsButDropsHeardSpeechAndSystemRows() {


### PR DESCRIPTION
## Summary
- Size the Export Activity History window to its actual content instead of a hardcoded 440pt, removing the whitespace below Cancel/Export.
- Suffix export filenames with `-jarvis-only` when "Jarvis responses only" is checked, so it doesn't collide with a full export.
- HTML export with screenshots now also writes an `images/` folder (in addition to the existing inline base64), matching Markdown/plain text.

## Test plan
- [x] `swift build`
- [x] `./scripts/run-tests.sh` (897 tests passing)
- [x] Manually verified the export sheet in `Jarvis Dev.app` via `./scripts/build-app.sh --run`

https://claude.ai/code/session_01Diw4AKtt8yvZ5u4zQBSiEX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the session picker window sizing so its height fits the displayed content.
  * HTML activity exports now include associated screenshot attachments.
  * Filtered activity exports now use a `-jarvis-only` filename suffix across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->