### PR TITLE
feat(coach): add configurable code snippets alongside hints

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -37,6 +37,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
     private var didStartApp = false
     private var sessionExplanationsEnabled = false
     private let explanationPreferences = ExplanationPreferences()
+    private let codePreferences = CodePreferences()
+    private var sessionCodeEnabled = false
     private let hotkeyPreferences = CoachingShortcut.allCases.map { HotkeyPreferences(shortcut: $0) }
     /// Monotonic revision stamped on each control-plane snapshot. Bumped at Start and whenever an
     /// explicit Settings edit installs a fresh plan; never by runtime health.
@@ -174,6 +176,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         // On by default, but the box is a session surface: this only arms the switch. It reaches the
         // screen on Start (below) and leaves it on Stop, so a stopped Jarvis shows nothing.
         overlayBox.setEnabled(appearance.boxEnabled)
+        overlayBox.setCodeEnabled(codePreferences.isEnabled)
 
         // No updater in a development bundle (no feed URL), so the menu omits the item entirely.
         updates = UpdateController()
@@ -185,9 +188,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         // The global hint hotkey is constructed before Settings so HotkeySection's closures (built
         // below) can already read/apply through it. `onRequest` is wired later, alongside the
         // rest of session lifecycle plumbing.
-        if !appearance.boxEnabled { explanationPreferences.isEnabled = false }
+        if !appearance.boxEnabled {
+            explanationPreferences.isEnabled = false
+            codePreferences.isEnabled = false
+        }
         hotkeys = HotkeyController(preferences: hotkeyPreferences.filter {
-            $0.shortcut != .explainMore || explanationPreferences.isEnabled
+            ($0.shortcut != .explainMore || explanationPreferences.isEnabled)
+                && ($0.shortcut != .showCode || codePreferences.isEnabled)
         })
 
         // Unified Settings window: Brain owns behavior; Connections owns shared authentication.
@@ -209,6 +216,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
             onKeySaved: { [weak self] credential, key in
                 self?.applySavedAPIKeyToRunningSession(credential: credential, key: key)
             })
+        let hotkeySection = HotkeySection(
+                preferences: hotkeyPreferences,
+                explanationPreferences: explanationPreferences,
+                codePreferences: codePreferences,
+                onCodeChanged: { [weak self] in self?.refreshOptionalShortcut(.showCode) },
+                boxEnabled: { [weak self] in self?.appearance.boxEnabled == true },
+                onExplanationsChanged: { [weak self] in self?.refreshOptionalShortcut(.explainMore) },
+                hasActiveHotkey: { [weak self] shortcut in
+                    guard let self else { return false }
+                    // Deferred bindings have no live registration to warn about until Start.
+                    return (self.requestManualHint != nil && !self.sessionAllows(shortcut))
+                        || self.hotkeys?.registered[shortcut] != nil
+                },
+                applyCombination: { [weak self] shortcut, combination in
+                    // `hotkeys` is constructed above, before Settings can ever be shown, so `self`
+                    // being torn down is the only way this falls through — report failure rather
+                    // than falsely claiming a rebind that never happened.
+                    guard let self else { return .failed(status: -1) }
+                    let outcome = self.hotkeys?.apply(combination, for: shortcut) ?? .failed(status: -1)
+                    if self.requestManualHint != nil, !self.sessionAllows(shortcut) {
+                        self.hotkeys?.unregister(shortcut) // Validate ownership, then release until Start.
+                    }
+                    return outcome
+                })
         let sections: [SettingsSection] = [
             brainSection,
             connectionsSection,
@@ -216,39 +247,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
                 onBoxEnabledChanged: { [weak self] enabled in
                     guard let self, !enabled else { return }
                     self.explanationPreferences.isEnabled = false
+                    self.codePreferences.isEnabled = false
+                    self.overlayBox.setCodeEnabled(false)
                     self.hotkeys?.unregister(.explainMore)
+                    self.hotkeys?.unregister(.showCode)
                 }),
             DisplaySection(preferences: screenPreferences) { [weak self] in
                 self?.reapplySessionPlan()
             },
             PrepMaterialSection(preferences: prepMaterialPreferences),
-            HotkeySection(
-                preferences: hotkeyPreferences,
-                explanationPreferences: explanationPreferences,
-                boxEnabled: { [weak self] in self?.appearance.boxEnabled == true },
-                onExplanationsChanged: { [weak self] in
-                    guard let self else { return }
-                    if self.explanationPreferences.isEnabled,
-                       self.requestManualHint == nil || self.sessionExplanationsEnabled,
-                       let preference = self.hotkeyPreferences.first(where: { $0.shortcut == .explainMore }) {
-                        self.hotkeys?.apply(preference.combination, for: .explainMore)
-                    } else {
-                        self.hotkeys?.unregister(.explainMore)
-                    }
-                },
-                hasActiveHotkey: { [weak self] shortcut in (shortcut == .explainMore && self?.requestManualHint != nil && self?.sessionExplanationsEnabled != true) || self?.hotkeys?.registered[shortcut] != nil },
-                applyCombination: { [weak self] shortcut, combination in
-                    // `hotkeys` is constructed above, before Settings can ever be shown, so `self`
-                    // being torn down is the only way this falls through — report failure rather
-                    // than falsely claiming a rebind that never happened.
-                    guard let self else { return .failed(status: -1) }
-                    if shortcut == .explainMore, self.requestManualHint != nil, !self.sessionExplanationsEnabled {
-                        let outcome = self.hotkeys?.apply(combination, for: shortcut) ?? .failed(status: -1)
-                        self.hotkeys?.unregister(shortcut) // Validate ownership, then release until Start.
-                        return outcome
-                    }
-                    return self.hotkeys?.apply(combination, for: shortcut) ?? .failed(status: -1)
-                }),
+            hotkeySection,
             ActivitySection(viewer: activityViewer),
         ]
         settingsWindow = SettingsWindow(sections: sections)
@@ -266,11 +274,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         // While a session is running, screenshot + ask the brain for a hint in one trip; otherwise
         // beep — there's no live driver/conversation to hint from when stopped.
         hotkeys?.onRequest = { [weak self] shortcut in
-            if shortcut == .explainMore, self?.sessionExplanationsEnabled != true { return }
             guard let self, let fire = self.requestManualHint else {
                 NSSound.beep() // ghost-mode-allowed: explicit user hotkey while stopped
                 return
             }
+            guard self.sessionAllows(shortcut) else { return }
             fire(shortcut)
         }
 
@@ -336,6 +344,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         let interviewFormat = brain.preferences.interviewFormat
         let interviewFormatAddendum = interviewFormat?.promptAddendum ?? ""
         let explanationsEnabled = explanationPreferences.isEnabled && appearance.boxEnabled
+        let codeEnabled = codePreferences.isEnabled && appearance.boxEnabled
+            && (interviewFormat == nil || interviewFormat == .coding || interviewFormat == .generalTechnical)
         let key = secrets.apiKey(for: .openAIAPIKey) ?? ""
         // The brain's key stays OpenAI-only (above); transcription reads whichever credential the
         // selected provider owns — Apple Speech has none, so this is "" there and unused.
@@ -487,6 +497,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
                 interviewFormatAddendum: interviewFormatAddendum,
                 interviewFormat: interviewFormat,
                 explanationsEnabled: explanationsEnabled,
+                codeEnabled: codeEnabled,
                 transcriptionConfiguration: transcriptionConfiguration,
                 appleSpeechLocale: appleSpeechLocale,
                 detectedCLIs: detectedCLIs,
@@ -548,6 +559,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         interviewFormatAddendum: String,
         interviewFormat: InterviewFormat?,
         explanationsEnabled: Bool,
+        codeEnabled: Bool,
         transcriptionConfiguration: TranscriptionConfiguration,
         appleSpeechLocale: Locale?,
         detectedCLIs initialDetectedCLIs: [BrainProvider: DetectedAgentCLI],
@@ -602,6 +614,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         let sessionDirectory = artifacts.currentSessionDir!
         // Fixed for the whole session — set before every construction/reapply path that bakes a
         // system prompt, including a later `applyBrainPreferencesToRunningSession` hot switch.
+        sessionCodeEnabled = codeEnabled
+        brain.codeEnabled = codeEnabled
+        overlayBox.setCodeEnabled(codeEnabled)
+        if codeEnabled, let preference = hotkeyPreferences.first(where: { $0.shortcut == .showCode }) {
+            hotkeys?.apply(preference.combination, for: .showCode)
+        } else {
+            hotkeys?.unregister(.showCode)
+        }
         sessionExplanationsEnabled = explanationsEnabled
         brain.explanationsEnabled = explanationsEnabled
         if explanationsEnabled, let preference = hotkeyPreferences.first(where: { $0.shortcut == .explainMore }) {
@@ -845,7 +865,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         }
         // Arm the hint hotkey for this session: capture the screen and force a one-trip hint, routed
         // through the same turn box as audio triggers (so Stop cancels it and rapid presses coalesce).
-        self.requestManualHint = { shortcut in turns.run { await driver.handleTrigger(shortcut.triggerReason) } }
+        self.requestManualHint = { shortcut in
+            turns.run { await driver.handleTrigger(shortcut.triggerReason) }
+        }
         transcriber.connect()
         themTranscriber.connect()
         if let reason = capture.start() {
@@ -891,6 +913,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         sessionIsLive = false
         overlayBox.setSessionLive(false)     // the history box goes away with the session
         requestManualHint = nil              // hotkey beeps again once there's no live session
+        overlayBox.setCodeEnabled(false)
         // Capture and clear this session handle before a quick Start installs another. The cancelled
         // tasks retain only its observer ports and can finish enqueueing into the old session.
         let (audit, auditDirectory) = artifacts.takeCurrentSession()
@@ -1140,6 +1163,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
 
 
 
+    private func sessionAllows(_ shortcut: CoachingShortcut) -> Bool {
+        switch shortcut {
+        case .hint: true
+        case .explainMore: sessionExplanationsEnabled
+        case .showCode: sessionCodeEnabled
+        }
+    }
+
+    private func refreshOptionalShortcut(_ shortcut: CoachingShortcut) {
+        let enabled = shortcut == .explainMore ? explanationPreferences.isEnabled : codePreferences.isEnabled
+        if enabled, requestManualHint == nil || sessionAllows(shortcut),
+           let preference = hotkeyPreferences.first(where: { $0.shortcut == shortcut }) {
+            hotkeys?.apply(preference.combination, for: shortcut)
+        } else {
+            hotkeys?.unregister(shortcut)
+        }
+    }
+
     /// Read the persisted control plane once and freeze it as the next revision.
     ///
     /// This is the only place preferences reach a coaching attempt. Everything a turn needs is
@@ -1148,7 +1189,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
     private func freshSessionPlan() -> SessionPlan {
         planRevision &+= 1
         return SessionPlan(revision: planRevision, screen: screenPreferences.selection,
-                           explanationsEnabled: sessionExplanationsEnabled)
+                           explanationsEnabled: sessionExplanationsEnabled, codeEnabled: sessionCodeEnabled)
     }
 
     /// An explicit Settings edit takes effect at the next attempt. A turn already running keeps the

--- a/Sources/JarvisApp/App/BrainComposition.swift
+++ b/Sources/JarvisApp/App/BrainComposition.swift
@@ -78,6 +78,7 @@ final class BrainComposition {
     /// calls per turn.
     var interviewFormatAddendum = ""
     var explanationsEnabled = true
+    var codeEnabled = false
 
     /// The two clients that move together with one provider/model route target.
     private struct BrainRuntime {
@@ -148,7 +149,7 @@ final class BrainComposition {
                                        systemPrompt: JarvisPrompts.Coach.system(
                                            prepMaterial: false,
                                            formatAddendum: interviewFormatAddendum,
-                                           explanationsEnabled: explanationsEnabled),
+                                           explanationsEnabled: explanationsEnabled, codeEnabled: codeEnabled),
                                        tools: coachTools,
                                        toolChoice: .required,
                                        runtime: runtimes.coach,

--- a/Sources/JarvisApp/Settings/HotkeyBindingView.swift
+++ b/Sources/JarvisApp/Settings/HotkeyBindingView.swift
@@ -13,6 +13,8 @@ import JarvisCore
 final class HotkeyBindingView: NSObject {
 
     private let preferences: HotkeyPreferences
+    private let codePreferences: CodePreferences?
+    private let onCodeChanged: () -> Void
     private let boxEnabled: () -> Bool
     private var explanationRow: SettingsRowView?
     private let explanationPreferences: ExplanationPreferences?
@@ -21,10 +23,10 @@ final class HotkeyBindingView: NSObject {
     private var shortcutRow: SettingsRowView?
     private var cardHeightConstraint: NSLayoutConstraint?
 
-    private var isEnabled: Bool { explanationPreferences?.isEnabled ?? true }
+    private var isEnabled: Bool { explanationPreferences?.isEnabled ?? codePreferences?.isEnabled ?? true }
     private var cardHeight: CGFloat {
         SettingsStyle.cardHeaderHeight
-            + (explanationPreferences == nil ? 0 : SettingsStyle.rowHeight)
+            + (explanationPreferences == nil && codePreferences == nil ? 0 : SettingsStyle.rowHeight)
             + (isEnabled ? SettingsStyle.rowHeight : 0)
     }
     /// Whether the controller currently has *any* combination registered. This is the only thing
@@ -53,11 +55,15 @@ final class HotkeyBindingView: NSObject {
     init(
         preferences: HotkeyPreferences,
         explanationPreferences: ExplanationPreferences? = nil,
+        codePreferences: CodePreferences? = nil,
+        onCodeChanged: @escaping () -> Void = {},
         boxEnabled: @escaping () -> Bool = { true },
         onExplanationsChanged: @escaping () -> Void = {},
         hasActiveHotkey: @escaping () -> Bool,
         applyCombination: @escaping (HotkeyCombination) -> HotkeyRegistrationOutcome
     ) {
+        self.codePreferences = codePreferences
+        self.onCodeChanged = onCodeChanged
         self.boxEnabled = boxEnabled
         self.preferences = preferences
         self.explanationPreferences = explanationPreferences
@@ -78,7 +84,8 @@ final class HotkeyBindingView: NSObject {
 
         let card = SettingsCardView(frame: NSRect(x: 0, y: 0, width: 712, height: cardHeight))
         card.translatesAutoresizingMaskIntoConstraints = false
-        card.setHeader(title: preferences.shortcut.title, detail: "Works only while a session is running")
+        card.setHeader(title: preferences.shortcut.title, detail: preferences.shortcut == .showCode
+            ? "Coding · snippets follow your hints" : "Works only while a session is running")
         let row = SettingsRowView(
             title: "Shortcut",
             detail: "Requires ⌘ or ⌥",
@@ -89,14 +96,14 @@ final class HotkeyBindingView: NSObject {
         shortcutRow = row
         card.contentView?.addSubview(row)
         var toggleRow: SettingsRowView?
-        if explanationPreferences != nil {
+        if explanationPreferences != nil || codePreferences != nil {
             let toggle = NSSwitch()
             toggle.target = self
             toggle.action = #selector(explanationsChanged)
-            toggle.setAccessibilityLabel("Enable explanations")
+            toggle.setAccessibilityLabel(codePreferences == nil ? "Enable explanations" : "Show code with hints")
             explanationSwitch = toggle
             let settingsRow = SettingsRowView(
-                title: "Enable explanations",
+                title: codePreferences == nil ? "Enable explanations" : "Show code with hints",
                 detail: "Takes effect the next time you start",
                 controlView: toggle,
                 controlSize: NSSize(width: 44, height: 26))
@@ -150,9 +157,14 @@ final class HotkeyBindingView: NSObject {
     }
 
     @objc private func explanationsChanged() {
-        guard let explanationPreferences, let explanationSwitch else { return }
-        explanationPreferences.isEnabled = explanationSwitch.state == .on
-        onExplanationsChanged()
+        guard let explanationSwitch else { return }
+        if let codePreferences {
+            codePreferences.isEnabled = explanationSwitch.state == .on
+            onCodeChanged()
+        } else if let explanationPreferences {
+            explanationPreferences.isEnabled = explanationSwitch.state == .on
+            onExplanationsChanged()
+        }
         recorder?.setCombination(preferences.combination)
         renderOutcome()
     }

--- a/Sources/JarvisApp/Settings/HotkeySection.swift
+++ b/Sources/JarvisApp/Settings/HotkeySection.swift
@@ -10,6 +10,8 @@ final class HotkeySection: NSObject, SettingsSection {
 
     init(preferences: [HotkeyPreferences],
          explanationPreferences: ExplanationPreferences,
+         codePreferences: CodePreferences,
+         onCodeChanged: @escaping () -> Void,
          boxEnabled: @escaping () -> Bool = { true },
          onExplanationsChanged: @escaping () -> Void,
          hasActiveHotkey: @escaping (CoachingShortcut) -> Bool,
@@ -17,6 +19,8 @@ final class HotkeySection: NSObject, SettingsSection {
         bindings = preferences.map { preference in
             HotkeyBindingView(preferences: preference,
                 explanationPreferences: preference.shortcut == .explainMore ? explanationPreferences : nil,
+                codePreferences: preference.shortcut == .showCode ? codePreferences : nil,
+                onCodeChanged: onCodeChanged,
                 boxEnabled: boxEnabled,
                 onExplanationsChanged: onExplanationsChanged,
                 hasActiveHotkey: { hasActiveHotkey(preference.shortcut) },
@@ -62,7 +66,7 @@ final class HotkeySection: NSObject, SettingsSection {
         scroll.onViewportChanged = relayout
         relayout()
         return SettingsPageView(title: title,
-            summary: "Request a next step or an explanation when you need more help.", bodyView: scroll)
+            summary: "Request a hint, an explanation, or the next code snippet.", bodyView: scroll)
     }
 
     func didBecomeActive() {

--- a/Sources/JarvisCore/Brain/Brain.swift
+++ b/Sources/JarvisCore/Brain/Brain.swift
@@ -68,7 +68,7 @@ public enum ToolInvocation: Sendable, Equatable {
     /// The overlay lines to show, already split by the model (the `speak` tool's `lines` array) and
     /// rendered one at a time — so the client never splits a free-form string on punctuation.
     /// Optional Mermaid is rendered only in an explicitly selected System Design session.
-    case speak(callId: String, lines: [String], mermaid: String? = nil, explanation: String? = nil)
+    case speak(callId: String, lines: [String], mermaid: String? = nil, explanation: String? = nil, codeSnippet: CodeSnippet? = nil)
     /// The model's explicit "nothing useful to add" decision. Silence is a tool call (not the absence
     /// of one) so that `tool_choice: required` can forbid plain-text output entirely — free text from
     /// a stay-quiet turn used to be stored in the server-side conversation, where the model imitated

--- a/Sources/JarvisCore/Brain/ToolInvocation+Parsing.swift
+++ b/Sources/JarvisCore/Brain/ToolInvocation+Parsing.swift
@@ -18,8 +18,19 @@ public extension ToolInvocation {
                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
             guard !lines.isEmpty else { return nil }
             let detail = (object?["explanation"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let snippet: CodeSnippet?
+            if let value = object?["codeSnippet"] as? [String: Any],
+               let language = value["language"] as? String,
+               let placement = value["placement"] as? String,
+               let code = value["code"] as? String,
+               let highlightedLines = value["highlightedLines"] as? [Int] {
+                snippet = CodeSnippet(language: language, placement: placement, code: code,
+                                      highlightedLines: highlightedLines)
+            } else {
+                snippet = nil
+            }
             return .speak(callId: callId, lines: lines, mermaid: object?["mermaid"] as? String,
-                          explanation: detail.flatMap { $0.isEmpty ? nil : $0 })
+                          explanation: detail.flatMap { $0.isEmpty ? nil : $0 }, codeSnippet: snippet)
         case staySilentTool.name:
             return .staySilent(callId: callId)
         case searchPrepNotesTool.name:

--- a/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
+++ b/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
@@ -215,16 +215,20 @@ final class CoachAttemptRunner: @unchecked Sendable {
         // Describing search_prep_notes when it isn't actually offered invites the model to call a
         // tool it doesn't have — and that call is a hard attempt failure (below), so `prepMaterial`
         // must track the real tool set (`tools`, below) exactly, not just hint at it.
+        let codeAllowed = attempt.plan.codeEnabled && (interviewFormat == nil || interviewFormat == .coding || interviewFormat == .generalTechnical)
         let systemPrompt = JarvisPrompts.Coach.system(
             prepMaterial: attempt.prepMaterial != nil,
             formatAddendum: interviewFormatAddendum,
-            explanationsEnabled: attempt.plan.explanationsEnabled)
+            explanationsEnabled: attempt.plan.explanationsEnabled, codeEnabled: codeAllowed)
         let historyBase: [ChatMessage] = [.system(systemPrompt)] + history.snapshot()
         if reason.isManual && work.preparedManualReason != reason {
             if let prompt = context.promptLine {
                 jlog("⌨️ coaching shortcut — \(prompt)")
-                activity?.record(reason == .manualExplanation
-                    ? .manualExplanation(prompt: prompt) : .manualHint(prompt: prompt))
+                switch reason {
+                case .manualCode: activity?.record(.manualCode(prompt: prompt))
+                case .manualExplanation: activity?.record(.manualExplanation(prompt: prompt))
+                default: activity?.record(.manualHint(prompt: prompt))
+                }
             }
             let screen = self.screen
             let shot = await Self.captureScreen(using: screen, selecting: attempt.plan.screen)
@@ -406,7 +410,7 @@ final class CoachAttemptRunner: @unchecked Sendable {
                             newPhase: .captureScreenContinuation)
                     }
 
-                case .speak(let callID, let lines, let mermaid, let requestedExplanation):
+                case .speak(let callID, let lines, let mermaid, let requestedExplanation, let requestedCode):
                     if Task.isCancelled {
                         jlog("… attempt cancelled (stopped) before speaking")
                         return .cancelled
@@ -416,31 +420,35 @@ final class CoachAttemptRunner: @unchecked Sendable {
                     if mermaid != nil && diagram == nil {
                         jlog("Diagram hint omitted: unsupported graph or interview format")
                     }
-                    let delivery = await MainActor.run { () -> (accepted: Bool, explanation: String?) in
-                        guard !Task.isCancelled else { return (false, nil) }
+                    let delivery = await MainActor.run { () -> (accepted: Bool, explanation: String?, code: CodeSnippet?) in
+                        guard !Task.isCancelled else { return (false, nil, nil) }
+                        let code = self.overlay.deliverCodeSnippet(codeAllowed ? requestedCode : nil)
                         let detail = self.overlay.deliver(lines, perLineSeconds: lines.map {
                             OverlayTiming.displaySeconds(for: $0, config: self.config)
                         }, diagram: diagram, explanation: attempt.plan.explanationsEnabled ? requestedExplanation : nil)
-                        return (true, detail)
+                        return (true, detail, code)
                     }
                     guard delivery.accepted else { return .cancelled }
                     let explanation = delivery.explanation
-                    activity?.record(.tip(lines: lines + (explanation.map { [$0] } ?? [])))
+                    let code = delivery.code
+                    let codeText = code.map { "\($0.placement)\n\($0.code)" }
+                    activity?.record(.tip(lines: lines + (explanation.map { [$0] } ?? []) + (codeText.map { [$0] } ?? [])))
                     // Only the selected call executes; extra provider calls were never delivered.
-                    var deliveredCalls = response.rawToolCalls.filter { $0.id == callID }
-                    if explanation == nil {
-                        // History describes what was delivered, not optional text suppressed by Settings.
-                        // These parsed values contain only JSON strings, arrays, and null, so encoding cannot fail.
-                        let arguments: [String: Any] = [
-                            "lines": lines, "mermaid": mermaid as Any? ?? NSNull(), "explanation": NSNull(),
-                        ]
-                        let data = try! JSONSerialization.data(withJSONObject: arguments, options: [.sortedKeys])
-                        deliveredCalls = deliveredCalls.map { call in
-                            call.id == callID
-                                ? RawToolCall(id: call.id, name: call.name,
-                                              argumentsJSON: String(decoding: data, as: UTF8.self))
-                                : call
-                        }
+                    // History describes delivered optional content, including independently enabled code.
+                    // Parsed values contain only JSON primitives, so encoding cannot fail.
+                    let codeArguments: [String: Any]? = code.map {
+                        ["language": $0.language, "placement": $0.placement, "code": $0.code,
+                         "highlightedLines": $0.highlightedLines]
+                    }
+                    let arguments: [String: Any] = [
+                        "lines": lines, "mermaid": diagram == nil ? NSNull() : mermaid as Any,
+                        "explanation": explanation as Any? ?? NSNull(),
+                        "codeSnippet": codeArguments as Any? ?? NSNull(),
+                    ]
+                    let data = try! JSONSerialization.data(withJSONObject: arguments, options: [.sortedKeys])
+                    let deliveredCalls = response.rawToolCalls.filter { $0.id == callID }.map { call in
+                        RawToolCall(id: call.id, name: call.name,
+                                    argumentsJSON: String(decoding: data, as: UTF8.self))
                     }
                     turnMessages.append(.assistantToolCalls(deliveredCalls))
                     turnMessages.append(.init(

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -198,7 +198,8 @@ public final class CoachDriver: @unchecked Sendable {
     public func updatePlan(_ plan: SessionPlan) {
         stateLock.lock()
         self.plan = SessionPlan(revision: plan.revision, screen: plan.screen,
-                                explanationsEnabled: self.plan.explanationsEnabled)
+                                explanationsEnabled: self.plan.explanationsEnabled,
+                                codeEnabled: self.plan.codeEnabled)
         stateLock.unlock()
     }
 

--- a/Sources/JarvisCore/Coach/ToolDefs.swift
+++ b/Sources/JarvisCore/Coach/ToolDefs.swift
@@ -12,7 +12,7 @@ public let captureScreenTool = ToolDef(
 public let speakTool = ToolDef(
     name: "speak",
     description: JarvisPrompts.Coach.ToolDescription.speak,
-    parametersJSON: #"{"type":"object","properties":{"lines":{"type":"array","items":{"type":"string"}},"explanation":{"type":["string","null"]}},"required":["lines","explanation"],"additionalProperties":false}"#
+    parametersJSON: #"{"type":"object","properties":{"lines":{"type":"array","items":{"type":"string"}},"explanation":{"type":["string","null"]},"codeSnippet":{"type":["object","null"],"properties":{"language":{"type":"string"},"placement":{"type":"string"},"code":{"type":"string"},"highlightedLines":{"type":"array","items":{"type":"integer"}}},"required":["language","placement","code","highlightedLines"],"additionalProperties":false}},"required":["lines","explanation","codeSnippet"],"additionalProperties":false}"#
 )
 
 public let staySilentTool = ToolDef(
@@ -37,5 +37,5 @@ public let searchPrepNotesTool = ToolDef(
 public let systemDesignSpeakTool = ToolDef(
     name: speakTool.name,
     description: JarvisPrompts.Coach.ToolDescription.speak,
-    parametersJSON: #"{"type":"object","properties":{"lines":{"type":"array","items":{"type":"string"}},"explanation":{"type":["string","null"]},"mermaid":{"type":["string","null"]}},"required":["lines","mermaid","explanation"],"additionalProperties":false}"#
+    parametersJSON: #"{"type":"object","properties":{"lines":{"type":"array","items":{"type":"string"}},"explanation":{"type":["string","null"]},"mermaid":{"type":["string","null"]},"codeSnippet":{"type":["object","null"],"properties":{"language":{"type":"string"},"placement":{"type":"string"},"code":{"type":"string"},"highlightedLines":{"type":"array","items":{"type":"integer"}}},"required":["language","placement","code","highlightedLines"],"additionalProperties":false}},"required":["lines","mermaid","explanation","codeSnippet"],"additionalProperties":false}"#
 )

--- a/Sources/JarvisCore/Config/CoachingShortcut.swift
+++ b/Sources/JarvisCore/Config/CoachingShortcut.swift
@@ -4,11 +4,13 @@ import Foundation
 public enum CoachingShortcut: UInt32, CaseIterable, Sendable {
     case hint = 1
     case explainMore = 2
+    case showCode = 3
 
     public var title: String {
         switch self {
         case .hint: "Give me a hint"
         case .explainMore: "Explain more"
+        case .showCode: "Show code"
         }
     }
 
@@ -16,6 +18,7 @@ public enum CoachingShortcut: UInt32, CaseIterable, Sendable {
         switch self {
         case .hint: .manualHint
         case .explainMore: .manualExplanation
+        case .showCode: .manualCode
         }
     }
 }

--- a/Sources/JarvisCore/Config/CodePreferences.swift
+++ b/Sources/JarvisCore/Config/CodePreferences.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Read by Settings and snapshotted into SessionPlan at explicit revision boundaries.
+public final class CodePreferences {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public var isEnabled: Bool {
+        get {
+            defaults.object(forKey: Defaults.Code.enabledKey) as? Bool
+                ?? Defaults.Code.enabled
+        }
+        set { defaults.set(newValue, forKey: Defaults.Code.enabledKey) }
+    }
+}

--- a/Sources/JarvisCore/Config/Defaults.swift
+++ b/Sources/JarvisCore/Config/Defaults.swift
@@ -102,6 +102,11 @@ public enum Defaults {
     // MARK: - Hotkey
 
     /// Availability of fuller explanations and their manual fallback.
+    public enum Code {
+        public static let enabledKey = "coaching.codeEnabled"
+        public static let enabled = false
+    }
+
     public enum Explanations {
         public static let enabledKey = "coaching.explanationsEnabled"
         public static let enabled = true
@@ -109,6 +114,10 @@ public enum Defaults {
 
     /// Independent shortcuts for an immediate hint or explanation mid-session.
     public enum Hotkey {
+        public static let codeKeyCodeKey = "hotkey.code.keyCode"
+        public static let codeModifiersKey = "hotkey.code.modifiers"
+        /// kVK_ANSI_K. Code is requested only by this explicit shortcut.
+        public static let codeCombination = HotkeyCombination(keyCode: 40, modifiers: [.command, .option])
         public static let explanationKeyCodeKey = "hotkey.explanation.keyCode"
         public static let explanationModifiersKey = "hotkey.explanation.modifiers"
         /// kVK_ANSI_E, with the same modifiers as the hint shortcut.

--- a/Sources/JarvisCore/Config/HotkeyPreferences.swift
+++ b/Sources/JarvisCore/Config/HotkeyPreferences.swift
@@ -11,13 +11,25 @@ public final class HotkeyPreferences: @unchecked Sendable {
     private let defaults: UserDefaults
     public let shortcut: CoachingShortcut
     private var keyCodeKey: String {
-        shortcut == .hint ? Defaults.Hotkey.keyCodeKey : Defaults.Hotkey.explanationKeyCodeKey
+        switch shortcut {
+        case .hint: Defaults.Hotkey.keyCodeKey
+        case .explainMore: Defaults.Hotkey.explanationKeyCodeKey
+        case .showCode: Defaults.Hotkey.codeKeyCodeKey
+        }
     }
     private var modifiersKey: String {
-        shortcut == .hint ? Defaults.Hotkey.modifiersKey : Defaults.Hotkey.explanationModifiersKey
+        switch shortcut {
+        case .hint: Defaults.Hotkey.modifiersKey
+        case .explainMore: Defaults.Hotkey.explanationModifiersKey
+        case .showCode: Defaults.Hotkey.codeModifiersKey
+        }
     }
     private var defaultCombination: HotkeyCombination {
-        shortcut == .hint ? Defaults.Hotkey.combination : Defaults.Hotkey.explanationCombination
+        switch shortcut {
+        case .hint: Defaults.Hotkey.combination
+        case .explainMore: Defaults.Hotkey.explanationCombination
+        case .showCode: Defaults.Hotkey.codeCombination
+        }
     }
 
     public init(defaults: UserDefaults = .standard, shortcut: CoachingShortcut = .hint) {

--- a/Sources/JarvisCore/Config/SessionPlan.swift
+++ b/Sources/JarvisCore/Config/SessionPlan.swift
@@ -34,14 +34,17 @@ public struct SessionPlan: Sendable, Equatable {
     /// log without comparing every field; nothing branches on its value.
     public let revision: UInt
     public let screen: ScreenCaptureSelection
+    public let codeEnabled: Bool
     /// Fixed at Start; screen revisions preserve this session capability.
     public let explanationsEnabled: Bool
 
     public init(revision: UInt, screen: ScreenCaptureSelection,
-                explanationsEnabled: Bool = Defaults.Explanations.enabled) {
+                explanationsEnabled: Bool = Defaults.Explanations.enabled,
+                codeEnabled: Bool = Defaults.Code.enabled) {
         self.revision = revision
         self.screen = screen
         self.explanationsEnabled = explanationsEnabled
+        self.codeEnabled = codeEnabled
     }
 
     /// The plan a session with no configured control plane runs against: active-window capture on

--- a/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
@@ -16,6 +16,7 @@ public enum ActivityEvent: Sendable {
         case heard
         case manualHint
         case manualExplanation
+        case manualCode
         case screenViewed
         case screenViewFailed
         case tip
@@ -35,6 +36,7 @@ public enum ActivityEvent: Sendable {
     /// The user explicitly requested help through the manual-hint shortcut.
     case manualHint(prompt: String)
     case manualExplanation(prompt: String)
+    case manualCode(prompt: String)
     /// Jarvis captured and viewed the screen while preparing a coaching response.
     case screenViewed(imageBase64JPEG: String)
     /// The brain chose to view the screen, but capture failed. Activity gets fixed recovery
@@ -76,6 +78,8 @@ public enum ActivityEvent: Sendable {
             return (.manualHint, "⌨️ hint shortcut — \(prompt)", nil)
         case .manualExplanation(let prompt):
             return (.manualExplanation, "⌨️ explain more shortcut — \(prompt)", nil)
+        case .manualCode(let prompt):
+            return (.manualCode, "⌨️ show code shortcut — \(prompt)", nil)
         case .screenViewed(let imageBase64JPEG):
             return (.screenViewed, "👁 looking at your screen", imageBase64JPEG)
         case .screenViewFailed:

--- a/Sources/JarvisCore/Diagnostics/CoachingRequestAttribution.swift
+++ b/Sources/JarvisCore/Diagnostics/CoachingRequestAttribution.swift
@@ -39,6 +39,7 @@ enum CoachingRequestAttribution {
         case .silence: "silence"
         case .manualHint: "manual_hint"
         case .manualExplanation: "manual_explanation"
+        case .manualCode: "manual_code"
         }
     }
 }

--- a/Sources/JarvisCore/Overlay/BroadcastOverlay.swift
+++ b/Sources/JarvisCore/Overlay/BroadcastOverlay.swift
@@ -6,6 +6,14 @@ import Foundation
 public final class BroadcastOverlay: OverlayRendering {
     private let sinks: [OverlayRendering]
 
+    @MainActor public func deliverCodeSnippet(_ snippet: CodeSnippet?) -> CodeSnippet? {
+        var delivered: CodeSnippet?
+        for sink in sinks {
+            if let code = sink.deliverCodeSnippet(snippet) { delivered = code }
+        }
+        return delivered
+    }
+
     @MainActor public var acceptsDetail: Bool { sinks.contains { $0.acceptsDetail } }
 
     @MainActor public func deliver(_ lines: [String], perLineSeconds: [TimeInterval],

--- a/Sources/JarvisCore/Overlay/CodeSnippet.swift
+++ b/Sources/JarvisCore/Overlay/CodeSnippet.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// A complete small component. Oversized code is rejected rather than cut into an invalid fragment.
+public struct CodeSnippet: Sendable, Equatable {
+    public let language: String
+    public let placement: String
+    public let code: String
+    /// One-based snippet line indices, independent of the editor's line numbers.
+    public let highlightedLines: [Int]
+
+    public init?(language: String, placement: String, code: String, highlightedLines: [Int] = []) {
+        guard highlightedLines.count <= 12 else { return nil }
+        let lineNormalized = code.replacingOccurrences(of: "\r\n", with: "\n")
+        // Reject other rendered line separators rather than rewriting possible string-literal content.
+        guard lineNormalized.allSatisfy({ !$0.isNewline || $0 == "\n" }) else { return nil }
+        let droppedLeading = lineNormalized.prefix { $0 == "\n" }.count
+        let normalized = lineNormalized.trimmingCharacters(in: .newlines)
+        let placement = placement.trimmingCharacters(in: .whitespacesAndNewlines)
+        let language = language.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lineCount = normalized.components(separatedBy: "\n").count
+        guard !normalized.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              normalized.count <= 2400, lineCount <= 12,
+              !placement.isEmpty, placement.count <= 160, language.count <= 40,
+              !placement.contains(where: { $0.isNewline }),
+              !language.contains(where: { $0.isNewline }) else { return nil }
+        self.language = language
+        self.placement = placement
+        self.code = normalized
+        self.highlightedLines = Array(Set(highlightedLines.compactMap { index in
+            // Check bounds before subtraction, including malformed Int.min/Int.max indices.
+            guard index > droppedLeading, index <= droppedLeading + lineCount else { return nil }
+            return index - droppedLeading
+        })).sorted()
+    }
+}

--- a/Sources/JarvisCore/Overlay/OverlayRendering.swift
+++ b/Sources/JarvisCore/Overlay/OverlayRendering.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// What the overlay needs to do; the real NSPanel impl lives in JarvisOverlay.
 public protocol OverlayRendering: AnyObject {
+    /// Deliver or clear the independent code area and report accepted visible content.
+    @MainActor func deliverCodeSnippet(_ snippet: CodeSnippet?) -> CodeSnippet?
     /// Sampled at delivery, since the user can hide the persistent surface during a request.
     @MainActor var acceptsDetail: Bool { get }
     /// Render and report accepted detail in one main-actor operation.
@@ -17,6 +19,7 @@ public protocol OverlayRendering: AnyObject {
 }
 
 extension OverlayRendering {
+    @MainActor public func deliverCodeSnippet(_ snippet: CodeSnippet?) -> CodeSnippet? { nil }
     @MainActor public var acceptsDetail: Bool { false }
 
     @MainActor public func deliver(_ lines: [String], perLineSeconds: [TimeInterval],

--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -74,6 +74,30 @@ extension JarvisPrompts {
         """
 
         /// Shared across interview formats and providers, including fixed-instruction CLI sessions.
+        private static let codeGuidance = """
+
+        # Code accompanies the current hint when enabled
+        Accompany each actionable coding hint with the matching codeSnippet. It must
+        implement that specific hint, not an unrelated step or an earlier hint. For conceptual guidance
+        without a useful implementation, set codeSnippet to null. Do not produce extra hints merely
+        to fill the code area; stay silent during healthy progress as usual.
+        Supply only the NEXT logical component (usually 3–8 lines, at most 12), never
+        a complete solution. Match the visible language, variable names, indentation, function signature,
+        and approach. Say precisely where it belongs in placement, using visible anchors rather than
+        invented editor line numbers. Preserve sound existing work.
+        If a local mistake blocks that step, include the corrected line and nearby next lines;
+        highlightedLines are 1-based indices WITHIN your snippet, not the editor. Use [] for a new
+        component or ordinary continuation; highlight only corrections to code the user already wrote.
+        Explain the correction
+        in the short hint. If the overall approach is invalid, explain the problem as a hint and set
+        codeSnippet to null; do not silently replace the solution.
+        If current code is not visible or capture failed, use the known problem and language to show
+        the first small logical component. Do not insist the user move a window. Do not pretend to
+        know unseen names or structure; label assumptions briefly in placement. If the problem itself
+        is unknown, give a short hint asking what is being solved instead of inventing a problem.
+        Code is independent of explanations. Never execute or insert code yourself.
+        """
+
         private static let explanationGuidance = """
 
         # Explain when understanding is missing
@@ -109,9 +133,10 @@ extension JarvisPrompts {
         ///   clean up: `promptAddendum` reads its bundled file on every access and this builder
         ///   runs per coaching turn, so the pre-resolved string keeps that a single file read
         ///   instead of one per turn.
-        public static func system(prepMaterial: Bool, formatAddendum: String, explanationsEnabled: Bool = true) -> String {
+        public static func system(prepMaterial: Bool, formatAddendum: String, explanationsEnabled: Bool = true, codeEnabled: Bool = false) -> String {
             (prepMaterial ? system + prepMaterialAddendum : system)
-                + (explanationsEnabled ? explanationGuidance : "") + formatAddendum
+                + (explanationsEnabled ? explanationGuidance : "")
+                + (codeEnabled ? codeGuidance : "") + formatAddendum
         }
 
         /// Appended by `system(prepMaterial:formatAddendum:)` only when `search_prep_notes` is
@@ -179,6 +204,15 @@ extension JarvisPrompts {
                 + "plain language with a small example and a concrete starting point. Put the fuller "
                 + "explanation in explanation and a short standalone summary in lines. If already "
                 + "explained, change the framing or simplify; do not just repeat the last hint."
+        }
+
+        static func manualCodeTrigger(timestamp: String) -> String {
+            "[\(timestamp)] The user pressed the Show code shortcut for THIS request. Show the next small "
+                + "logical snippet for their current sticking point, aligned with their existing code. "
+                + "Use codeSnippet with language, placement, raw code, and highlightedLines for local corrections. "
+                + "Keep lines as a short placement or correction hint. Do not show the full solution. "
+                + "If no current code is visible, provide the first component using known problem context. "
+                + "If the overall approach is invalid, give its corrective hint and leave codeSnippet null."
         }
 
         static func recognizedText(_ text: String) -> String {

--- a/Sources/JarvisCore/Triggers/Trigger.swift
+++ b/Sources/JarvisCore/Triggers/Trigger.swift
@@ -8,8 +8,10 @@ public enum TriggerReason: Sendable, Equatable {
     case manualHint                           // capture + force a hint, one trip
     case manualExplanation                    // capture + explain the current confusion
 
+    case manualCode                           // capture + next logical snippet, hotkey only
+
     public var isManual: Bool {
-        self == .manualHint || self == .manualExplanation
+        self == .manualHint || self == .manualExplanation || self == .manualCode
     }
 }
 
@@ -41,6 +43,8 @@ public struct TriggerContext: Sendable {
             return JarvisPrompts.Coach.manualHintTrigger(timestamp: stamp)
         case .manualExplanation:
             return JarvisPrompts.Coach.manualExplanationTrigger(timestamp: stamp)
+        case .manualCode:
+            return JarvisPrompts.Coach.manualCodeTrigger(timestamp: stamp)
         }
     }
 

--- a/Sources/JarvisOverlay/CodeSnippetDocumentView.swift
+++ b/Sources/JarvisOverlay/CodeSnippetDocumentView.swift
@@ -1,0 +1,48 @@
+import AppKit
+import JarvisCore
+
+/// Placement wraps at the viewport width while code retains its original line breaks and indentation.
+@MainActor
+final class CodeSnippetDocumentView: NSView {
+    private let placement = NSTextField(wrappingLabelWithString: "")
+    private let textView = NSTextView()
+    override var isFlipped: Bool { true }
+    var codeText: NSAttributedString { textView.attributedString() }
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        placement.textColor = .white
+        placement.font = .systemFont(ofSize: 12, weight: .medium)
+        textView.isEditable = false
+        textView.isSelectable = false
+        textView.drawsBackground = false
+        textView.textContainerInset = NSSize(width: 12, height: 8)
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = true
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = textView.maxSize
+        textView.setAccessibilityLabel("Code snippet")
+        addSubview(placement)
+        addSubview(textView)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    func show(_ snippet: CodeSnippet, fontSize: CGFloat) {
+        placement.stringValue = snippet.placement
+        textView.textStorage?.setAttributedString(CodeSnippetFormatting.render(snippet, fontSize: fontSize))
+        textView.sizeToFit()
+    }
+
+    func fit(viewportWidth: CGFloat) {
+        let width = max(1, viewportWidth - 28)
+        let height = max(18, ceil(placement.attributedStringValue.boundingRect(
+            with: NSSize(width: width, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading]).height))
+        placement.frame = NSRect(x: 14, y: 4, width: width, height: height)
+        textView.setFrameOrigin(NSPoint(x: 0, y: height + 6))
+        setFrameSize(NSSize(width: max(viewportWidth, textView.frame.width),
+            height: textView.frame.maxY))
+    }
+}

--- a/Sources/JarvisOverlay/CodeSnippetFormatting.swift
+++ b/Sources/JarvisOverlay/CodeSnippetFormatting.swift
@@ -1,0 +1,44 @@
+import AppKit
+import JarvisCore
+
+/// Lightweight lexical accents only: unknown languages remain fully readable plain code.
+@MainActor
+enum CodeSnippetFormatting {
+    static func render(_ snippet: CodeSnippet, fontSize: CGFloat) -> NSAttributedString {
+        let result = NSMutableAttributedString(string: snippet.code, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular),
+            .foregroundColor: NSColor(white: 0.94, alpha: 1),
+        ])
+        let source = snippet.code as NSString
+        let fullRange = NSRange(location: 0, length: source.length)
+        // A single ordered lexer prevents keywords inside strings or comments being recolored.
+        // Keep quoted tokens on one line: a lifetime or truncated string must not color later code.
+        let pattern = #"(?m)(//[^\n]*|#[^\n]*)|("(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*')|\b(func|def|let|var|const|return|if|else|for|while|in|class|struct|enum|guard|import|from|public|private|static|new|nil|null|true|false|None|True|False|async|await|throw|try|catch|break|continue)\b|\b\d+(?:\.\d+)?\b"#
+        if let lexer = try? NSRegularExpression(pattern: pattern) {
+            for match in lexer.matches(in: snippet.code, range: fullRange) {
+                let color: NSColor
+                if match.range(at: 1).location != NSNotFound {
+                    color = NSColor(srgbRed: 0.62, green: 0.74, blue: 0.68, alpha: 1)
+                } else if match.range(at: 2).location != NSNotFound {
+                    color = NSColor(srgbRed: 0.69, green: 0.88, blue: 0.65, alpha: 1)
+                } else if match.range(at: 3).location != NSNotFound {
+                    color = NSColor(srgbRed: 0.82, green: 0.72, blue: 1, alpha: 1)
+                } else {
+                    color = NSColor(srgbRed: 1, green: 0.81, blue: 0.57, alpha: 1)
+                }
+                result.addAttribute(.foregroundColor, value: color, range: match.range)
+            }
+        }
+        var offset = 0
+        for (index, line) in snippet.code.components(separatedBy: "\n").enumerated() {
+            let count = (line as NSString).length
+            if snippet.highlightedLines.contains(index + 1), count > 0 {
+                result.addAttribute(.backgroundColor,
+                    value: NSColor(srgbRed: 0.25, green: 0.18, blue: 0.07, alpha: 1),
+                    range: NSRange(location: offset, length: count))
+            }
+            offset += count + 1
+        }
+        return result
+    }
+}

--- a/Sources/JarvisOverlay/CodeSnippetView.swift
+++ b/Sources/JarvisOverlay/CodeSnippetView.swift
@@ -1,0 +1,74 @@
+import AppKit
+import JarvisCore
+
+/// Independent scrolling keeps new coaching history from moving the code under the user's eyes.
+@MainActor
+final class CodeSnippetView: NSView {
+    static let background = NSColor(srgbRed: 0.055, green: 0.07, blue: 0.10, alpha: 1)
+    let dismissButton = NSButton(title: "Dismiss", target: nil, action: nil)
+    var onDismiss: (() -> Void)?
+    private let title = NSTextField(labelWithString: "")
+    private let scroll = NSScrollView()
+    private let emptyLabel = NSTextField(wrappingLabelWithString: "Code for your next coding hint will appear here.")
+    private let document = CodeSnippetDocumentView(frame: .zero)
+    private(set) var snippet: CodeSnippet?
+    var codeText: NSAttributedString { document.codeText }
+
+    override init(frame: NSRect) {
+        super.init(frame: frame)
+        wantsLayer = true
+        // This opaque backing deliberately does not inherit the history's configurable opacity.
+        layer?.backgroundColor = Self.background.cgColor
+        title.textColor = NSColor(white: 0.86, alpha: 1)
+        title.font = .systemFont(ofSize: 11, weight: .semibold)
+        dismissButton.bezelStyle = .inline
+        dismissButton.contentTintColor = .white
+        // Inline button titles otherwise inherit dark text from a light system appearance.
+        dismissButton.attributedTitle = NSAttributedString(string: "Dismiss", attributes: [
+            .foregroundColor: NSColor(white: 0.85, alpha: 1),
+            .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+        ])
+        dismissButton.target = self
+        dismissButton.action = #selector(dismiss)
+        dismissButton.setAccessibilityLabel("Dismiss code snippet")
+        scroll.hasVerticalScroller = true
+        scroll.hasHorizontalScroller = true
+        scroll.scrollerStyle = .overlay
+        scroll.autohidesScrollers = true
+        scroll.drawsBackground = false
+        scroll.documentView = document
+        emptyLabel.textColor = NSColor(white: 0.8, alpha: 1)
+        emptyLabel.font = .systemFont(ofSize: 13)
+        for view in [title, dismissButton, scroll, emptyLabel] { addSubview(view) }
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func layout() {
+        super.layout()
+        title.frame = NSRect(x: 14, y: bounds.height - 25, width: max(0, bounds.width - 100), height: 18)
+        dismissButton.frame = NSRect(x: bounds.width - 78, y: bounds.height - 27, width: 66, height: 22)
+        scroll.frame = NSRect(x: 0, y: 0, width: bounds.width, height: max(0, bounds.height - 28))
+        emptyLabel.frame = NSRect(x: 14, y: 12, width: max(0, bounds.width - 28), height: max(0, bounds.height - 44))
+        document.fit(viewportWidth: scroll.contentSize.width)
+    }
+
+    func show(_ snippet: CodeSnippet?, fontSize: CGFloat, enabled: Bool = true) {
+        let changed = self.snippet != snippet
+        self.snippet = snippet
+        isHidden = !enabled
+        emptyLabel.isHidden = snippet != nil
+        scroll.isHidden = snippet == nil
+        dismissButton.isHidden = snippet == nil
+        title.stringValue = "CODE"
+        needsLayout = true
+        guard let snippet else { return }
+        title.stringValue = snippet.language.isEmpty ? "CODE" : "CODE · \(snippet.language)"
+        document.show(snippet, fontSize: fontSize)
+        document.fit(viewportWidth: max(1, bounds.width))
+        if changed { scroll.contentView.scroll(to: .zero) }
+        needsLayout = true
+    }
+
+    @objc private func dismiss() { onDismiss?() }
+}

--- a/Sources/JarvisOverlay/OverlayBoxPanel.swift
+++ b/Sources/JarvisOverlay/OverlayBoxPanel.swift
@@ -26,6 +26,11 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     /// The layer-backed, opaque rounded fill behind the text — its alpha is the box's opacity.
     private let box: ResizeReportingView
     private let textView: NSTextView
+    private let codeView = CodeSnippetView(frame: .zero)
+    private var codeSnippet: CodeSnippet?
+    private var codeEnabled = Defaults.Code.enabled
+    private static let sampleCode = CodeSnippet(language: "swift", placement: "At the start of solve",
+        code: "guard !items.isEmpty else { return nil }\nlet first = items[0]")
     /// The chrome strip across the top: collapse, the name, clear.
     private let header: OverlayBoxHeaderView
     /// The scrolling log under the header. Held so the header's height can be taken off it on every
@@ -172,10 +177,18 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
         resizeAffordance = affordance
 
         box.addSubview(scroll)
+        box.addSubview(codeView)
+        codeView.isHidden = true
         box.addSubview(header)
         box.addSubview(affordance)   // topmost, so its tracking area sees the whole box
         panel.contentView = box
         super.init()
+        codeView.onDismiss = { [weak self] in
+            guard let self else { return }
+            if self.display == .log { self.codeSnippet = nil }
+            self.codeView.show(nil, fontSize: self.fontSize, enabled: self.codeEnabled && !self.isCollapsed)
+            self.layoutCode()
+        }
         header.collapseButton.target = self
         header.collapseButton.action = #selector(toggleCollapsed)
         header.clearButton.target = self
@@ -274,6 +287,35 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
         }
     }
 
+    public func deliverCodeSnippet(_ snippet: CodeSnippet?) -> CodeSnippet? {
+        codeSnippet = acceptsDetail && codeEnabled ? snippet : nil
+        refreshCode()
+        if panel.isVisible { reassertCaptureExclusion() }
+        return codeSnippet
+    }
+
+    public func setCodeEnabled(_ enabled: Bool) {
+        codeEnabled = enabled
+        if !enabled { codeSnippet = nil }
+        refreshCode()
+    }
+
+    private func refreshCode() {
+        codeView.show(codeEnabled ? (display == .sample ? Self.sampleCode : codeSnippet) : nil,
+                      fontSize: fontSize, enabled: codeEnabled && !isCollapsed)
+        layoutCode()
+    }
+
+    private func layoutCode() {
+        let available = max(0, box.bounds.height - chrome.height)
+        let preferred = min(box.bounds.height * 0.45,
+            76 + CGFloat(codeView.snippet?.code.components(separatedBy: "\n").count ?? 0) * (fontSize + 4))
+        // Preserve the header and one history line even at the minimum expanded size.
+        let height = codeView.isHidden ? 0 : min(max(0, available - 44), max(96, preferred))
+        codeView.frame = NSRect(x: 0, y: 0, width: box.bounds.width, height: height)
+        scroll.frame = NSRect(x: 0, y: height, width: box.bounds.width, height: max(0, available - height))
+    }
+
     public func deliver(_ lines: [String], perLineSeconds: [TimeInterval],
                         diagram: DiagramHint?, explanation: String?) -> String? {
         let summary = lines.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -350,6 +392,7 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
         // The sample is not the user's log, so it offers nothing to erase: the clear button stays away
         // rather than sitting there as a control that does nothing.
         header.setHasContent(display == .log && !entries.isEmpty)
+        refreshCode()
     }
 
     // MARK: - Visibility (the Settings toggle, gated on a live session)
@@ -357,6 +400,7 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     /// Wipe the log. Called on each fresh Start so the box shows only the current conversation,
     /// matching how the session rotates.
     public func clear() {
+        codeSnippet = nil
         entries.removeAll()
         renderDisplay()
     }
@@ -385,10 +429,12 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     /// user collapsed it during, not to the next one.
     public func setSessionLive(_ live: Bool) {
         isSessionLive = live
+        if !live { codeSnippet = nil }
         // Start takes the sample down and Stop can put it back, both without Settings saying anything:
         // whether the preview stands in is derived, not commanded.
         applyDisplay()
         if live { setCollapsed(false) }
+        refreshCode()
         applyVisibility()
     }
 
@@ -478,6 +524,9 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     // MARK: - Test hooks (internal; reached via `@testable import JarvisOverlay`)
 
     /// The panel's current capture-sharing type. `.none` means excluded from screen capture.
+    var currentCodeSnippet: CodeSnippet? { codeView.snippet }
+    var currentCodeHeight: CGFloat { codeView.frame.height }
+
     var currentSharingType: NSWindow.SharingType { panel.sharingType }
 
     /// Number of logged responses — lets tests assert append/clear behavior.

--- a/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainClientTests.swift
@@ -446,7 +446,7 @@ import JarvisCore
             messages: [.system("coach prompt"), .user("help")],
             tools: coachTools,
             toolChoice: .force(speakTool.name))
-        guard case .speak(_, let lines, nil, nil) = response.toolCalls.first else {
+        guard case .speak(_, let lines, nil, nil, nil) = response.toolCalls.first else {
             Issue.record("expected forced speak")
             return
         }
@@ -473,7 +473,7 @@ import JarvisCore
         ] {
             let response = client.parse(
                 reply: reply, tools: coachTools, toolChoice: .required)
-            guard case .speak(_, let lines, nil, nil) = response.toolCalls.first else {
+            guard case .speak(_, let lines, nil, nil, nil) = response.toolCalls.first else {
                 Issue.record("expected speak for \(reply)")
                 continue
             }

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -215,6 +215,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                             screen: ScreenCapturing = FakeScreen(),
                             overlay: OverlayRendering = FakeOverlay(),
                             clock: Clock, config: Config = .default,
+                            codeEnabled: Bool = false,
                             coachingAttempts: (any CoachingAttemptAuditing)? = nil,
                             automaticAttemptDelay: @escaping CoachDriver.AutomaticAttemptDelay = { _ in },
                             onBrainFailure: (@MainActor @Sendable (BrainFailure) -> Void)? = nil,
@@ -234,6 +235,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
             config: config, transcript: transcript,
             route: route, screen: screen, overlay: overlay, clock: clock,
             coachingAttempts: coachingAttempts,
+            plan: SessionPlan(revision: 0, screen: SessionPlan.default.screen, codeEnabled: codeEnabled),
             automaticAttemptDelay: automaticAttemptDelay,
             activity: activity,
             prepMaterial: prepMaterial
@@ -1995,13 +1997,13 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         })
     }
 
-    @Test(arguments: [TriggerReason.manualHint, .manualExplanation])
+    @Test(arguments: [TriggerReason.manualHint, .manualExplanation, .manualCode])
     func manualHintWakesFailedAttemptEvenWhileSpeechIsUnsettled(_ reason: TriggerReason) async {
         let gate = AsyncGate()
         let brain = GatedFailureThenSpeakingBrain(gate: gate)
         let (driver, transcript) = makeDriver(
             brain: brain,
-            clock: ManualClock())
+            clock: ManualClock(), codeEnabled: true)
         transcript.append(.init(speaker: .me, text: "first attempt", at: 0))
 
         async let outcome = driver.handleTrigger(.turnEnd)
@@ -2012,17 +2014,18 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 
         #expect(await outcome == .spoke)
         #expect(brain.calls.count == 2)
+        #expect(brain.calls.last?.first?.text?.contains("# Code accompanies") == true)
         driver.updateTranscriptionWork(false, for: .them)
     }
 
-    @Test(arguments: [TriggerReason.manualHint, .manualExplanation])
+    @Test(arguments: [TriggerReason.manualHint, .manualExplanation, .manualCode])
     func automaticRetryOfFailedManualHintWaitsForUnsettledSpeech(_ reason: TriggerReason) async {
         let gate = AsyncGate()
         let delayGate = AsyncGate()
         let brain = GatedFailureThenSpeakingBrain(gate: gate)
         let (driver, _) = makeDriver(
             brain: brain,
-            clock: ManualClock(),
+            clock: ManualClock(), codeEnabled: true,
             automaticAttemptDelay: { _ in await delayGate.enter() })
         driver.updateTranscriptionWork(true, for: .them)
 
@@ -2049,6 +2052,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         driver.updateTranscriptionWork(false, for: .them)
         #expect(await outcome.value == .spoke)
         #expect(brain.calls.count == 2)
+        #expect(brain.calls.last?.first?.text?.contains("# Code accompanies") == true)
     }
 
     @Test func automaticManualHintAttemptDoesNotRecapture() async {

--- a/Tests/JarvisCoreTests/Coach/CodeRequestTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CodeRequestTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct CodeRequestTests {
+    @Test(arguments: [TriggerReason.turnEnd, .manualHint, .manualExplanation])
+    func disabledTriggersCannotDeliverCode(_ reason: TriggerReason) async throws {
+        let snippet = try #require(CodeSnippet(language: "Python", placement: "Inside your loop", code: "seen[ch] = right"))
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["Remember this position."], codeSnippet: snippet)])])
+        let transcript = RollingTranscript()
+        transcript.append(.init(speaker: .me, text: "I am stuck with the loop", at: 0))
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, transcript, sink)
+        #expect(await driver.handleTrigger(reason) == .spoke)
+        #expect(sink.codeUpdates == [nil])
+        #expect(sink.lines == ["Remember this position."])
+    }
+
+    @Test func manualCodeUsesCurrentContextAndWorksWithExplanationsDisabled() async throws {
+        let snippet = try #require(CodeSnippet(language: "Python", placement: "Inside your loop", code: "seen[ch] = right"))
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "s", lines: ["Remember this position."], codeSnippet: snippet)]),
+            .init(toolCalls: [.speak(callId: "s2", lines: ["Your approach needs a different data structure."])])
+        ])
+        let transcript = RollingTranscript()
+        transcript.append(.init(speaker: .them, text: "Find the longest substring without repeats", at: 0))
+        transcript.append(.init(speaker: .me, text: "I used seen and left, but got stuck in the loop", at: 1))
+        let sink = CodeRequestSink()
+        let screen = FakeScreen()
+        let driver = makeDriver(brain, transcript, sink, screen: screen, codeEnabled: true, explanationsEnabled: false)
+        #expect(await driver.handleTrigger(.manualCode) == .spoke)
+        #expect(sink.codeUpdates.count == 1)
+        #expect((sink.codeUpdates.last ?? nil) == snippet)
+        #expect(screen.captureCount == 1)
+        #expect(brain.toolChoices.last == .force("speak"))
+        #expect(brain.calls[0].contains { $0.imageBase64JPEG != nil })
+        #expect(brain.calls[0].contains { $0.text?.contains("seen and left") == true })
+        #expect(await driver.handleTrigger(.manualCode) == .spoke)
+        #expect(sink.codeUpdates.count == 2)
+        #expect((sink.codeUpdates.last ?? nil) == nil)
+    }
+
+    @Test(arguments: [TriggerReason.turnEnd, .manualHint, .manualExplanation])
+    func enabledHintsDeliverMatchingCodeAndClearOnNextHint(_ reason: TriggerReason) async throws {
+        let snippet = try #require(CodeSnippet(language: "Python", placement: "In loop", code: "seen[ch] = right"))
+        let brain = ScriptedBrain(script: [
+            .init(toolCalls: [.speak(callId: "one", lines: ["Remember the position"], codeSnippet: snippet)]),
+            .init(toolCalls: [.speak(callId: "two", lines: ["Reconsider the approach"])])])
+        let transcript = RollingTranscript()
+        transcript.append(.init(speaker: .me, text: "I am stuck implementing the loop", at: 0))
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, transcript, sink, codeEnabled: true)
+        #expect(await driver.handleTrigger(reason) == .spoke)
+        #expect(sink.codeUpdates.count == 1)
+        #expect((sink.codeUpdates.last ?? nil) == snippet)
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        #expect(sink.codeUpdates.count == 2)
+        #expect((sink.codeUpdates.last ?? nil) == nil)
+    }
+
+    @Test(arguments: [TriggerReason.manualHint, .manualCode])
+    func generalTechnicalSessionsCanDeliverCode(_ reason: TriggerReason) async throws {
+        let code = try #require(CodeSnippet(language: "Python", placement: "Start", code: "seen = {}"))
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["Initialize state"], codeSnippet: code)])])
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, RollingTranscript(), sink, format: .generalTechnical, codeEnabled: true)
+        #expect(await driver.handleTrigger(reason) == .spoke)
+        #expect(sink.codeUpdates == [code])
+        #expect(brain.calls.count == 1)
+    }
+
+    @Test func codePreferenceDefaultsOffAndPersistsIndependently() {
+        let suite = "CodePreferencesTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let code = CodePreferences(defaults: defaults)
+        #expect(!code.isEnabled)
+        code.isEnabled = true
+        #expect(CodePreferences(defaults: defaults).isEnabled)
+        ExplanationPreferences(defaults: defaults).isEnabled = false
+        #expect(code.isEnabled)
+        code.isEnabled = false
+        #expect(!CodePreferences(defaults: defaults).isEnabled)
+    }
+
+    @Test(arguments: [true, false])
+    func codeCapabilityAndPromptRemainFixedAcrossPlanEdits(_ enabled: Bool) async throws {
+        let snippet = try #require(CodeSnippet(language: "Python", placement: "Start", code: "seen = {}"))
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["Initialize state"], codeSnippet: snippet)])])
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, RollingTranscript(), sink, codeEnabled: enabled)
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        driver.updatePlan(SessionPlan(revision: 1, screen: SessionPlan.default.screen, codeEnabled: !enabled))
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        #expect(sink.codeUpdates == [enabled ? snippet : nil, enabled ? snippet : nil])
+        #expect(brain.calls[0].first?.text == brain.calls[1].first?.text)
+        #expect(brain.calls[0].first?.text?.contains("# Code accompanies") == enabled)
+        let restarted = makeDriver(brain, RollingTranscript(), sink, codeEnabled: !enabled)
+        #expect(await restarted.handleTrigger(.manualHint) == .spoke)
+        #expect((sink.codeUpdates.last ?? nil) == (enabled ? nil : snippet))
+    }
+
+    @Test(arguments: [InterviewFormat.behavioral, .systemDesign])
+    func enabledNonCodingHintsStillSuppressCode(_ format: InterviewFormat) async throws {
+        let code = try #require(CodeSnippet(language: "Python", placement: "Start", code: "seen = {}"))
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "one", lines: ["Consider the requirements"], codeSnippet: code)])])
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, RollingTranscript(), sink, format: format, codeEnabled: true)
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        #expect(sink.codeUpdates == [nil])
+    }
+
+    @Test(arguments: [true, false])
+    func deliveredHistoryKeepsOnlyEnabledCodeWhenExplanationsAreOff(_ enabled: Bool) async throws {
+        let args = #"{"lines":["Initialize state"],"explanation":"Hidden detail","codeSnippet":{"language":"Python","placement":"Start","code":"seen = {}","highlightedLines":[]}}"#
+        let response = BrainResponse(toolCalls: [try #require(ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON: args))],
+            rawToolCalls: [.init(id: "s", name: "speak", argumentsJSON: args)])
+        let brain = ScriptedBrain(script: [response, response])
+        let driver = makeDriver(brain, RollingTranscript(), CodeRequestSink(), codeEnabled: enabled, explanationsEnabled: false)
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        let call = try #require(brain.calls.last?.flatMap { $0.toolCalls ?? [] }.first { $0.name == "speak" })
+        let object = try #require(JSONSerialization.jsonObject(with: Data(call.argumentsJSON.utf8)) as? [String: Any])
+        #expect(object["explanation"] is NSNull)
+        if enabled { #expect((object["codeSnippet"] as? [String: Any])?["code"] as? String == "seen = {}") }
+        else { #expect(object["codeSnippet"] is NSNull) }
+    }
+
+    @Test @MainActor func hidingBoxDuringCodeRequestScrubsHistory() async throws {
+        let args = #"{"lines":["Initialize state"],"codeSnippet":{"language":"Python","placement":"Start","code":"seen = {}","highlightedLines":[]}}"#
+        let response = BrainResponse(toolCalls: [try #require(ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON: args))],
+            rawToolCalls: [.init(id: "s", name: "speak", argumentsJSON: args)])
+        let gate = AsyncGate()
+        let brain = GatedBrain(gate: gate, response: response)
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, RollingTranscript(), sink, codeEnabled: true)
+        let task = Task { await driver.handleTrigger(.manualCode) }
+        await gate.waitUntilEntered()
+        sink.acceptsDetail = false
+        await gate.release()
+        #expect(await task.value == .spoke)
+        #expect(sink.codeUpdates == [nil])
+        sink.acceptsDetail = true
+        #expect(await driver.handleTrigger(.manualHint) == .spoke)
+        #expect((sink.codeUpdates.last ?? nil)?.code == "seen = {}")
+        let call = try #require(brain.calls.last?.flatMap { $0.toolCalls ?? [] }.first { $0.name == "speak" })
+        let object = try #require(JSONSerialization.jsonObject(with: Data(call.argumentsJSON.utf8)) as? [String: Any])
+        #expect(object["codeSnippet"] is NSNull)
+    }
+
+    @Test func malformedCodeRetainsUsefulHint() throws {
+        let payloads = ["null", "42", #"{"language":"Python","placement":"In loop","code":" ","highlightedLines":[]}"#,
+            #"{"language":"Python","placement":"In loop","code":"x = 1","highlightedLines":"bad"}"#]
+        for payload in payloads {
+            let call = ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON: "{\"lines\":[\"Continue here\"],\"codeSnippet\":\(payload)}")
+            guard case .speak(_, let lines, _, _, let snippet) = call else { Issue.record("Lost the hint"); continue }
+            #expect(lines == ["Continue here"])
+            #expect(snippet == nil)
+        }
+    }
+
+    @Test func codeHotkeyPersistsIndependently() {
+        let suite = "CodeRequestTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let code = HotkeyPreferences(defaults: defaults, shortcut: .showCode)
+        let hint = HotkeyPreferences(defaults: defaults, shortcut: .hint)
+        let explain = HotkeyPreferences(defaults: defaults, shortcut: .explainMore)
+        let saved = HotkeyCombination(keyCode: 12, modifiers: [.command, .shift])
+        code.combination = saved
+        #expect(HotkeyPreferences(defaults: defaults, shortcut: .showCode).combination == saved)
+        #expect(hint.combination == Defaults.Hotkey.combination)
+        #expect(explain.combination == Defaults.Hotkey.explanationCombination)
+    }
+
+    @Test func validCodeParsingPreservesIndentationAndRejectsOversizedComponent() throws {
+        let snippet: [String: Any] = ["language": "Python", "placement": "Inside your loop",
+            "code": "    if ch in seen:\n        left = max(left, seen[ch] + 1)", "highlightedLines": [2]]
+        for oversized in [false, true] {
+            var value = snippet
+            if oversized { value["code"] = Array(repeating: "x = 1", count: 13).joined(separator: "\n") }
+            let json = try JSONSerialization.data(withJSONObject: ["lines": ["Keep the left edge moving forward."], "codeSnippet": value])
+            let call = ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON: String(decoding: json, as: UTF8.self))
+            guard case .speak(_, let lines, _, _, let code) = call else { Issue.record("Expected hint"); continue }
+            #expect(lines.count == 1)
+            if oversized { #expect(code == nil) }
+            else {
+                #expect(code?.code.hasPrefix("    if") == true)
+                #expect(code?.highlightedLines == [2])
+            }
+        }
+    }
+
+    @Test func captureFailureStillAllowsFirstComponentFromKnownContext() async throws {
+        let snippet = try #require(CodeSnippet(language: "Python", placement: "Start window state", code: "seen = {}\nleft = 0"))
+        let brain = ScriptedBrain(script: [.init(toolCalls: [.speak(callId: "s", lines: ["Start with window state."], codeSnippet: snippet)])])
+        let transcript = RollingTranscript()
+        transcript.append(.init(speaker: .them, text: "Find the longest substring without repeats", at: 0))
+        let sink = CodeRequestSink()
+        let driver = makeDriver(brain, transcript, sink, screen: MissingCodeScreen(), codeEnabled: true)
+        #expect(await driver.handleTrigger(.manualCode) == .spoke)
+        #expect((sink.codeUpdates.last ?? nil) == snippet)
+        #expect(brain.calls[0].contains { $0.text?.contains("failed") == true })
+    }
+
+    private func makeDriver(_ brain: BrainClient, _ transcript: RollingTranscript, _ sink: OverlayRendering,
+                            screen: ScreenCapturing = FakeScreen(), format: InterviewFormat? = nil,
+                            codeEnabled: Bool = false, explanationsEnabled: Bool = true,
+                            activity: (any ActivityEventRecording)? = nil) -> CoachDriver {
+        let target = BrainTarget(provider: .openAI, modelID: BrainModelCatalog.defaultModel(for: .openAI).id)
+        return CoachDriver(config: .default, transcript: transcript,
+            route: .init(targets: [.init(target: target, brain: brain)]),
+            screen: screen, overlay: sink, clock: ManualClock(now: 100),
+            plan: SessionPlan(revision: 0, screen: SessionPlan.default.screen,
+                              explanationsEnabled: explanationsEnabled, codeEnabled: codeEnabled),
+            activity: activity, interviewFormat: format)
+    }
+}
+
+private final class CodeRequestSink: OverlayRendering {
+    @MainActor var acceptsDetail = true
+    @MainActor func deliverCodeSnippet(_ snippet: CodeSnippet?) -> CodeSnippet? {
+        let code = acceptsDetail ? snippet : nil
+        codeUpdates.append(code)
+        return code
+    }
+    var codeUpdates: [CodeSnippet?] = []
+    var lines: [String] = []
+    func render(_ lines: [String], perLineSeconds: [TimeInterval]) { self.lines = lines }
+}
+
+private final class MissingCodeScreen: ScreenCapturing, Sendable {
+    func capture(_ selection: ScreenCaptureSelection) -> ScreenSnapshot? { nil }
+    func cancelCapture() {}
+}

--- a/Tests/JarvisCoreTests/Coach/ExplainMoreTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ExplainMoreTests.swift
@@ -6,7 +6,7 @@ import Testing
     @Test func parserKeepsExplanationAndIgnoresMalformedOptionalDetail() throws {
         let call = ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON:
             #"{"lines":["Keep a moving range."],"explanation":"  Grow the right edge.\n\nMove the left edge past a repeat.  "}"#)
-        guard case .speak(_, let lines, _, let explanation) = call else {
+        guard case .speak(_, let lines, _, let explanation, _) = call else {
             Issue.record("Expected a speak call"); return
         }
         #expect(lines == ["Keep a moving range."])
@@ -14,7 +14,7 @@ import Testing
         for detail in ["null", "42", "\"   \""] {
             let call = ToolInvocation.parse(callId: "s", name: "speak", argumentsJSON:
                 "{\"lines\":[\"Still useful\"],\"explanation\":\(detail)}")
-            guard case .speak(_, let lines, _, let explanation) = call else {
+            guard case .speak(_, let lines, _, let explanation, _) = call else {
                 Issue.record("Optional detail must not discard a valid hint"); continue
             }
             #expect(lines == ["Still useful"])
@@ -78,14 +78,14 @@ import Testing
         #expect(brain.calls[0].contains { $0.text?.contains("capture") == true && $0.text?.contains("failed") == true })
     }
 
-    @Test(arguments: [TriggerReason.manualHint, .manualExplanation])
+    @Test(arguments: [TriggerReason.manualHint, .manualExplanation, .manualCode])
     func latestManualIntentSurvivesNaturalWakeWhileBusy(_ latest: TriggerReason) async throws {
         let gate = AsyncGate()
         let brain = GatedBrain(gate: gate, response: .init(toolCalls: [.speak(callId: "s", lines: ["Continue."])]))
         let transcript = RollingTranscript()
         transcript.append(.init(speaker: .me, text: "Let's work through this problem", at: 0))
         let screen = FakeScreen()
-        let driver = makeDriver(brain: brain, transcript: transcript, screen: screen, overlay: FakeOverlay())
+        let driver = makeDriver(brain: brain, transcript: transcript, screen: screen, overlay: FakeOverlay(), codeEnabled: true)
         let task = Task { await driver.handleTrigger(.turnEnd) }
         await gate.waitUntilEntered()
         let first: TriggerReason = latest == .manualHint ? .manualExplanation : .manualHint
@@ -95,8 +95,10 @@ import Testing
         await gate.release()
         #expect(await task.value == .spoke)
         try #require(brain.calls.count == 2)
+        #expect(brain.calls.last?.first?.text?.contains("# Code accompanies") == true)
         let userText = brain.calls[1].filter { $0.role == .user }.compactMap(\.text).joined(separator: " ")
-        #expect(userText.contains(latest == .manualHint ? "hint shortcut" : "Explain more"))
+        let expected = latest == .manualCode ? "Show code" : (latest == .manualHint ? "hint shortcut" : "Explain more")
+        #expect(userText.contains(expected))
         #expect(!userText.contains(latest == .manualHint ? "Explain more" : "hint shortcut"))
         #expect(screen.captureCount == 1)
     }
@@ -198,12 +200,12 @@ import Testing
     }
 
     private func makeDriver(brain: BrainClient, transcript: RollingTranscript,
-                            screen: ScreenCapturing, overlay: OverlayRendering, explanationsEnabled: Bool = true) -> CoachDriver {
+                            screen: ScreenCapturing, overlay: OverlayRendering, explanationsEnabled: Bool = true, codeEnabled: Bool = false) -> CoachDriver {
         let target = BrainTarget(provider: .openAI, modelID: BrainModelCatalog.defaultModel(for: .openAI).id)
         return CoachDriver(config: .default, transcript: transcript,
             route: ConfiguredBrainRoute(targets: [.init(target: target, brain: brain)]),
             screen: screen, overlay: overlay, clock: ManualClock(now: 100),
-            plan: SessionPlan(revision: 0, screen: SessionPlan.default.screen, explanationsEnabled: explanationsEnabled))
+            plan: SessionPlan(revision: 0, screen: SessionPlan.default.screen, explanationsEnabled: explanationsEnabled, codeEnabled: codeEnabled))
     }
 }
 

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -2,6 +2,13 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct ToolDefsTests {
+    @Test(arguments: [speakTool, systemDesignSpeakTool])
+    func speakSchemaLeavesHighlightLimitToLocalValidation(_ tool: ToolDef) {
+        #expect(!tool.parametersJSON.contains("\"maxItems\""))
+        #expect(CodeSnippet(language: "swift", placement: "Inside solve", code: "return result",
+                            highlightedLines: Array(repeating: 1, count: 13)) == nil)
+    }
+
     @Test func toolNames() {
         #expect(captureScreenTool.name == "capture_screen")
         #expect(speakTool.name == "speak")
@@ -138,7 +145,7 @@ import Testing
     @Test func parseMapsEachCoachTool() {
         if case .captureScreen? = ToolInvocation.parse(callId: "c", name: "capture_screen", argumentsJSON: "{}") {} else { Issue.record("capture_screen") }
         if case .staySilent? = ToolInvocation.parse(callId: "c", name: "stay_silent", argumentsJSON: "{}") {} else { Issue.record("stay_silent") }
-        guard case .speak(_, let lines, nil, nil)? = ToolInvocation.parse(
+        guard case .speak(_, let lines, nil, nil, nil)? = ToolInvocation.parse(
             callId: "c", name: "speak", argumentsJSON: #"{"lines":["a","b"]}"#) else {
             Issue.record("speak"); return
         }

--- a/Tests/JarvisCoreTests/CodeSnippetTests.swift
+++ b/Tests/JarvisCoreTests/CodeSnippetTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import JarvisCore
+
+@Suite struct CodeSnippetTests {
+    @Test(arguments: ["\r", "\u{2028}"])
+    func rejectsUnsupportedNewlinesThatWouldBypassLineLimit(_ separator: String) {
+        let code = Array(repeating: "return value", count: 13).joined(separator: separator)
+        #expect(CodeSnippet(language: "swift", placement: "Inside solve", code: code) == nil)
+    }
+
+    @Test func trimsLeadingLinesWithoutMovingCorrectionHighlights() throws {
+        let snippet = try #require(CodeSnippet(language: "python", placement: "Loop",
+            code: "\n\nif ch in seen:\n    left = seen[ch] + 1\n", highlightedLines: [Int.min, 1, 3, 4, Int.max]))
+        #expect(snippet.highlightedLines == [1, 2])
+    }
+
+    @Test func rejectsTooManyHighlightIndicesBeforeNormalization() {
+        #expect(CodeSnippet(language: "swift", placement: "Start", code: "let x = 1",
+                            highlightedLines: Array(repeating: 1, count: 13)) == nil)
+        #expect(CodeSnippet(language: "swift", placement: "Start", code: "let x = 1",
+                            highlightedLines: Array(repeating: 1, count: 12))?.highlightedLines == [1])
+    }
+
+    @Test func preservesIndentationAndRejectsPartialOversizeCode() throws {
+        let snippet = try #require(CodeSnippet(language: " swift ", placement: " Inside solve ",
+            code: "\r\n  let value = 1\r\n    return value\r\n", highlightedLines: [-1, 1, 1, 3]))
+        #expect(snippet.code == "  let value = 1\n    return value")
+        #expect(snippet.highlightedLines == [2])
+        #expect(snippet.language == "swift")
+        #expect(snippet.placement == "Inside solve")
+        #expect(CodeSnippet(language: "", placement: "x", code: String(repeating: "x\n", count: 13)) == nil)
+        #expect(CodeSnippet(language: "", placement: "x", code: String(repeating: "x", count: 2401)) == nil)
+        #expect(CodeSnippet(language: "", placement: " ", code: "x") == nil)
+        #expect(CodeSnippet(language: "", placement: "x", code: " \n ") == nil)
+    }
+}

--- a/Tests/JarvisOverlayTests/CodeSnippetRenderingTests.swift
+++ b/Tests/JarvisOverlayTests/CodeSnippetRenderingTests.swift
@@ -1,0 +1,210 @@
+import AppKit
+import JarvisCore
+import Testing
+@testable import JarvisOverlay
+
+@Suite struct CodeSnippetRenderingTests {
+    @MainActor @Test(arguments: ["'", "\""])
+    func unmatchedQuotesDoNotColorAcrossLines(_ quote: String) throws {
+        let snippet = try #require(CodeSnippet(language: "text", placement: "Current component",
+            code: "prefix \(quote)a\nreturn value\nend \(quote)"))
+        let text = CodeSnippetFormatting.render(snippet, fontSize: 16)
+        let baseline = try #require(CodeSnippet(language: "text", placement: "Next step", code: "return value"))
+        let expected = CodeSnippetFormatting.render(baseline, fontSize: 16)
+        let keyword = (snippet.code as NSString).range(of: "return")
+        #expect((text.attribute(.foregroundColor, at: keyword.location, effectiveRange: nil) as? NSColor)
+            == (expected.attribute(.foregroundColor, at: 0, effectiveRange: nil) as? NSColor))
+    }
+
+    @MainActor @Test func deliveryAcceptsOnlyVisibleCodeAndExplanation() throws {
+        let box = OverlayBoxPanel()
+        let sink = BroadcastOverlay([box])
+        box.setCodeEnabled(true)
+        let snippet = try #require(CodeSnippet(language: "python", placement: "Start", code: "seen = {}"))
+        #expect(sink.deliverCodeSnippet(snippet) == nil)
+        #expect(sink.deliver(["Initialize"], perLineSeconds: [1], diagram: nil, explanation: "Keep state") == nil)
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        #expect(sink.deliverCodeSnippet(snippet) == snippet)
+        #expect(box.currentCodeSnippet == snippet)
+        #expect(sink.deliver(["Initialize"], perLineSeconds: [1], diagram: nil, explanation: "Keep state") == "Keep state")
+        box.setEnabled(false)
+        #expect(sink.deliverCodeSnippet(snippet) == nil)
+        #expect(box.currentCodeSnippet == nil)
+        #expect(sink.deliver(["Initialize"], perLineSeconds: [1], diagram: nil, explanation: "Keep state") == nil)
+        box.setSessionLive(false)
+    }
+
+    @MainActor @Test func codeDockCollapsesWithHeaderAndRestoresWithoutLosingSnippet() throws {
+        let box = OverlayBoxPanel()
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        box.setCodeEnabled(true)
+        let code = try #require(CodeSnippet(language: "Python", placement: "Start", code: "seen = {}"))
+        #expect(box.deliverCodeSnippet(code) == code)
+        box.clickCollapseButton()
+        #expect(box.isCollapsed)
+        #expect(box.currentCodeHeight == 0)
+        box.clickCollapseButton()
+        #expect(!box.isCollapsed)
+        #expect(box.currentCodeHeight > 0)
+        #expect(box.currentCodeSnippet == code)
+    }
+
+    @MainActor @Test func codeSettingControlsEmptyDockAndRejectsLateOutput() throws {
+        let box = OverlayBoxPanel()
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        #expect(box.currentCodeHeight == 0)
+        box.setCodeEnabled(true)
+        #expect(box.currentCodeHeight > 0)
+        #expect(box.currentCodeSnippet == nil)
+        let code = try #require(CodeSnippet(language: "Python", placement: "Start", code: "seen = {}"))
+        #expect(box.deliverCodeSnippet(code) == code)
+        // Settings turns off the live code dock together with the master box.
+        box.setEnabled(false)
+        box.setCodeEnabled(false)
+        box.setEnabled(true)
+        #expect(box.deliverCodeSnippet(code) == nil)
+        #expect(box.currentCodeHeight == 0)
+        #expect(box.currentCodeSnippet == nil)
+        box.setCodeEnabled(true)
+        #expect(box.currentCodeSnippet == nil)
+        #expect(box.currentCodeHeight > 0)
+    }
+
+    @MainActor @Test func hintsPreserveCodeAndPreviewCannotReplaceLiveDelivery() throws {
+        let box = OverlayBoxPanel()
+        box.setEnabled(true)
+        box.setCodeEnabled(true)
+        let snippet = try #require(CodeSnippet(language: "swift", placement: "Inside solve", code: "  return value"))
+        // Preview is only available while stopped; live delivery begins after it closes.
+        box.showAppearancePreview(true)
+        #expect(box.currentCodeSnippet != nil)
+        box.showAppearancePreview(false)
+        #expect(box.currentCodeSnippet == nil)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        #expect(BroadcastOverlay([box]).deliverCodeSnippet(snippet) == snippet)
+        _ = box.deliver(["Another hint"], perLineSeconds: [1], diagram: nil, explanation: nil)
+        #expect(box.currentCodeSnippet == snippet)
+        box.showAppearancePreview(true)
+        #expect(box.currentCodeSnippet == snippet)
+        box.showAppearancePreview(false)
+        #expect(box.currentCodeSnippet == snippet)
+        #expect(box.deliverCodeSnippet(nil) == nil)
+        #expect(box.currentCodeSnippet == nil)
+        #expect(box.deliverCodeSnippet(snippet) == snippet)
+        box.setSessionLive(false)
+        #expect(box.currentCodeSnippet == nil)
+        box.setSessionLive(true)
+        #expect(box.deliverCodeSnippet(snippet) == snippet)
+        box.clear()
+        #expect(box.currentCodeSnippet == nil)
+    }
+
+    @MainActor @Test func dockHeightIsBoundedAndDisabledBoxStaysHidden() throws {
+        let box = OverlayBoxPanel(contentSize: NSSize(width: 320, height: 240))
+        box.setCodeEnabled(true)
+        box.setFontSize(32)
+        let snippet = try #require(CodeSnippet(language: "python", placement: "Inside solve",
+            code: "for item in items:\n    if item:\n        result.append(item)\nreturn result"))
+        #expect(box.deliverCodeSnippet(snippet) == nil)
+        #expect(!box.isPanelVisible)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        #expect(box.deliverCodeSnippet(snippet) == nil)
+        #expect(!box.isPanelVisible)
+        box.setEnabled(true)
+        #expect(box.isPanelVisible)
+        #expect(box.deliverCodeSnippet(snippet) == snippet)
+        #expect(box.currentCodeHeight > 0)
+        #expect(box.currentCodeHeight <= 108)
+        box.setEnabled(false)
+        #expect(!box.isPanelVisible)
+    }
+
+    @MainActor @Test func minimumBoxKeepsCodeReadableAndPlacementScrollableWithoutTooltips() throws {
+        let box = OverlayBoxPanel(contentSize: NSSize(width: 240, height: 140))
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        box.setCodeEnabled(true)
+        let snippet = try #require(CodeSnippet(language: "swift",
+            placement: "Inside solve, after collecting the current window and before updating the result with the next candidate", code: "return result"))
+        #expect(box.deliverCodeSnippet(snippet) == snippet)
+        #expect(box.currentCodeHeight >= 70)
+        #expect(box.currentContentSize.height - box.currentCodeHeight - box.currentHeaderHeight >= 44)
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 240, height: 96))
+        dock.show(snippet, fontSize: 24)
+        dock.layoutSubtreeIfNeeded()
+        let scroll = try #require(dock.subviews.compactMap { $0 as? NSScrollView }.first)
+        #expect(scroll.contentSize.height >= 64)
+        let document = try #require(scroll.documentView)
+        let placement = try #require(document.subviews.compactMap { $0 as? NSTextField }.first)
+        #expect(placement.stringValue == snippet.placement)
+        #expect(placement.frame.height > 18)
+        #expect(placement.toolTip == nil)
+        #expect(document.frame.height > scroll.contentSize.height)
+    }
+
+    @MainActor @Test func normalDockShowsThreeLinesWithoutScrollingAndDismissHasContrast() throws {
+        let snippet = try #require(CodeSnippet(language: "swift", placement: "Inside solve",
+            code: "let next = value + 1\nresult.append(next)\nreturn result"))
+        let box = OverlayBoxPanel(contentSize: NSSize(width: 580, height: 420))
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        box.setCodeEnabled(true)
+        box.setFontSize(18)
+        #expect(box.deliverCodeSnippet(snippet) == snippet)
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 580, height: box.currentCodeHeight))
+        dock.show(snippet, fontSize: 18)
+        dock.layoutSubtreeIfNeeded()
+        let scroll = try #require(dock.subviews.compactMap { $0 as? NSScrollView }.first)
+        let document = try #require(scroll.documentView)
+        #expect(document.frame.height <= scroll.contentSize.height)
+        let foreground = try #require(dock.dismissButton.attributedTitle.attribute(
+            .foregroundColor, at: 0, effectiveRange: nil) as? NSColor)
+        #expect((luminance(foreground) + 0.05) / (luminance(CodeSnippetView.background) + 0.05) >= 4.5)
+    }
+
+    @MainActor @Test func syntaxForegroundMeetsContrastOnCodeAndCorrectionBackgrounds() throws {
+        let snippet = try #require(CodeSnippet(language: "swift", placement: "Inside solve",
+            code: "let n = 42 // count\nreturn \"value\"", highlightedLines: [1, 2]))
+        let text = CodeSnippetFormatting.render(snippet, fontSize: 16)
+        text.enumerateAttributes(in: NSRange(location: 0, length: text.length)) { attributes, _, _ in
+            let foreground = attributes[.foregroundColor] as! NSColor
+            let background = attributes[.backgroundColor] as? NSColor ?? CodeSnippetView.background
+            let ratio = (luminance(foreground) + 0.05) / (luminance(background) + 0.05)
+            #expect(ratio >= 4.5)
+        }
+    }
+
+    @MainActor @Test func codeFitsSeparateAreaAndRetainsOpaqueReadableFormatting() throws {
+        let snippet = try #require(CodeSnippet(language: "swift", placement: "Inside solve", code: "  let value = 1\n  return value", highlightedLines: [2]))
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 300, height: 130))
+        dock.show(snippet, fontSize: 24)
+        #expect(dock.codeText.string == snippet.code)
+        #expect(dock.layer?.backgroundColor?.alpha == 1)
+        let font = try #require(dock.codeText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        #expect(font.pointSize == 24)
+        #expect(font.isFixedPitch)
+        #expect(dock.codeText.attribute(.backgroundColor, at: 18, effectiveRange: nil) != nil)
+        var dismissed = false
+        dock.onDismiss = { dismissed = true }
+        dock.dismissButton.performClick(nil)
+        #expect(dismissed)
+    }
+}
+
+private func luminance(_ color: NSColor) -> CGFloat {
+    let rgb = color.usingColorSpace(.sRGB)!
+    func linear(_ component: CGFloat) -> CGFloat {
+        component <= 0.04045 ? component / 12.92 : pow((component + 0.055) / 1.055, 2.4)
+    }
+    return 0.2126 * linear(rgb.redComponent) + 0.7152 * linear(rgb.greenComponent)
+        + 0.0722 * linear(rgb.blueComponent)
+}

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -78,7 +78,7 @@ moments the model judges worthwhile.
    progress is consumed from the module stream.
    Natural triggers coalesce while waiting. Each finalized turn carries its transcript boundary, so
    a delayed transcript-batch callback arriving after another attempt committed that same line is
-   consumed instead of buying a duplicate request. Either explicit coaching shortcut bypasses this wait.
+   consumed instead of buying a duplicate request. Any explicit coaching shortcut bypasses this wait.
    The CoachDriver then calls the brain on every trigger that carries **substance** — there is no
    cooldown, rate cap, or wake-word gate. Whether to speak (and whether the user just addressed
    Jarvis) is the model's call, governed by the system prompt; the only hard gates are the user's
@@ -180,14 +180,15 @@ or unchanged code alone does not. Repeated confusion calls for simpler framing o
 while productive progress calls for silence. This policy applies across interview formats without a
 separate classifier, timer, or model request.
 
-Two configurable global shortcuts are fallbacks for a missed need: **Give me a hint** (default
+Three configurable global shortcuts are fallbacks for a missed need: **Give me a hint** (default
 **⌥⌘J**) requests the next useful hint; **Explain more** (default **⌥⌘E**) explicitly requests
-clarification of the relevant gap, which may span several earlier hints. Both snapshot a fresh screen,
+clarification of the relevant gap, which may span several earlier hints; **Show code** (default
+**⌥⌘K**) requests the next small coding component. All snapshot a fresh screen,
 include the available conversation, and force `speak` in one brain round trip. If capture fails, the
 request identifies the missing screen and uses available context without inventing visible details.
 They share the ordinary single-flight coach loop and provider route. Natural wakes preserve pending
 manual intent; the latest explicit shortcut chooses its kind. A fresh manual press may bypass unsettled
-transcription, while an automatic retry waits for settlement. Stop cancels either request; while stopped,
+transcription, while an automatic retry waits for settlement. Stop cancels any request; while stopped,
 an explicit shortcut only beeps. Activity records which shortcut was pressed.
 
 The `speak` action keeps short `lines` for captions and an optional plain-text `explanation` for fuller
@@ -210,11 +211,39 @@ Explanation text follows the existing coaching history and Activity paths. It op
 never activates Jarvis, and respects the box's enabled/session visibility. Disabling the box leaves
 only the brief caption if that surface is enabled; it does not force a hidden surface on.
 
+**Show code with hints** enables matching snippets in Coding or general sessions, defaulting off.
+`SessionPlan.codeEnabled` is frozen at Start and preserved across screen revisions. The app resolves
+the session format at Start, so non-coding sessions cannot reserve an empty code area. Only enabled
+sessions receive the shortened code guidance in their fixed system prompt. The Show code shortcut
+requests the next snippet; it never edits the preference or enables code during a disabled session.
+Saved settings take effect on the next Start. Tool-field removal is deferred with explanations to #273.
+The fixed `speak.codeSnippet` schema carries language, placement, code, and corrected-line indices;
+[`CodeSnippet`](../Sources/JarvisCore/Overlay/CodeSnippet.swift) bounds and validates it without
+truncating code. Highlight arrays are bounded before normalization, and trimming leading blank lines
+rebases correction indices. Invalid attachments retain the useful text hint. The prompt requests one logical
+component matching visible names, language, and structure. Local mistakes include a highlighted
+correction and relevant next lines; an invalid overall approach receives a corrective hint instead.
+Without visible code, known problem context supports a first component without inventing unseen names.
+
+[`OverlayBoxPanel`](../Sources/JarvisOverlay/OverlayBoxPanel.swift) pins the snippet in a separate
+bottom scroll area inside the existing capture-excluded panel. Its opaque dark background preserves
+syntax contrast regardless of history opacity; monospace text uses the configured size. Each new hint
+replaces its snippet, or clears the previous code when none is appropriate, so guidance and code agree.
+Dismiss and session clear remove the snippet. While enabled, an empty code area remains reserved;
+a session started with code off has no dock. The dock collapses
+with the header and restores its snippet on expansion. Settings preview
+includes code only when enabled and restores the real snippet on close. The caption carries
+only the short hint; Activity includes the accepted placement and code. Explanation preferences do
+not govern code. Box visibility and code acceptance are checked together on the main actor at delivery;
+a hidden snippet is also removed from committed tool history and Activity. Disabling the master box
+releases the shortcut, disables the saved code setting, and clears/disables the current code dock.
+Re-enabling the box alone does not restore the dock; code must be enabled before a new Start.
+
 Shortcuts use **Carbon `RegisterEventHotKey`**, which needs no Accessibility/TCC permission.
 [`CoachingShortcut`](../Sources/JarvisCore/Config/CoachingShortcut.swift) provides stable event identities;
 `HotkeyController` dispatches only matching Jarvis events. Each binding persists independently through
 `HotkeyPreferences`. Registering a replacement happens before releasing the old binding, so a
-collision—including the other Jarvis shortcut—keeps the prior working binding. See
+collision—including another Jarvis shortcut—keeps the prior working binding. See
 [Settings → Shortcuts](./settings-window.md#shortcuts).
 
 ## 3. Components
@@ -234,7 +263,7 @@ collision—including the other Jarvis shortcut—keeps the prior working bindin
 | **Overlay Caption** | Render `speak` output: up to ~3 short lines (model-split), shown one at a time and queued so a newer tip never cuts off the current one; non-activating, always-on-top, excluded from capture. Switchable from Settings — **off by default**; when off, tips are suppressed. | AppKit NSPanel; `OverlayCaptionPanel`. |
 | **Overlay Box** | A persistent window logging every `speak` tip in full, timestamped — the scrollable history of what the caption flashed one line at a time. Movable, resizable, translucent, also excluded from capture; switched on/off from Settings (**on by default**). Its own header carries the box's controls: **collapse** on the left, which rolls the panel down to the header strip and back without losing the size the user dragged to, the name in the middle, and **clear** on the right, which appears only when there is something to erase. The header's proportions are derived from the box's height (`OverlayBoxChrome`) rather than fixed, so the strip stays aimable at the floor of `Defaults.Overlay.Box.heightRange` and stays chrome on a box dragged to fill a display. A borderless window advertises no resize affordance, and macOS refuses to let an inactive app set the cursor, so the box draws its own (`OverlayBoxResizeAffordanceView`): the edge or corner under the pointer lights up, on an `.activeAlways` tracking area, which is what reaches a background app. That view also owns the drag, so the region that lights is the region that resizes. Its thin edge grips are the only thing that refuses a window drag, because AppKit applies `mouseDownCanMoveWindow == false` to a view's whole frame: a full-size view refusing it freezes the box in place. It follows the session: shown on Start (cleared and rolled open, for the new conversation) and hidden on Stop. Its size persists across launches; its position does not, so it opens centered. Fed by the same `speak` call as the caption via **`BroadcastOverlay`**, which fans one `OverlayRendering.render` out to both sinks (so `CoachDriver` is unchanged). System-design visual hints are image attachments beside their text in this same box; the caption remains text-only. See [Private architecture hints](#private-architecture-hints). | AppKit NSPanel; `OverlayBoxPanel`. |
 | **MenuBar** | Manual **Start/Stop** of the pipeline (no auto-start), the same authoritative readiness status shown by Activity, and one-time API-key entry when OpenAI is in use. Stopped and active use a boxless monochrome eye: closed on the Listening Lens's diagonal axis while stopped and open while active, with the active icon following the system menu-bar foreground instead of a brand color. The attention states retain the lit Listening Lens tile — amber while checking or recovering and red when a Start is blocked before any session begins — and the menu and tooltip name the requirement behind those attention states; stopped is simply labeled `Jarvis is stopped`. A failed system stream may degrade to microphone-only, while a failed microphone stream stops the session. The two overlay surfaces are switched from Settings, and the Overlay Box is cleared from its own header, not from the menu. A centered, disabled caption at the bottom of the menu names the running build, so a user can report it without opening Settings: a release shows a muted `v<version>` from `CFBundleShortVersionString`, and a local build shows a red `Dev`, keyed off the development marker `scripts/build-app.sh` stamps into the assembled bundle (see `MenuBarController.buildCaptionItem()`). | AppKit menu-bar item; owner-only file for the key. |
-| **HotkeyController** | Register the independent hint and explanation shortcuts and route each press to its manual coaching request while a session runs (beep otherwise). See [§2 On-demand coaching shortcuts](#on-demand-coaching-shortcuts). | Carbon HIToolbox (`RegisterEventHotKey`, no TCC). |
+| **HotkeyController** | Register the independent hint, explanation, and code shortcuts and route each press to its manual coaching request while a session runs (beep otherwise). See [§2 On-demand coaching shortcuts](#on-demand-coaching-shortcuts). | Carbon HIToolbox (`RegisterEventHotKey`, no TCC). |
 | **PermissionGate** | Gather every TCC grant at launch instead of mid-session, and keep Jarvis closed until it holds all three: one button walks Microphone, System Audio Recording, and Screen Recording one dialog at a time, and closing the window quits. `SystemAudioPermissionProbe` proves the silently-enforced system-audio grant by playing a muted tone into a tap of Jarvis's own process and listening for it. See [§3 Permissions](#permissions). | AVFoundation, `CGRequestScreenCaptureAccess`, Core Audio process taps. |
 
 Each component has one job and a narrow interface. The CoachDriver is the only place the
@@ -391,7 +420,7 @@ stream owns unfinished work so it does not cross an earlier utterance that is ab
 explicit coaching shortcut interrupts that postponement even after the wait begins and upgrades the same
 pending-work attempt to a forced hint; ordinary natural triggers remain parked until transcription
 settles. `TriggerReason` remains the model-facing
-reason that made coaching useful (`turnEnd`, `silence`, `manualHint`, or `manualExplanation`); pending work is scheduler
+reason that made coaching useful (`turnEnd`, `silence`, `manualHint`, `manualExplanation`, or `manualCode`); pending work is scheduler
 state, not a fourth instruction to the model. An automatic attempt with no newer trigger reuses the
 pending work's reason; when another natural trigger arrives, its newer reason describes the fresh
 snapshot.

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -68,7 +68,7 @@ lazy lifecycle; its adaptive light/dark feed is simply framed by the same page a
 | `ConnectionsSection` | "Connections" | yes | Shared authentication and provider readiness in four stacked cards — **OpenAI API**, **Gemini API**, **Claude Code**, **Codex CLI**. OpenAI and Gemini each expose their own Jarvis-managed API-key editor (`APIKeyControls`, one instance per `Credential`); Claude Code and Codex CLI report their externally managed local-account state without importing or changing those accounts. Saving a key never restarts a live conversation: an established OpenAI Realtime or Gemini Live socket stays connected and picks up the new key only on its next reconnect. |
 | `OverlaySection` | "Overlay" | yes | Two matching cards, one per overlay surface — **Overlay Caption** (the transient on-screen tip) and **Overlay Box** (the persistent response history). Each card has an icon, description, On/Off toggle, and the same Text Size + Opacity row layout; the box also has **Show diagrams**, enabled by default. When a surface is **on** its rows and live sample appear only while the Overlay tab is selected (`didBecomeActive`/`didResignActive`); when **off**, its rows and sample are hidden and the card collapses. Persists via `OverlayAppearance`. |
 | `DisplaySection` | "Screen" | yes | One **Screen capture** card with the capture-scope dropdown — **Active window** (default) or one **Entire display** entry per connected display — followed by a concise fallback/privacy callout. Persists via `ScreenCapturePreferences` and applies to the next screenshot. |
-| `HotkeySection` | "Shortcuts" | yes | Independent **Give me a hint** and **Explain more** recorders, with per-binding failure feedback and persisted combinations. |
+| `HotkeySection` | "Shortcuts" | yes | Independent **Give me a hint**, **Explain more**, and **Show code** recorders, with per-binding failure feedback and persisted combinations. |
 | `ActivitySection` | "Activity" | yes | Embeds the `ActivityViewer` content (`makeContentView()` / `teardown()`) in the shared page/card shell so the adaptive light/dark feed stretches with the window. Its compact toolbar shows the selected session's exact directory ID with **Copy ID**. A session without a report shows **Evaluate**: one click runs the sole `AgenticEvaluator` through a locally installed Claude Code / Codex CLI over the source checkout plus the complete session directory, writes owner-only `eval-report.md`, and opens it. While it runs the button shows **Evaluating…**; afterward it becomes **Open report**, which reopens the saved result without another model run. The agent reads the full unfiltered `jarvis-activity.jsonl` whenever it needs the user-visible sequence and correlates it with `coaching-attempts.jsonl`, `brain-traffic.jsonl`, screenshots, and live source. The derived transcript leads with a neutral artifact/distribution/correlation-field index and normalized provider-call telemetry; missing evidence remains unavailable, and neither table declares a defect. The findings-driven prompt gives the read-only agent file and source-search tools instead of a historical-incident checklist, and the report uses generic Summary / Findings / Evidence gaps / Recommendations sections. `scripts/eval-session.sh` is a second launcher for this same `JarvisEvaluation` evaluator, not another evaluation path. `EvalReportPage` renders the markdown as `eval-report.html`; **Copy as Markdown** hands the raw report to an agent chat. Evaluation, report opening, and history clearing stay disabled through the live coaching/teardown lifecycle. |
 
 `AppDelegate` builds the section list at launch and passes it to `SettingsWindow`. All tabs are
@@ -168,8 +168,9 @@ preview is running. The plain setters
 
 ## Shortcuts
 
-**Give me a hint** defaults to **⌥⌘J**; **Explain more** defaults to **⌥⌘E**. Both work during a
-session as fallbacks for proactive coaching; [architecture.md](./architecture.md#on-demand-coaching-shortcuts)
+**Give me a hint** defaults to **⌥⌘J**, **Explain more** to **⌥⌘E**, and **Show code** to **⌥⌘K**.
+They work during a session; code is available in Coding and general sessions only. Hints and
+explanations are fallbacks for proactive coaching; the code hotkey requests a snippet only when the session started with code enabled; [architecture.md](./architecture.md#on-demand-coaching-shortcuts)
 defines their context, output, and scheduling behavior. Each card uses `HotkeyBindingView` and the
 existing recorder, requiring Command or Option. A successful rebind takes effect immediately and
 persists only that shortcut through `HotkeyPreferences`; defaults and storage keys live in
@@ -185,12 +186,24 @@ Start. The row says “Takes effect the next time you start.” Disabling Overla
 saved explanation setting and its switch remains unavailable until the box is enabled again.
 Ordinary hints remain available.
 
-A collision with another application or the other Jarvis shortcut leaves the old working binding
+A collision with another application or another Jarvis shortcut leaves the old working binding
 active and displays feedback for that card. If no binding could be registered at launch, its warning
-persists across tab visits. The two cards scroll at small window sizes, including when both warnings
-are visible. Resizing or changing a binding card preserves the reading offset, clamped to the available content. The Overlay Box distinguishes semibold hints from regular explanation paragraphs with an
+persists across tab visits. The three cards scroll at small window sizes, including when registration warnings
+are visible. Resizing or changing a binding card preserves the reading offset, clamped to the available
+content. The Overlay Box distinguishes semibold hints from regular explanation paragraphs with an
 **Explanation** label and spacing. Both bodies use the configured text size; the appearance preview
 shows an example. Neither surface's visibility preference changes.
+
+The **Show code** card includes **Show code with hints**, off by default, persisted by
+`CodePreferences`. It is captured at Start: enabled coding/general sessions reserve the
+[dedicated code area](./architecture.md#on-demand-coaching-shortcuts) and request matching snippets
+alongside hints. Saved changes affect the next Start; they do not alter the active dock or prompt.
+The hotkey requests the next snippet only for a session that started with code enabled. Turning the
+setting off hides its recorder and releases the binding; enabling or rebinding during a disabled
+session leaves the shortcut deferred until Start. Code remains independent of **Enable explanations**.
+Both features require Overlay Box; switching the box off also disables their saved settings,
+releases their shortcuts, and clears/disables the live code dock. Re-enabling the box alone does not
+restore code; enable code before the next Start. The rows show the dependency. No shortcut enables the master box.
 
 ## Brain
 

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -281,12 +281,26 @@ playback, remains in
 
 ## Built
 
+**Show code with hints** optionally supplies the next contextual coding component with each hint.
+Its capability is fixed at Start; the configurable fallback hotkey requests code for the current
+guidance only in enabled sessions. Settings changes take effect on the next Start.
+[`CodeSnippet`](../Sources/JarvisCore/Overlay/CodeSnippet.swift) validates bounded attachments;
+[`OverlayBoxPanel`](../Sources/JarvisOverlay/OverlayBoxPanel.swift) keeps them in a syntax-colored
+bottom dock while hints continue above. Disabling Overlay Box turns off the saved code setting,
+releases its shortcut, and clears/disables the live dock until code is enabled for a new Start.
+Runtime authorization suppresses code when the session capability is off;
+each new hint replaces or clears its matching snippet.
+See [architecture.md](./architecture.md#on-demand-coaching-shortcuts) for behavior and failure handling.
+Signed synthetic dock/shortcut checks and model scenarios cover the feature; real interview audio,
+capture, cross-app shortcuts, and screen-sharing exclusion still need live verification.
+
 Proactive clarification and a separate **Explain more** shortcut share the existing coach loop.
 [`JarvisPrompts.Coach`](../Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift) supplies the policy across
 formats; `speak.explanation` carries fuller plain-text detail into the persistent overlay box and
 Activity while captions stay short. Semibold hints and labeled, regular-weight explanation paragraphs
-remain visually distinct at the configured text size. Both shortcuts are independently configurable in Settings; **Enable explanations** controls
+remain visually distinct at the configured text size. Hint and explanation shortcuts are independently configurable in Settings; **Enable explanations** controls
 automatic detail and its shortcut for the next Start while retaining the saved binding.
+Disabling Overlay Box turns off the saved explanation setting and releases its shortcut.
 The persistent box gates detail delivery live; hidden detail is omitted from Activity and history;
 see [architecture.md → On-demand coaching shortcuts](./architecture.md#on-demand-coaching-shortcuts).
 
@@ -294,7 +308,7 @@ System Design sessions support [private high-level architecture hints](./archite
 [`DiagramHint`](../Sources/JarvisCore/Overlay/DiagramHint.swift) validates a small Mermaid subset, and
 [`DiagramHintImage`](../Sources/JarvisOverlay/DiagramHintImage.swift) renders boxes and arrows alongside
 the hint inside the capture-excluded overlay box. Graphs scale proportionally with the window;
-Settings → Overlay → Overlay Box offers **Show diagrams**, enabled by default. Other formats remain text-only.
+Settings → Overlay → Overlay Box offers **Show diagrams**, enabled by default. Diagrams are limited to System Design.
 
 Tested `JarvisCore` + `JarvisBrainProviders` + `JarvisEvaluation` + `JarvisOverlay` + `JarvisScreenCapture` harness is green
 (`./scripts/run-tests.sh`); `JarvisApp` is the thin OS shell, verified by the smoke run.
@@ -320,7 +334,7 @@ Tested `JarvisCore` + `JarvisBrainProviders` + `JarvisEvaluation` + `JarvisOverl
 - `Sources/JarvisApp/Capture/` — one-clock aggregate mic + sample-preserving system-audio capture that starts without waiting for a system-audio writer, with AEC3 echo cancellation, Silero voice-activity detection, and resampling to whichever wire rate the selected provider requires (`AggregateEchoCapture`, `WebRTCEchoCanceller`, `SileroVoiceActivityDetector`, `Resampler`); provider construction (`TranscriptionSessionFactory`); OpenAI Realtime item/readiness/liveness/transactional-reconnect handling (`RealtimeTranscriber`); Gemini Live readiness/liveness/reconnect handling with server-owned finalization and no client-managed ledger (`GeminiLiveTranscriber`); macOS 26+ on-device final-result transcription and model preparation (`AppleSpeechTranscriber`, `AppleSpeechModelPreparation`); continuity/network diagnostics; permission reporting and requesting, including the self-tap tone probe that is the only way to ask for or prove the silently-enforced system-audio grant (`Permissions`, `SystemAudioPermissionProbe`); plus the window-scoped screenshot + OCR edge (`WindowScopedScreenCapture`, `ScreenTextRecognizer`).
 - `Sources/JarvisApp/Onboarding/` — the launch permission gate that gathers Microphone, System Audio Recording, and Screen Recording one dialog at a time and keeps Jarvis closed until it holds all three, so no TCC prompt appears mid-session (`PermissionGate`, `PermissionsChecklistView`) ([architecture.md → Permissions](./architecture.md#permissions)).
 - `Sources/JarvisApp/Settings/` — the unified Settings window (`SettingsWindow` hosting Brain behavior, shared Connections, Overlay, Screen, Prep material, and Activity sections), with shared page, rounded-card, responsive-row, and scroll primitives so every tab keeps one visual system without coupling section behavior.
-- `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon hint and Explain more shortcuts, with independent persisted bindings.
+- `Sources/JarvisApp/Shortcuts/HotkeyController.swift` — the global Carbon hint, Explain more, and Show code shortcuts, with independent persisted bindings.
 - `Sources/JarvisApp/Viewer/ActivityViewer.swift` — the in-app `WKWebView` activity viewer, with the current non-persisted readiness badge, an exact selectable/copyable session ID, and one-click **Evaluate** / **Open report** agentic audit flow.
 - `Sources/EvalPrep/main.swift` — the Foundation-only terminal entry point for the same `AgenticEvaluator` Activity invokes; `scripts/eval-session.sh` runs it over the repo + session dir.
 - `Sources/CJarvisAEC/lib/libjarvis-aec.a` — the prebuilt, zero-dylib WebRTC AEC3 native edge (the `CJarvisAEC` target; rebuilt by `scripts/build-aec.sh`).


### PR DESCRIPTION
## Summary

Jarvis can accompany an actionable coding hint with the next small code component in a dedicated bottom area of the persistent overlay. Snippets preserve visible language, names, structure, and viable approaches; local corrections highlight the relevant snippet lines. Invalid approaches get a corrective hint, and missing visible code uses known problem context without inventing unseen names.

**Show code with hints** defaults off and takes effect at the next Start. Supported sessions reserve the code area and receive matching snippets with hints; each hint replaces or clears its snippet. The configurable **Show code** shortcut (⌥⌘K) requests a snippet only when code was enabled for the session. Code remains independent of explanations.

Capabilities and conditional prompts remain fixed across display-plan revisions. Turning Overlay Box off disables saved features, releases their shortcuts, and clears/disables the live code dock. Reopening the box does not restore code until it is enabled for a new Start. Visibility checks and actual delivery happen in one main-actor turn; Activity and conversation history contain only accepted content.

The dock uses syntax coloring over an opaque backing for contrast, with scrolling, correction highlights, dismissal, and header/collapse lifecycle support. Snippet bounds are enforced locally. Nullable tool fields remain until #273 establishes session-composed tools; this PR adds no per-request schemas or relaxed CLI invariants.

Based directly on `main` after #270 merged. The duplicate working plan and unreachable shortcut/rendering paths have been removed; the wiki describes the final design.

## Validation

- 55 focused tests in 5 suites pass, including corrected initial capability setup, retries/coalescing, real overlay delivery, off/on behavior, schema shape, and local bounds.
- `swift build && ./scripts/run-tests.sh` executed: build and all guards pass; the full AppKit host exits 0 without its final suite summary. A complete suite pass is not claimed.
- No live API schema verification or full live interview test was performed for this revision.
- Existing running Jarvis Dev and its bundle were left untouched.
