### PR TITLE
fix(overlay): wrap and fit code snippets within the panel

### DIFF
--- a/Sources/JarvisOverlay/CodeSnippetDocumentView.swift
+++ b/Sources/JarvisOverlay/CodeSnippetDocumentView.swift
@@ -1,7 +1,7 @@
 import AppKit
 import JarvisCore
 
-/// Placement wraps at the viewport width while code retains its original line breaks and indentation.
+/// Both sections wrap at the viewport width without changing the underlying code or highlights.
 @MainActor
 final class CodeSnippetDocumentView: NSView {
     private let placement = NSTextField(wrappingLabelWithString: "")
@@ -18,9 +18,9 @@ final class CodeSnippetDocumentView: NSView {
         textView.drawsBackground = false
         textView.textContainerInset = NSSize(width: 12, height: 8)
         textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = true
+        textView.isHorizontallyResizable = false
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.containerSize = textView.maxSize
         textView.setAccessibilityLabel("Code snippet")
         addSubview(placement)
@@ -32,7 +32,6 @@ final class CodeSnippetDocumentView: NSView {
     func show(_ snippet: CodeSnippet, fontSize: CGFloat) {
         placement.stringValue = snippet.placement
         textView.textStorage?.setAttributedString(CodeSnippetFormatting.render(snippet, fontSize: fontSize))
-        textView.sizeToFit()
     }
 
     func fit(viewportWidth: CGFloat) {
@@ -41,8 +40,17 @@ final class CodeSnippetDocumentView: NSView {
             with: NSSize(width: width, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading]).height))
         placement.frame = NSRect(x: 14, y: 4, width: width, height: height)
-        textView.setFrameOrigin(NSPoint(x: 0, y: height + 6))
-        setFrameSize(NSSize(width: max(viewportWidth, textView.frame.width),
-            height: textView.frame.maxY))
+        // Constrain TextKit before measuring: sizeToFit with an unbounded container produces
+        // a document wider than the dock and clips long code lines off its right edge.
+        let textWidth = max(1, viewportWidth)
+        textView.setFrameSize(NSSize(width: textWidth, height: textView.frame.height))
+        if let container = textView.textContainer, let manager = textView.layoutManager {
+            container.containerSize = NSSize(width: max(1, textWidth - 2 * textView.textContainerInset.width),
+                                             height: .greatestFiniteMagnitude)
+            manager.ensureLayout(for: container)
+            let textHeight = ceil(manager.usedRect(for: container).height) + 2 * textView.textContainerInset.height
+            textView.frame = NSRect(x: 0, y: height + 6, width: textWidth, height: textHeight)
+        }
+        setFrameSize(NSSize(width: textWidth, height: textView.frame.maxY))
     }
 }

--- a/Sources/JarvisOverlay/CodeSnippetView.swift
+++ b/Sources/JarvisOverlay/CodeSnippetView.swift
@@ -11,6 +11,7 @@ final class CodeSnippetView: NSView {
     private let scroll = NSScrollView()
     private let emptyLabel = NSTextField(wrappingLabelWithString: "Code for your next coding hint will appear here.")
     private let document = CodeSnippetDocumentView(frame: .zero)
+    private var preferredFontSize: CGFloat = 18
     private(set) var snippet: CodeSnippet?
     var codeText: NSAttributedString { document.codeText }
 
@@ -32,7 +33,7 @@ final class CodeSnippetView: NSView {
         dismissButton.action = #selector(dismiss)
         dismissButton.setAccessibilityLabel("Dismiss code snippet")
         scroll.hasVerticalScroller = true
-        scroll.hasHorizontalScroller = true
+        scroll.hasHorizontalScroller = false
         scroll.scrollerStyle = .overlay
         scroll.autohidesScrollers = true
         scroll.drawsBackground = false
@@ -50,10 +51,19 @@ final class CodeSnippetView: NSView {
         dismissButton.frame = NSRect(x: bounds.width - 78, y: bounds.height - 27, width: 66, height: 22)
         scroll.frame = NSRect(x: 0, y: 0, width: bounds.width, height: max(0, bounds.height - 28))
         emptyLabel.frame = NSRect(x: 14, y: 12, width: max(0, bounds.width - 28), height: max(0, bounds.height - 44))
-        document.fit(viewportWidth: scroll.contentSize.width)
+        guard let snippet else { return }
+        // Keep the largest readable size that fits; a tiny panel can still scroll vertically.
+        var size = preferredFontSize
+        while true {
+            document.show(snippet, fontSize: size)
+            document.fit(viewportWidth: scroll.contentSize.width)
+            if document.frame.height <= scroll.contentSize.height || size <= 12 { break }
+            size = max(12, size - 1)
+        }
     }
 
     func show(_ snippet: CodeSnippet?, fontSize: CGFloat, enabled: Bool = true) {
+        preferredFontSize = min(18, max(12, fontSize))
         let changed = self.snippet != snippet
         self.snippet = snippet
         isHidden = !enabled
@@ -64,10 +74,18 @@ final class CodeSnippetView: NSView {
         needsLayout = true
         guard let snippet else { return }
         title.stringValue = snippet.language.isEmpty ? "CODE" : "CODE · \(snippet.language)"
-        document.show(snippet, fontSize: fontSize)
+        document.show(snippet, fontSize: preferredFontSize)
         document.fit(viewportWidth: max(1, bounds.width))
         if changed { scroll.contentView.scroll(to: .zero) }
         needsLayout = true
+    }
+
+    /// Measure wrapped content at the preferred size before allocating the dock's bounded height.
+    func preferredHeight(viewportWidth: CGFloat) -> CGFloat {
+        guard let snippet else { return 96 }
+        document.show(snippet, fontSize: preferredFontSize)
+        document.fit(viewportWidth: viewportWidth)
+        return 28 + document.frame.height
     }
 
     @objc private func dismiss() { onDismiss?() }

--- a/Sources/JarvisOverlay/OverlayBoxPanel.swift
+++ b/Sources/JarvisOverlay/OverlayBoxPanel.swift
@@ -309,10 +309,12 @@ public final class OverlayBoxPanel: NSObject, OverlayRendering, OverlayBoxApplyi
     private func layoutCode() {
         let available = max(0, box.bounds.height - chrome.height)
         let preferred = min(box.bounds.height * 0.45,
-            76 + CGFloat(codeView.snippet?.code.components(separatedBy: "\n").count ?? 0) * (fontSize + 4))
+            codeView.preferredHeight(viewportWidth: box.bounds.width))
         // Preserve the header and one history line even at the minimum expanded size.
         let height = codeView.isHidden ? 0 : min(max(0, available - 44), max(96, preferred))
         codeView.frame = NSRect(x: 0, y: 0, width: box.bounds.width, height: height)
+        codeView.needsLayout = true
+        codeView.layoutSubtreeIfNeeded()
         scroll.frame = NSRect(x: 0, y: height, width: box.bounds.width, height: max(0, available - height))
     }
 

--- a/Tests/JarvisOverlayTests/CodeSnippetLayoutTests.swift
+++ b/Tests/JarvisOverlayTests/CodeSnippetLayoutTests.swift
@@ -1,0 +1,85 @@
+import AppKit
+import JarvisCore
+import Testing
+@testable import JarvisOverlay
+
+@MainActor
+@Suite struct CodeSnippetLayoutTests {
+    @Test func longLinesWrapWithoutChangingCodeOrHighlights() throws {
+        let snippet = try #require(CodeSnippet(language: "python", placement: "Inside the loop",
+            code: "for index, value in enumerate(candidates, start=offset):\n    output[index] = transform(value)\n    last = value",
+            highlightedLines: [1]))
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 300, height: 240))
+        dock.show(snippet, fontSize: 32)
+        dock.layoutSubtreeIfNeeded()
+        let scroll = try #require(dock.subviews.compactMap { $0 as? NSScrollView }.first)
+        let document = try #require(scroll.documentView)
+        let text = try #require(document.subviews.compactMap { $0 as? NSTextView }.first)
+        #expect(document.frame.width <= scroll.contentSize.width)
+        #expect(document.frame.height <= scroll.contentSize.height)
+        #expect(dock.codeText.string == snippet.code)
+        #expect(dock.codeText.attribute(.backgroundColor, at: 0, effectiveRange: nil) != nil)
+        let manager = try #require(text.layoutManager)
+        let container = try #require(text.textContainer)
+        manager.ensureLayout(for: container)
+        var fragments = 0
+        manager.enumerateLineFragments(forGlyphRange: manager.glyphRange(for: container)) { _, _, _, _, _ in
+            fragments += 1
+        }
+        #expect(fragments > 3)
+    }
+
+    @Test func compactCodeFitsWithoutScrollingAndRecoversSizeWhenRoomReturns() throws {
+        let snippet = try #require(CodeSnippet(language: "swift", placement: "Current component",
+            code: (1...6).map { "let item\($0) = \($0)" }.joined(separator: "\n")))
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 320, height: 160))
+        dock.show(snippet, fontSize: 32)
+        dock.layoutSubtreeIfNeeded()
+        let scroll = try #require(dock.subviews.compactMap { $0 as? NSScrollView }.first)
+        let document = try #require(scroll.documentView)
+        let compactFont = try #require(dock.codeText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        #expect(compactFont.pointSize >= 12)
+        #expect(compactFont.pointSize < 18)
+        #expect(document.frame.height <= scroll.contentSize.height)
+        dock.setFrameSize(NSSize(width: 640, height: 320))
+        dock.needsLayout = true
+        dock.layoutSubtreeIfNeeded()
+        let restoredFont = try #require(dock.codeText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        #expect(restoredFont.pointSize == 18)
+        #expect(dock.codeText.string == snippet.code)
+        #expect(document.frame.width <= scroll.contentSize.width)
+    }
+
+    @Test func dockGrowsForWrappedLinesWhenPanelHasRoom() throws {
+        let box = OverlayBoxPanel(contentSize: NSSize(width: 320, height: 800))
+        box.setEnabled(true)
+        box.setSessionLive(true)
+        defer { box.setSessionLive(false) }
+        box.setCodeEnabled(true)
+        let short = try #require(CodeSnippet(language: "swift", placement: "Current component", code: "return result"))
+        #expect(box.deliverCodeSnippet(short) == short)
+        let shortHeight = box.currentCodeHeight
+        let long = try #require(CodeSnippet(language: "swift", placement: "Current component",
+            code: "let matchingCandidates = candidates.filter { candidate in candidate.isValid && candidate.score > minimumScore }"))
+        #expect(box.deliverCodeSnippet(long) == long)
+        #expect(box.currentCodeHeight > shortHeight)
+        #expect(box.currentCodeHeight <= 360)
+    }
+
+    @Test func tinyViewportKeepsAllCodeReachableAtReadableSize() throws {
+        let snippet = try #require(CodeSnippet(language: "text", placement: "Current component",
+            code: String(repeating: "a", count: 220)))
+        let dock = CodeSnippetView(frame: NSRect(x: 0, y: 0, width: 240, height: 96))
+        dock.show(snippet, fontSize: 32)
+        dock.layoutSubtreeIfNeeded()
+        let scroll = try #require(dock.subviews.compactMap { $0 as? NSScrollView }.first)
+        let document = try #require(scroll.documentView)
+        let font = try #require(dock.codeText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
+        #expect(font.pointSize >= 12)
+        #expect(document.frame.width <= scroll.contentSize.width)
+        #expect(document.frame.height > scroll.contentSize.height)
+        scroll.contentView.scroll(to: NSPoint(x: 0, y: document.frame.height))
+        #expect(scroll.contentView.bounds.maxY >= document.frame.maxY)
+        #expect(dock.codeText.string == snippet.code)
+    }
+}

--- a/Tests/JarvisOverlayTests/CodeSnippetRenderingTests.swift
+++ b/Tests/JarvisOverlayTests/CodeSnippetRenderingTests.swift
@@ -190,7 +190,9 @@ import Testing
         #expect(dock.codeText.string == snippet.code)
         #expect(dock.layer?.backgroundColor?.alpha == 1)
         let font = try #require(dock.codeText.attribute(.font, at: 0, effectiveRange: nil) as? NSFont)
-        #expect(font.pointSize == 24)
+        // Code now uses a compact, fit-to-section size instead of mirroring the history font.
+        #expect(font.pointSize >= 12)
+        #expect(font.pointSize <= 18)
         #expect(font.isFixedPitch)
         #expect(dock.codeText.attribute(.backgroundColor, at: 18, effectiveRange: nil) != nil)
         var dismissed = false

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -227,7 +227,11 @@ Without visible code, known problem context supports a first component without i
 
 [`OverlayBoxPanel`](../Sources/JarvisOverlay/OverlayBoxPanel.swift) pins the snippet in a separate
 bottom scroll area inside the existing capture-excluded panel. Its opaque dark background preserves
-syntax contrast regardless of history opacity; monospace text uses the configured size. Each new hint
+syntax contrast regardless of history opacity. Long code lines wrap within the dock without changing
+source text or correction highlights. The dock measures wrapped content to use available space;
+code uses a compact monospace size and shrinks only as needed to fit, down to a readable minimum
+(see `CodeSnippetView`). Very small panels retain vertical scrolling rather than clipping code or
+shrinking it indefinitely. Each new hint
 replaces its snippet, or clears the previous code when none is appropriate, so guidance and code agree.
 Dismiss and session clear remove the snippet. While enabled, an empty code area remains reserved;
 a session started with code off has no dock. The dock collapses

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -286,7 +286,8 @@ Its capability is fixed at Start; the configurable fallback hotkey requests code
 guidance only in enabled sessions. Settings changes take effect on the next Start.
 [`CodeSnippet`](../Sources/JarvisCore/Overlay/CodeSnippet.swift) validates bounded attachments;
 [`OverlayBoxPanel`](../Sources/JarvisOverlay/OverlayBoxPanel.swift) keeps them in a syntax-colored
-bottom dock while hints continue above. Disabling Overlay Box turns off the saved code setting,
+bottom dock while hints continue above. Code wraps and uses a compact font sized to fit the available
+section; vertical scrolling remains a fallback at small panel sizes. Disabling Overlay Box turns off the saved code setting,
 releases its shortcut, and clears/disables the live dock until code is enabled for a new Start.
 Runtime authorization suppresses code when the session capability is off;
 each new hint replaces or clears its matching snippet.


### PR DESCRIPTION
Long code lines extended beyond the code dock, forcing users to widen the panel during an interview. Large history fonts also made short snippets needlessly scroll.

Code now wraps to the dock width without altering source text or correction highlights. The dock measures wrapped content when allocating height and selects the largest fitting compact font (12–18 pt). It restores the larger size when space returns and retains vertical scrolling only when the readable minimum cannot fit within the existing dock limit.

Validation:
- Reproduced horizontal overflow and oversized-font failures with new layout regressions before the fix.
- 21 affected tests across 4 suites pass, covering wrapping, fitting, resize recovery, minimum-size overflow, dock growth, and existing delivery/appearance behavior.
- Visually inspected a synthetic offscreen AppKit rendering.
- `swift build && ./scripts/run-tests.sh` exits 0; the known local AppKit test-host issue still prevents a complete full-suite summary. No full-suite pass is claimed.

No live app restart or interview-session changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long code snippets now wrap within the available overlay width without changing source text or highlighting.
  * Code automatically adjusts to a compact, readable font size to fit available space.
  * Small overlay areas retain vertical scrolling so code remains accessible.

* **Bug Fixes**
  * Improved code panel sizing and layout to prevent clipping and horizontal scrolling.

* **Documentation**
  * Updated architecture and status documentation to describe the revised code display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->