### PR TITLE
fix(activity): separate hint explanation and code sections

### DIFF
--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -309,7 +309,7 @@ final class ActivityViewer: NSObject, WKNavigationDelegate {
             retainingMostRecentInsertions: ActivityLog.retainedEntryLimit)
         let rows = snapshot.entries.map { entry, data in
             ActivityLog.rowScript(time: entry.time, message: entry.message,
-                                  imageBase64: data?.base64EncodedString())
+                                  imageBase64: data?.base64EncodedString(), response: entry.response)
         }
         beginLoad(shell: ActivityLog.htmlShell(), rows: rows,
                   shown: rows.count, total: snapshot.total)

--- a/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
+++ b/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
@@ -431,8 +431,7 @@ final class CoachAttemptRunner: @unchecked Sendable {
                     guard delivery.accepted else { return .cancelled }
                     let explanation = delivery.explanation
                     let code = delivery.code
-                    let codeText = code.map { "\($0.placement)\n\($0.code)" }
-                    activity?.record(.tip(lines: lines + (explanation.map { [$0] } ?? []) + (codeText.map { [$0] } ?? [])))
+                    activity?.record(.tip(lines: lines, explanation: explanation, codeSnippet: code))
                     // Only the selected call executes; extra provider calls were never delivered.
                     // History describes delivered optional content, including independently enabled code.
                     // Parsed values contain only JSON primitives, so encoding cannot fail.

--- a/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
@@ -43,7 +43,7 @@ public enum ActivityEvent: Sendable {
     /// guidance while raw failure detail stays in debug.
     case screenViewFailed
     /// Jarvis displayed these coaching lines to the user.
-    case tip(lines: [String])
+    case tip(lines: [String], explanation: String? = nil, codeSnippet: CodeSnippet? = nil)
     /// The brain explicitly chose `stay_silent` for this turn.
     case stayedSilent
     /// The single terminal lifecycle event for a live coaching session. The reason is a closed,
@@ -68,6 +68,11 @@ public enum ActivityEvent: Sendable {
     /// many relevant chunks came back, 0 meaning nothing scored usefully.
     case prepNotesSearched(query: String, matchCount: Int)
 
+    var response: ActivityResponse? {
+        guard case .tip(let lines, let explanation, let code) = self else { return nil }
+        return ActivityResponse(lines: lines, explanation: explanation, codeSnippet: code)
+    }
+
     /// Keep persisted identity, human copy, and the optional screenshot payload in one exhaustive
     /// mapping so adding or editing an event cannot make its `k` disagree with what Activity shows.
     var rendered: (kind: Kind, message: String, imageBase64: String?) {
@@ -88,8 +93,8 @@ public enum ActivityEvent: Sendable {
                 "👁 couldn't view your screen — screen capture failed; check Screen Recording permission",
                 nil
             )
-        case .tip(let lines):
-            return (.tip, "💬 \(lines.joined(separator: " "))", nil)
+        case .tip(let lines, let explanation, let code):
+            return (.tip, ActivityResponse(lines: lines, explanation: explanation, codeSnippet: code).message, nil)
         case .stayedSilent:
             return (.stayedSilent, "🤫 stayed silent — nothing useful to add", nil)
         case .sessionEnded(let reason):

--- a/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityHistoryExporter.swift
@@ -76,7 +76,11 @@ public enum ActivityHistoryExporter {
     ) -> String {
         var lines = ["# Jarvis session — \(session.label)", "", "Session ID: \(session.id)", ""]
         for (entry, data) in entries {
-            lines.append("**\(entry.time)** — \(entry.message)")
+            if let response = entry.response {
+                lines.append("**\(entry.time)**\n\n\(response.markdown)")
+            } else {
+                lines.append("**\(entry.time)** — \(entry.message)")
+            }
             if includeScreenshots, let imageFile = entry.imageFile, data != nil {
                 lines.append("")
                 lines.append("![screenshot](images/\(imageFile))")
@@ -93,7 +97,7 @@ public enum ActivityHistoryExporter {
     ) -> String {
         var lines = ["Jarvis session — \(session.label)", "Session ID: \(session.id)", ""]
         for (entry, data) in entries {
-            lines.append("\(entry.time)  \(entry.message)")
+            lines.append("\(entry.time)  \(entry.response?.plainText ?? entry.message)")
             if includeScreenshots, let imageFile = entry.imageFile, data != nil {
                 lines.append("[screenshot: images/\(imageFile)]")
             }
@@ -114,11 +118,11 @@ public enum ActivityHistoryExporter {
         var rows = ""
         for (entry, data) in entries {
             rows += "<div class=\"row\"><span class=\"t\">\(escape(entry.time))</span>"
-            rows += "<span class=\"m\">\(escape(entry.message))"
+            rows += "<div class=\"m\">\(entry.response?.html ?? escape(entry.message))"
             if includeScreenshots, let data {
                 rows += "<img src=\"data:image/jpeg;base64,\(data.base64EncodedString())\">"
             }
-            rows += "</span></div>\n"
+            rows += "</div></div>\n"
         }
         return """
         <!doctype html><html lang="en"><head><meta charset="utf-8">
@@ -127,6 +131,11 @@ public enum ActivityHistoryExporter {
           body { font: 13px/1.5 -apple-system, sans-serif; margin: 24px; }
           .row { display: grid; grid-template-columns: 70px 1fr; gap: 12px; padding: 6px 0; }
           .t { color: #888; }
+          .m { min-width: 0; white-space: pre-wrap; }
+          section + section { border-top: 1px solid #ddd; margin-top: 12px; padding-top: 8px; }
+          h3 { margin: 0 0 4px; font-size: 12px; }
+          p { margin: 0; }
+          pre { overflow-x: auto; white-space: pre; padding: 10px; background: #f4f4f4; }
           img { display: block; max-width: 480px; margin-top: 8px; border-radius: 6px; }
         </style></head><body>
         <h1>Jarvis session — \(escape(session.label))</h1>

--- a/Sources/JarvisCore/Diagnostics/ActivityLog.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityLog.swift
@@ -34,6 +34,7 @@ public final class ActivityLog: @unchecked Sendable {
         public let time: String
         public let message: String
         public let imageFile: String?
+        public let response: ActivityResponse?
         /// Numeric event time and stable insertion tie-breaker. Both are nil for old or mixed
         /// sessions that cannot be reordered safely.
         public let occurredAt: TimeInterval?
@@ -43,11 +44,13 @@ public final class ActivityLog: @unchecked Sendable {
             message: String,
             imageFile: String?,
             occurredAt: TimeInterval? = nil,
-            insertionOrder: UInt64? = nil
+            insertionOrder: UInt64? = nil,
+            response: ActivityResponse? = nil
         ) {
             self.time = time
             self.message = message
             self.imageFile = imageFile
+            self.response = response
             self.occurredAt = occurredAt
             self.insertionOrder = insertionOrder
         }
@@ -70,6 +73,7 @@ public final class ActivityLog: @unchecked Sendable {
     /// On-disk line format for `jarvis-activity.jsonl` (one JSON object per line).
     private struct PersistedEntry: Codable {
         let t: String       // time, HH:mm:ss
+        let response: ActivityResponse? // absent in legacy, unstructured rows
         let m: String       // message
         let s: String?      // shot filename, if any
         let k: ActivityEvent.Kind?  // stable event identity; nil only for backward-compatible old rows
@@ -217,14 +221,14 @@ public final class ActivityLog: @unchecked Sendable {
             let baseEntry = Entry(
                 time: df.string(from: date),
                 message: rendered.message,
-                imageFile: shotFilename)
+                imageFile: shotFilename, response: event.response)
             let item = entries.append(baseEntry, occurredAt: date.timeIntervalSince1970)
             let entry = Entry(
                 time: baseEntry.time,
                 message: baseEntry.message,
                 imageFile: baseEntry.imageFile,
                 occurredAt: item.occurredAt,
-                insertionOrder: item.insertionOrder)
+                insertionOrder: item.insertionOrder, response: baseEntry.response)
             totalCount += 1
             if rendered.kind == .sessionEnded {
                 sessionHasEnded = true
@@ -244,7 +248,8 @@ public final class ActivityLog: @unchecked Sendable {
                     imageBase64: rendered.imageBase64,
                     insertionIndex: chronologicalIndex,
                     insertionOrder: item.insertionOrder,
-                    removedInsertionOrders: removedItems.map(\.insertionOrder))))
+                    removedInsertionOrders: removedItems.map(\.insertionOrder),
+                    response: entry.response)))
         }
     }
 
@@ -273,7 +278,7 @@ public final class ActivityLog: @unchecked Sendable {
                     time: e.time,
                     message: e.message,
                     imageBase64: b64,
-                    insertionOrder: item.insertionOrder)
+                    insertionOrder: item.insertionOrder, response: e.response)
             }
             return Snapshot(
                 shellHTML: Self.htmlShell(),
@@ -295,6 +300,7 @@ public final class ActivityLog: @unchecked Sendable {
     ) -> Data? {
         try? JSONEncoder().encode(PersistedEntry(
             t: entry.time,
+            response: entry.response,
             m: entry.message,
             s: entry.imageFile,
             k: kind,
@@ -316,11 +322,13 @@ public final class ActivityLog: @unchecked Sendable {
         imageBase64: String?,
         insertionIndex: Int? = nil,
         insertionOrder: UInt64? = nil,
-        removedInsertionOrders: [UInt64] = []
+        removedInsertionOrders: [UInt64] = [],
+        response: ActivityResponse? = nil
     ) -> String {
         struct Row: Encodable {
             let time: String
             let message: String
+            let response: ActivityResponse?
             let cls: String
             let img: String?
             let insertionIndex: Int?
@@ -328,7 +336,7 @@ public final class ActivityLog: @unchecked Sendable {
             let insertionOrder: String?
             let removedInsertionOrders: [String]?
         }
-        let row = Row(time: time, message: message, cls: cssClass(for: message),
+        let row = Row(time: time, message: message, response: response, cls: cssClass(for: message),
                       img: imageBase64.map { "data:image/jpeg;base64,\($0)" },
                       insertionIndex: insertionIndex,
                       insertionOrder: insertionOrder.map(String.init),
@@ -467,6 +475,15 @@ public final class ActivityLog: @unchecked Sendable {
                  white-space: pre-wrap; }
           .t { color: var(--muted); font-size: 10px; }
           .m { min-width: 0; }
+          .response-section + .response-section { margin-top: 12px; padding-top: 10px;
+                                                  border-top: 1px solid var(--line); }
+          .response-section h3 { margin: 0 0 4px; color: var(--muted); font-size: 10px;
+                                 font-weight: 600; text-transform: uppercase; letter-spacing: .04em; }
+          .response-section p { margin: 0; }
+          .response-section .code-language { color: var(--muted); font-size: 10px; }
+          .response-section pre { margin: 6px 0 0; padding: 10px; overflow-x: auto;
+                                  white-space: pre; background: var(--surface); color: var(--text);
+                                  border-radius: 6px; font: 11px/1.5 ui-monospace, Menlo, monospace; }
           .say .m  { color: var(--say); }
           .see .m  { color: var(--see); }
           .hear .m { color: var(--hear); }
@@ -489,6 +506,31 @@ public final class ActivityLog: @unchecked Sendable {
         <main id="log"></main>
         <div class="lightbox" id="lightbox"><img id="lightbox-img" alt="full-size screenshot"></div>
         <script>
+          function responseSection(parent,label){
+            var section=document.createElement('section'); section.className='response-section';
+            var heading=document.createElement('h3'); heading.textContent=label;
+            section.appendChild(heading); parent.appendChild(section); return section;
+          }
+          function responseText(parent,text,cls){
+            var body=document.createElement('p'); body.textContent=text;
+            if(cls) body.className=cls;
+            parent.appendChild(body);
+          }
+          function renderResponse(parent,response){
+            if(response.lines && response.lines.length){
+              responseText(responseSection(parent,'Hint'),response.lines.join('\\n'));
+            }
+            if(response.explanation && response.explanation.trim()){
+              responseText(responseSection(parent,'Explanation'),response.explanation);
+            }
+            if(response.code && response.code.code && response.code.code.trim()){
+              var section=responseSection(parent,'Code');
+              if(response.code.language) responseText(section,response.code.language,'code-language');
+              if(response.code.placement) responseText(section,response.code.placement);
+              var pre=document.createElement('pre'), code=document.createElement('code');
+              code.textContent=response.code.code; pre.appendChild(code); section.appendChild(pre);
+            }
+          }
           function appendRow(p){
             var log=document.getElementById('log');
             var near=(window.innerHeight+window.scrollY)>=(document.body.scrollHeight-60);
@@ -503,7 +545,8 @@ public final class ActivityLog: @unchecked Sendable {
               row.dataset.insertionOrder=p.insertionOrder;
             }
             var t=document.createElement('span'); t.className='t'; t.textContent=p.time||'';
-            var m=document.createElement('span'); m.className='m'; m.textContent=p.message||'';
+            var m=document.createElement('div'); m.className='m';
+            if(p.response) renderResponse(m,p.response); else m.textContent=p.message||'';
             if(p.img){
               var a=document.createElement('a'); a.className='shot'; a.href=p.img;
               var img=document.createElement('img'); img.src=p.img; img.alt='screenshot of the user\\'s screen';

--- a/Sources/JarvisCore/Diagnostics/ActivityResponse+Export.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityResponse+Export.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+extension ActivityResponse {
+    var plainText: String {
+        var parts = ["Hint\n\(lines.joined(separator: "\n"))"]
+        if let explanation { parts.append("Explanation\n\(explanation)") }
+        if let code { parts.append("Code\n\(code.language)\n\(code.placement)\n\(code.code)") }
+        return parts.joined(separator: "\n\n")
+    }
+
+    var markdown: String {
+        var parts = ["### Hint\n\n\(lines.joined(separator: "\n"))"]
+        if let explanation { parts.append("### Explanation\n\n\(explanation)") }
+        if let code {
+            // A snippet may itself contain Markdown fences; preserve it as one literal code block.
+            var fence = "```"
+            while code.code.contains(fence) { fence += "`" }
+            parts.append("### Code\n\n\(code.language)\n\n\(code.placement)\n\n\(fence)\n\(code.code)\n\(fence)")
+        }
+        return parts.joined(separator: "\n\n")
+    }
+
+    var html: String {
+        func escape(_ value: String) -> String {
+            value.replacingOccurrences(of: "&", with: "&amp;")
+                .replacingOccurrences(of: "<", with: "&lt;")
+                .replacingOccurrences(of: ">", with: "&gt;")
+        }
+        var result = "<section><h3>Hint</h3><p>\(escape(lines.joined(separator: "\n")))</p></section>"
+        if let explanation {
+            result += "<section><h3>Explanation</h3><p>\(escape(explanation))</p></section>"
+        }
+        if let code {
+            result += "<section><h3>Code</h3><p>\(escape(code.language))</p>"
+                + "<p>\(escape(code.placement))</p><pre><code>\(escape(code.code))</code></pre></section>"
+        }
+        return result
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/ActivityResponse.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityResponse.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The delivered parts of one coaching response, retained separately for live Activity, history,
+/// and export. The plain message remains readable by older builds and evidence consumers.
+public struct ActivityResponse: Codable, Equatable, Sendable {
+    public struct Code: Codable, Equatable, Sendable {
+        public let language: String
+        public let placement: String
+        public let code: String
+    }
+
+    public let lines: [String]
+    public let explanation: String?
+    public let code: Code?
+
+    public init(lines: [String], explanation: String? = nil, codeSnippet: CodeSnippet? = nil) {
+        self.lines = lines
+        let detail = explanation?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.explanation = detail?.isEmpty == false ? detail : nil
+        code = codeSnippet.map { Code(language: $0.language, placement: $0.placement, code: $0.code) }
+    }
+
+    var message: String {
+        guard explanation != nil || code != nil else { return "💬 \(lines.joined(separator: " "))" }
+        var parts = ["💬 Hint\n\(lines.joined(separator: "\n"))"]
+        if let explanation { parts.append("Explanation\n\(explanation)") }
+        if let code {
+            parts.append("Code\n\(code.language)\n\(code.placement)\n\(code.code)")
+        }
+        return parts.joined(separator: "\n\n")
+    }
+}

--- a/Sources/JarvisCore/Diagnostics/SessionStore.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionStore.swift
@@ -43,6 +43,7 @@ public struct SessionStore: Sendable {
     private struct Line: Decodable {
         let t: String
         let m: String
+        let response: ActivityResponse?
         let s: String?
         /// A raw value lets this build distinguish current typed events from unknown kinds; only
         /// current kinds bypass the human-copy classifier.
@@ -177,7 +178,7 @@ public struct SessionStore: Sendable {
                 message: line.m,
                 imageFile: shotName,
                 occurredAt: line.o,
-                insertionOrder: insertionOrder)
+                insertionOrder: insertionOrder, response: line.response)
             out.append(LoadedEntry(entry: entry, imageData: bytes, occurredAt: line.o))
         }
         let total = out.count
@@ -196,7 +197,7 @@ public struct SessionStore: Sendable {
                     ActivityLog.Entry(
                         time: entry.time,
                         message: entry.message,
-                        imageFile: entry.imageFile),
+                        imageFile: entry.imageFile, response: entry.response),
                     loaded.imageData)
             }
             return EntrySnapshot(entries: entries, total: total)

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityResponseTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityResponseTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import JarvisCore
+
+@Suite struct ActivityResponseTests {
+    @Test func deliveredPartsSurviveLiveReplayPersistenceAndMixedHistory() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (log, evidence) = ActivityLog.recordingSession(in: dir)
+        let snippet = try #require(CodeSnippet(language: "python", placement: "After the loop",
+            code: "if ready:\n    return values"))
+        evidence.record(.tip(lines: ["Return the values."], explanation: "The caller needs a result.",
+                             codeSnippet: snippet))
+        _ = await evidence.close()
+        let live = log.attach { _ in }
+        let script = try #require(live.rows.first)
+        let object = try #require(try JSONSerialization.jsonObject(
+            with: Data(script.dropFirst("appendRow(".count).dropLast(2).utf8)) as? [String: Any])
+        let response = try #require(object["response"] as? [String: Any])
+        #expect(response["lines"] as? [String] == ["Return the values."])
+        #expect(response["explanation"] as? String == "The caller needs a result.")
+        #expect((response["code"] as? [String: Any])?["code"] as? String == "if ready:\n    return values")
+
+        let session = SessionStore.Session(id: "2026-09-10_00-00-00_abcd", label: "test", url: dir,
+                                           isCurrent: false, evidenceIsComplete: true)
+        let store = SessionStore(base: dir.deletingLastPathComponent(), current: nil)
+        let reloaded = try #require(store.entries(for: session).first?.0)
+        #expect(reloaded.response?.explanation == "The caller needs a result.")
+        #expect(reloaded.response?.code?.placement == "After the loop")
+        #expect(reloaded.response?.code?.code == "if ready:\n    return values")
+        #expect(reloaded.message.contains("\n\nExplanation\n"))
+
+        // Mixed sessions take a separate path that strips incomplete chronology metadata.
+        let file = dir.appendingPathComponent(ActivityLog.filename)
+        var data = try Data(contentsOf: file)
+        data.append(Data(#"{"t":"00:00:01","m":"💬 legacy hint"}"#.utf8))
+        data.append(0x0a)
+        try data.write(to: file)
+        let mixed = store.entries(for: session)
+        #expect(mixed.count == 2)
+        #expect(mixed[0].0.response == reloaded.response)
+        #expect(mixed[1].0.response == nil)
+        #expect(mixed[1].0.message == "💬 legacy hint")
+    }
+
+    @Test func exportsKeepSectionsIndentationAndLiteralMarkup() throws {
+        let snippet = try #require(CodeSnippet(language: "html", placement: "Inside the example",
+            code: "  <script>literal()</script>\n  ```"))
+        let response = ActivityResponse(lines: ["Inspect <input>."], explanation: "Keep <tags> literal.",
+                                        codeSnippet: snippet)
+        let entry = ActivityLog.Entry(time: "00:00", message: response.message, imageFile: nil,
+                                      response: response)
+        let session = SessionStore.Session(id: "test", label: "test", url: URL(fileURLWithPath: "/tmp/test"),
+                                           isCurrent: false, evidenceIsComplete: true)
+        func export(_ format: ActivityHistoryExporter.ExportFormat) -> String {
+            ActivityHistoryExporter.export(session: session, entries: [(entry, nil)], format: format,
+                includeScreenshots: false, jarvisResponsesOnly: true).text
+        }
+        let markdown = export(.markdown)
+        #expect(markdown.contains("### Hint\n"))
+        #expect(markdown.contains("### Explanation\n"))
+        #expect(markdown.contains("### Code\n"))
+        #expect(markdown.contains("````\n  <script>literal()</script>\n  ```\n````"))
+        let text = export(.plainText)
+        #expect(text.contains("\n\nExplanation\n"))
+        #expect(text.contains("  <script>literal()</script>\n  ```"))
+        let html = export(.html)
+        #expect(html.contains("<h3>Code</h3>"))
+        #expect(html.contains("<pre><code>  &lt;script&gt;literal()&lt;/script&gt;\n  ```</code></pre>"))
+        #expect(!html.contains("<script>"))
+    }
+}

--- a/Tests/JarvisViewerTests/ActivityResponseSectionsTests.swift
+++ b/Tests/JarvisViewerTests/ActivityResponseSectionsTests.swift
@@ -1,0 +1,39 @@
+import Testing
+import WebKit
+@testable import JarvisCore
+
+@Suite(.serialized) struct ActivityResponseSectionsTests {
+    @MainActor @Test func separatesResponsePartsAndPreservesLiteralCode() async throws {
+        let h = WebViewHarness()
+        try await h.load(ActivityLog.htmlShell())
+        let snippet = try #require(CodeSnippet(language: "python", placement: "After the while loop",
+            code: "if value < 2:\n    return \"<script>bad()</script>\""))
+        try await h.eval(ActivityLog.rowScript(time: "12:00", message: "legacy fallback", imageBase64: nil,
+            response: ActivityResponse(lines: ["Return result after the loop."],
+                explanation: "The caller otherwise receives None.", codeSnippet: snippet)))
+        let headings = try await h.eval(
+            "Array.from(document.querySelectorAll('.response-section h3')).map(x=>x.textContent).join('|')"
+        ) as? String
+        #expect(headings == "Hint|Explanation|Code")
+        let code = try await h.eval("document.querySelector('.response-section pre code')?.textContent") as? String
+        #expect(code == "if value < 2:\n    return \"<script>bad()</script>\"")
+        let injected = try await h.eval("document.querySelectorAll('#log script').length") as? Int
+        #expect(injected == 0)
+        let text = try await h.eval("document.querySelector('#log').textContent") as? String
+        #expect(text?.contains("After the while loop") == true)
+        #expect(text?.contains("legacy fallback") == false)
+    }
+
+    @MainActor @Test func ordinaryHintOmitsEmptyExplanationAndCodeSections() async throws {
+        let h = WebViewHarness()
+        try await h.load(ActivityLog.htmlShell())
+        try await h.eval(ActivityLog.rowScript(time: "12:00", message: "💬 Return result.", imageBase64: nil,
+            response: ActivityResponse(lines: ["Return result."], explanation: "  ")))
+        let headings = try await h.eval(
+            "Array.from(document.querySelectorAll('.response-section h3')).map(x=>x.textContent).join('|')"
+        ) as? String
+        #expect(headings == "Hint")
+        let text = try await h.eval("document.querySelector('#log').textContent") as? String
+        #expect(text?.contains("Return result.") == true)
+    }
+}

--- a/wiki/settings-window.md
+++ b/wiki/settings-window.md
@@ -205,6 +205,18 @@ Both features require Overlay Box; switching the box off also disables their sav
 releases their shortcuts, and clears/disables the live code dock. Re-enabling the box alone does not
 restore code; enable code before the next Start. The rows show the dependency. No shortcut enables the master box.
 
+## Activity response sections
+
+Each new coaching response retains its delivered **Hint**, optional **Explanation**, and optional
+**Code** as separate fields through `ActivityResponse`. The Activity feed labels each present part;
+code keeps its indentation in a monospace block with language and placement guidance. The same
+sections survive live replay, reopening a saved session, and Markdown, plain-text, or HTML export.
+The recorder includes only explanation and code actually accepted by the overlay.
+
+Existing sessions without structured response fields display their original messages. Activity does
+not guess boundaries from old flattened prose. New records also retain a readable text message for
+older readers and the session evaluator; structured fields drive the sectioned viewer.
+
 ## Brain
 
 The Brain tab owns the whole "who answers a coaching attempt" decision, persisted through

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -297,7 +297,10 @@ capture, cross-app shortcuts, and screen-sharing exclusion still need live verif
 Proactive clarification and a separate **Explain more** shortcut share the existing coach loop.
 [`JarvisPrompts.Coach`](../Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift) supplies the policy across
 formats; `speak.explanation` carries fuller plain-text detail into the persistent overlay box and
-Activity while captions stay short. Semibold hints and labeled, regular-weight explanation paragraphs
+Activity while captions stay short. Activity preserves labeled
+Hint, Explanation, and Code sections through live replay, saved sessions, and exports via
+[`ActivityResponse`](../Sources/JarvisCore/Diagnostics/ActivityResponse.swift); older flattened rows
+remain readable. Semibold hints and labeled, regular-weight explanation paragraphs
 remain visually distinct at the configured text size. Hint and explanation shortcuts are independently configurable in Settings; **Enable explanations** controls
 automatic detail and its shortcut for the next Start while retaining the saved binding.
 Disabling Overlay Box turns off the saved explanation setting and releases its shortcut.

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -297,10 +297,9 @@ capture, cross-app shortcuts, and screen-sharing exclusion still need live verif
 Proactive clarification and a separate **Explain more** shortcut share the existing coach loop.
 [`JarvisPrompts.Coach`](../Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift) supplies the policy across
 formats; `speak.explanation` carries fuller plain-text detail into the persistent overlay box and
-Activity while captions stay short. Activity preserves labeled
-Hint, Explanation, and Code sections through live replay, saved sessions, and exports via
-[`ActivityResponse`](../Sources/JarvisCore/Diagnostics/ActivityResponse.swift); older flattened rows
-remain readable. Semibold hints and labeled, regular-weight explanation paragraphs
+Activity while captions stay short. Activity presents labeled response sections; see
+[Activity response sections](./settings-window.md#activity-response-sections) for the delivery,
+replay, export, and legacy-session contract. Semibold hints and labeled, regular-weight explanation paragraphs
 remain visually distinct at the configured text size. Hint and explanation shortcuts are independently configurable in Settings; **Enable explanations** controls
 automatic detail and its shortcut for the next Start while retaining the saved binding.
 Disabling Overlay Box turns off the saved explanation setting and releases its shortcut.


### PR DESCRIPTION
Activity currently joins hint lines, explanation, placement guidance, and code into one message. Preserve the delivered response fields through recording, JSONL, live replay, saved-session loading, and export. The feed labels Hint, Explanation, and Code, omits absent sections, and renders literal indented code in a monospace block.

Existing unstructured sessions remain readable; their boundaries are not guessed. This PR does not change explanation policy, which is covered separately by #285.

Validation: WebKit regression tests failed on missing sections before implementation, then passed. The combined change's 67 focused tests covered viewer rendering, persistence, exports, and existing explanation/code behavior. A synthetic WebKit feed was visually inspected. The Activity-only branch also passed `swift build && ./scripts/run-tests.sh` (exit code 0 and all five guards); the full runner did not emit a final test-count summary. Review found no actionable issues. Live capture/provider smoke checks were not run.
