### PR TITLE
feat(coach): check the screen when a new question starts

### DIFF
--- a/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
+++ b/Sources/JarvisCore/Coach/CoachAttemptRunner.swift
@@ -218,6 +218,11 @@ final class CoachAttemptRunner: @unchecked Sendable {
         let systemPrompt = JarvisPrompts.Coach.system(
             prepMaterial: attempt.prepMaterial != nil,
             formatAddendum: interviewFormatAddendum)
+        // Retire a screen read that has aged out before this request is built, so the snapshot below
+        // never carries OCR that presents a minutes-old screen as the current one.
+        history.expireStaleScreenText(
+            olderThan: config.screenTextStalenessSeconds,
+            at: context.sessionElapsedSeconds)
         let historyBase: [ChatMessage] = [.system(systemPrompt)] + history.snapshot()
 
         if reason == .manualHint && !work.manualHintPrepared {
@@ -238,7 +243,8 @@ final class CoachAttemptRunner: @unchecked Sendable {
                 turnMessages.append(.userImage(shot.imageBase64))
                 if let text = shot.recognizedText {
                     jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
-                    let observation = ChatMessage.user(JarvisPrompts.Coach.recognizedText(text))
+                    let observation = ChatMessage.user(JarvisPrompts.Coach.captureResult(
+                        timestamp: self.captureStamp(), recognizedText: text))
                     observations.append(observation)
                     turnMessages.append(observation)
                 }
@@ -381,16 +387,17 @@ final class CoachAttemptRunner: @unchecked Sendable {
                         if let text = shot.recognizedText {
                             jlog("🔤 read \(text.count(where: { $0 == "\n" }) + 1) lines of on-screen text")
                         }
+                        let stamp = self.captureStamp()
                         work.screenObservation = [
                             .user(JarvisPrompts.Coach.captureResult(
-                                recognizedText: shot.recognizedText
+                                timestamp: stamp, recognizedText: shot.recognizedText
                             )),
                             .userImage(shot.imageBase64),
                         ]
                         appendToolContinuation(
                             toolCallId: callID,
                             resultText: JarvisPrompts.Coach.captureResult(
-                                recognizedText: shot.recognizedText),
+                                timestamp: stamp, recognizedText: shot.recognizedText),
                             extraMessages: [.userImage(shot.imageBase64)],
                             newPhase: .captureScreenContinuation)
                     } else {
@@ -426,7 +433,7 @@ final class CoachAttemptRunner: @unchecked Sendable {
                         role: .tool,
                         text: JarvisPrompts.Coach.tipShown,
                         toolCallId: callID))
-                    history.commit(turnMessages)
+                    history.commit(turnMessages, at: context.sessionElapsedSeconds)
                     ledger.commit(through: delta.upTo)
                     return .completed(.spoke)
 
@@ -437,7 +444,8 @@ final class CoachAttemptRunner: @unchecked Sendable {
                     }
                     jlog("… nothing useful to add, staying silent")
                     activity?.record(.stayedSilent)
-                    commitIfWorthKeeping(turnMessages, deltaText: substantiveDeltaText)
+                    commitIfWorthKeeping(turnMessages, deltaText: substantiveDeltaText,
+                                        at: context.sessionElapsedSeconds)
                     ledger.commit(through: delta.upTo)
                     return .completed(.silentByModel)
 
@@ -494,9 +502,17 @@ final class CoachAttemptRunner: @unchecked Sendable {
         return AttemptExecution(id: attemptID, result: result)
     }
 
-    private func commitIfWorthKeeping(_ turn: [ChatMessage], deltaText: String) {
+    private func commitIfWorthKeeping(_ turn: [ChatMessage], deltaText: String,
+                                      at sessionElapsed: TimeInterval) {
         guard !deltaText.isEmpty || turn.count > 1 else { return }
-        history.commit(turn)
+        history.commit(turn, at: sessionElapsed)
+    }
+
+    /// The [mm:ss] session stamp for a capture, read at the moment of the shot rather than from the
+    /// attempt's trigger context: the tool loop shoots seconds after the attempt opened, and a stamp
+    /// that claims otherwise is the very drift this is here to expose.
+    private func captureStamp() -> String {
+        RollingTranscript.stamp(clock.now() - sessionStart)
     }
 
     /// Screen capture is an OS-bound synchronous edge, so run it off the cooperative executor.

--- a/Sources/JarvisCore/Coach/CoachHistory.swift
+++ b/Sources/JarvisCore/Coach/CoachHistory.swift
@@ -18,6 +18,11 @@ public final class CoachHistory: @unchecked Sendable {
     /// the tail is safe for that, but an in-place OCR collapse is not, because the summary would
     /// reintroduce the very screen text the collapse just retired.
     private var rewriteRevision: UInt = 0
+    /// Session-elapsed seconds at which the one still-verbatim OCR block was committed, or nil when
+    /// history holds none. Stored rather than read back out of the message text: the [mm:ss] stamp in
+    /// a capture result is written for the model, and parsing our own prompt copy would make the
+    /// wording of a catalog string load-bearing.
+    private var liveScreenTextElapsed: TimeInterval?
 
     public init() {}
 
@@ -51,7 +56,7 @@ public final class CoachHistory: @unchecked Sendable {
     ///   reasoning items outright. The id-less call + output pair is the long-proven history shape.
     /// Both rewrites cost one prompt-cache divergence at the tail of the just-finished turn — far
     /// cheaper than re-billing the content on every request for the rest of the session.
-    public func commit(_ turn: [ChatMessage]) {
+    public func commit(_ turn: [ChatMessage], at sessionElapsed: TimeInterval) {
         guard !turn.isEmpty else { return }
         lock.lock(); defer { lock.unlock() }
         var turn = turn
@@ -61,6 +66,10 @@ public final class CoachHistory: @unchecked Sendable {
             rewriteRevision &+= 1
             // One tool loop may capture more than once — only the turn's newest OCR stays verbatim.
             for i in turn.indices where i < newest { turn[i] = Self.collapsingSupersededOCR(turn[i]) }
+            // The shot itself was taken a few seconds before this commit, well inside the staleness
+            // window, so the commit time stands in for the capture time rather than being threaded
+            // separately from each of the two capture sites.
+            liveScreenTextElapsed = sessionElapsed
         }
         messages.append(contentsOf: turn.compactMap { m in
             if let raw = m.rawItemsJSON { return Self.convertRawItems(raw) }
@@ -70,16 +79,41 @@ public final class CoachHistory: @unchecked Sendable {
         })
     }
 
+    /// Retire the one still-verbatim OCR block once it is older than `olderThan`, so a screen read
+    /// minutes ago stops presenting itself as the screen now. Superseding alone cannot do this: it
+    /// fires only when a NEWER capture lands, so the last dump of a session — or of a stretch where
+    /// the coach never looked again — persists verbatim to the end. Reported by a session audit where
+    /// the coach answered a freshly asked question against the previous question's screen.
+    ///
+    /// Called explicitly by the attempt runner just before it snapshots, rather than folded into
+    /// `snapshot()`: expiry is an in-place rewrite of committed messages, and hiding one inside a
+    /// read would make a getter bump `rewriteRevision` and diverge the prompt-cache prefix. Returns
+    /// whether anything was retired, and is a no-op once it has been.
+    @discardableResult
+    public func expireStaleScreenText(olderThan: TimeInterval, at sessionElapsed: TimeInterval) -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard let landed = liveScreenTextElapsed, sessionElapsed - landed > olderThan else { return false }
+        messages = messages.map { Self.collapsingOCR(in: $0, to: JarvisPrompts.Coach.staleRecognizedTextStub) }
+        rewriteRevision &+= 1
+        liveScreenTextElapsed = nil
+        return true
+    }
+
     /// Rewrite one committed message so its OCR block becomes the catalog's superseded marker.
     /// Text before the block — e.g. a successful capture result — survives.
     private static func collapsingSupersededOCR(_ m: ChatMessage) -> ChatMessage {
+        collapsingOCR(in: m, to: JarvisPrompts.Coach.supersededRecognizedTextStub)
+    }
+
+    /// Replace a message's OCR block with `stub`, keeping everything before the header — the capture
+    /// result's "[mm:ss] screenshot captured" line — so the retired look still says when it happened.
+    private static func collapsingOCR(in m: ChatMessage, to stub: String) -> ChatMessage {
         guard let text = m.text,
               let header = text.range(of: JarvisPrompts.Coach.recognizedTextHeader)
         else { return m }
         return ChatMessage(
             role: m.role,
-            text: String(text[..<header.lowerBound])
-                + JarvisPrompts.Coach.supersededRecognizedTextStub,
+            text: String(text[..<header.lowerBound]) + stub,
             toolCallId: m.toolCallId
         )
     }

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -22,9 +22,11 @@ public struct Config: Sendable {
     /// How long a capture's OCR text keeps describing "the screen" before `CoachHistory` retires it to
     /// a stub. The newest dump is otherwise the one block that never collapses — superseding only ever
     /// fires when a *newer* capture lands — so with no further look it sits in history verbatim for the
-    /// rest of the session and reads as current. Two minutes is short enough that a question change or
-    /// a rewritten editor buffer does not inherit the previous screen, and long enough that a coach
-    /// working through one problem keeps the screen it just read instead of looking again every turn.
+    /// rest of the session and reads as current. Five minutes keeps a coach working through one
+    /// problem on the screen it already read — an editor changes constantly, and expiring mid-problem
+    /// buys a re-look that the screen gate would otherwise not have asked for. It is a backstop
+    /// against a dump outliving its screen indefinitely, not the mechanism that grounds a new
+    /// question: the screen gate captures at a question's start, well before this fires.
     public var screenTextStalenessSeconds: TimeInterval
     /// Fixed time added to every overlay line before its reading time. Unlike a movie viewer (eyes on
     /// the screen, audio reinforcing the text), our user is mid-conversation and only *glances* at the
@@ -75,7 +77,7 @@ public struct Config: Sendable {
         silenceMaxIntervalSeconds: TimeInterval = 960,
         silenceIdleCutoffSeconds: TimeInterval = 1_800,
         historyCompactionTokenThreshold: Int = 10_000,
-        screenTextStalenessSeconds: TimeInterval = 120,
+        screenTextStalenessSeconds: TimeInterval = 300,
         overlayNoticeBufferSeconds: TimeInterval = 2.0,
         overlaySecondsPerWord: TimeInterval = 0.35,
         overlayMaxDisplaySeconds: TimeInterval = 8,

--- a/Sources/JarvisCore/Config/Config.swift
+++ b/Sources/JarvisCore/Config/Config.swift
@@ -19,6 +19,13 @@ public struct Config: Sendable {
     /// rare (a few times an hour), small enough that per-request input stays cheap. The estimator is
     /// conservative for non-ASCII scripts so this boundary is useful in multilingual sessions.
     public var historyCompactionTokenThreshold: Int
+    /// How long a capture's OCR text keeps describing "the screen" before `CoachHistory` retires it to
+    /// a stub. The newest dump is otherwise the one block that never collapses — superseding only ever
+    /// fires when a *newer* capture lands — so with no further look it sits in history verbatim for the
+    /// rest of the session and reads as current. Two minutes is short enough that a question change or
+    /// a rewritten editor buffer does not inherit the previous screen, and long enough that a coach
+    /// working through one problem keeps the screen it just read instead of looking again every turn.
+    public var screenTextStalenessSeconds: TimeInterval
     /// Fixed time added to every overlay line before its reading time. Unlike a movie viewer (eyes on
     /// the screen, audio reinforcing the text), our user is mid-conversation and only *glances* at the
     /// overlay — so the dominant cost is noticing the tip and redirecting their gaze, which is constant
@@ -68,6 +75,7 @@ public struct Config: Sendable {
         silenceMaxIntervalSeconds: TimeInterval = 960,
         silenceIdleCutoffSeconds: TimeInterval = 1_800,
         historyCompactionTokenThreshold: Int = 10_000,
+        screenTextStalenessSeconds: TimeInterval = 120,
         overlayNoticeBufferSeconds: TimeInterval = 2.0,
         overlaySecondsPerWord: TimeInterval = 0.35,
         overlayMaxDisplaySeconds: TimeInterval = 8,
@@ -84,6 +92,7 @@ public struct Config: Sendable {
         self.silenceMaxIntervalSeconds = silenceMaxIntervalSeconds
         self.silenceIdleCutoffSeconds = silenceIdleCutoffSeconds
         self.historyCompactionTokenThreshold = historyCompactionTokenThreshold
+        self.screenTextStalenessSeconds = screenTextStalenessSeconds
         self.overlayNoticeBufferSeconds = overlayNoticeBufferSeconds
         self.overlaySecondsPerWord = overlaySecondsPerWord
         self.overlayMaxDisplaySeconds = overlayMaxDisplaySeconds

--- a/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
+++ b/Sources/JarvisCore/Prompts/JarvisPrompts+Coach.swift
@@ -21,8 +21,10 @@ extension JarvisPrompts {
         - New speech appears under "New since last turn" with [mm:ss] timestamps. A
           "(no speech for ...)" marker means quiet, not a request. Longer quiet makes being stuck more likely,
           but does not prove it.
-        - You can see the screen only through capture_screen. A fresh screenshot or OCR in the current input
-          counts as current screen context.
+        - You can see the screen only through capture_screen. Every capture result opens with the same
+          [mm:ss] session stamp as transcript lines, and describes the screen at that moment, not now.
+          Only a result from the current request counts as current screen context; an earlier one is a
+          record of a screen that has probably moved on, most of all across a change of question.
         - OCR text is a reading aid that garbles the odd token; the screenshot image is ground truth. Before
           asserting a specific line or token is wrong, verify it in the image — if you can only see it in
           OCR, frame the tip as something to double-check ("verify line 18 uses ==") rather than as a defect.
@@ -42,6 +44,14 @@ extension JarvisPrompts {
            or "one pass" without the problem). Never guess missing content. This gate applies to either speaker.
            If "me" asked, call capture_screen now, then speak after the result. If only "them" spoke and no tip
            is warranted, call stay_silent without capturing.
+
+           It also covers the start of a new coding or technical question, including one "them" stated
+           in full aloud: capture once before your first tip on it. The shared editor or problem pane
+           is the source of truth there. Speech reaches you through transcription that garbles symbols,
+           numbers, and names, and the written statement carries the constraints, examples, and
+           starting signature that a spoken version leaves out. One capture settles the question; do
+           not re-capture it turn after turn. A behavioral question has no such shared screen, so this
+           does not apply to one.
         4. "me" is making steady progress: call stay_silent.
         5. Progress is unclear, especially after silence: call capture_screen unless a fresh result is already
            available. Then speak only if the user seems stuck; otherwise call stay_silent.
@@ -124,6 +134,11 @@ extension JarvisPrompts {
             + "errors; the screenshot image is ground truth):"
         static let supersededRecognizedTextStub =
             "[an earlier screen's OCR text was here — superseded by a newer capture]"
+        // Neutral like the two stubs above, and deliberately free of any "look again" instruction:
+        // an earlier recapture cue living in user-role history biased the coach toward capturing on
+        // every quiet turn. When to look is governed once, in the screen gate.
+        static let staleRecognizedTextStub =
+            "[this screen's OCR text was here — too old to describe the screen now]"
         static let manualHintCaptureFailed =
             "The screen capture requested for the manual hint failed."
         static let earlierCaptureFailed =
@@ -150,9 +165,17 @@ extension JarvisPrompts {
             "\(recognizedTextHeader)\n\(text)"
         }
 
-        static func captureResult(recognizedText text: String?) -> String {
-            guard let text else { return captureSucceeded }
-            return "\(captureSucceeded)\n\n\(recognizedText(text))"
+        /// Opens with the same [mm:ss] session stamp as transcript lines and trigger notes, so the
+        /// model reads a capture's age in the one idiom it already uses for timing. Without it the
+        /// newest OCR block reads as "the screen", whatever its age: a session audit caught the coach
+        /// naming the problem from a dump taken before the interviewer moved on to the next question.
+        /// The stamp sits ahead of the OCR header on purpose — `CoachHistory` collapses the block from
+        /// the header onwards, so the stamp survives into the superseded and stale stubs and still
+        /// says when that retired look happened.
+        static func captureResult(timestamp: String, recognizedText text: String?) -> String {
+            let head = "[\(timestamp)] \(captureSucceeded)"
+            guard let text else { return head }
+            return "\(head)\n\n\(recognizedText(text))"
         }
 
         static func condensedHistory(_ summary: String) -> String {

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -323,8 +323,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(brain.calls[1].contains { $0.role == .assistant && $0.toolCalls?.first?.name == "capture_screen" })
         #expect(brain.calls[1].contains { $0.role == .tool && $0.toolCallId == "c1" })
         #expect(brain.calls[1].contains { $0.imageBase64JPEG != nil })
-        // No OCR text on this snapshot → the tool result stays the plain marker.
-        #expect(brain.calls[1].first { $0.role == .tool }?.text == "screenshot captured")
+        // No OCR text on this snapshot → the tool result stays the plain marker, dated like a
+        // transcript line so the model can tell a fresh look from one taken minutes ago.
+        #expect(brain.calls[1].first { $0.role == .tool }?.text == "[00:00] screenshot captured")
         #expect(brain.requestContexts.compactMap { $0 }.map(\.phase) == [
             .initial, .captureScreenContinuation,
         ])

--- a/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachHistoryTests.swift
@@ -4,8 +4,8 @@ import Testing
 @Suite struct CoachHistoryTests {
     @Test func commitAppendsInOrder() {
         let h = CoachHistory()
-        h.commit([.user("one")])
-        h.commit([.user("two")])
+        h.commit([.user("one")], at: 0)
+        h.commit([.user("two")], at: 0)
         #expect(h.snapshot().compactMap(\.text) == ["one", "two"])
     }
 
@@ -14,8 +14,8 @@ import Testing
     /// reads; a fresh look is always one capture_screen away).
     @Test func imagesBecomeStubsAtCommit() {
         let h = CoachHistory()
-        h.commit([.user("a"), .userImage("QUJD")])
-        h.commit([.user("b"), .userImage("REVG")])
+        h.commit([.user("a"), .userImage("QUJD")], at: 0)
+        h.commit([.user("b"), .userImage("REVG")], at: 0)
         let snap = h.snapshot()
         #expect(!snap.contains { $0.imageBase64JPEG != nil })
         #expect(snap.filter { ($0.text ?? "").contains("no longer available") }.count == 2)   // the stubs
@@ -32,17 +32,17 @@ import Testing
         let ocr = { (body: String) in "\(JarvisPrompts.Coach.recognizedTextHeader)\n\(body)" }
         let h = CoachHistory()
         h.commit([.user("turn 1"),
-                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("if (min < sum)"))", toolCallId: "c1")])
-        h.commit([.user("turn 2")])                                  // no capture: nothing collapses
+                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("if (min < sum)"))", toolCallId: "c1")], at: 0)
+        h.commit([.user("turn 2")], at: 0)                                  // no capture: nothing collapses
         #expect(h.snapshot().contains { ($0.text ?? "").contains("if (min < sum)") })
 
-        h.commit([.user(ocr("if (sum < min)"))])                     // hint-path OCR rides as a user message
+        h.commit([.user(ocr("if (sum < min)"))], at: 0)                     // hint-path OCR rides as a user message
         var texts = h.snapshot().compactMap(\.text)
         #expect(texts.contains("screenshot captured\n\n\(JarvisPrompts.Coach.supersededRecognizedTextStub)"))  // prefix survives
         #expect(!texts.joined().contains("if (min < sum)"))          // stale body gone
         #expect(texts.contains { $0.contains("if (sum < min)") })    // newest OCR verbatim
 
-        h.commit([.init(role: .tool, text: "screenshot captured\n\n\(ocr("rewritten"))", toolCallId: "c2")])
+        h.commit([.init(role: .tool, text: "screenshot captured\n\n\(ocr("rewritten"))", toolCallId: "c2")], at: 0)
         texts = h.snapshot().compactMap(\.text)
         #expect(texts.contains(JarvisPrompts.Coach.supersededRecognizedTextStub))                // the user-shaped OCR collapsed whole
         #expect(!texts.joined().contains("if (sum < min)"))
@@ -57,7 +57,7 @@ import Testing
         let h = CoachHistory()
         h.commit([.user("turn"),
                   .init(role: .tool, text: "screenshot captured\n\n\(ocr("first look"))", toolCallId: "c1"),
-                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("second look"))", toolCallId: "c2")])
+                  .init(role: .tool, text: "screenshot captured\n\n\(ocr("second look"))", toolCallId: "c2")], at: 0)
         let texts = h.snapshot().compactMap(\.text)
         #expect(!texts.joined().contains("first look"))
         #expect(texts.contains("screenshot captured\n\n\(JarvisPrompts.Coach.supersededRecognizedTextStub)"))
@@ -74,7 +74,7 @@ import Testing
         h.commit([.user("a"),
                   .rawItems([#"{"type":"reasoning","id":"rs_1","encrypted_content":"blob"}"#,
                              #"{"type":"function_call","id":"fc_1","call_id":"c1","name":"capture_screen","arguments":"{}"}"#]),
-                  .init(role: .tool, text: "screenshot captured", toolCallId: "c1")])
+                  .init(role: .tool, text: "screenshot captured", toolCallId: "c1")], at: 0)
         let snap = h.snapshot()
         #expect(!snap.contains { $0.rawItemsJSON != nil })                       // nothing verbatim survives
         #expect(!snap.contains { ($0.toolCalls?.first?.argumentsJSON ?? "").contains("blob") })
@@ -87,7 +87,7 @@ import Testing
     /// there is nothing a later turn could use.
     @Test func reasoningOnlyPassthroughIsDroppedWholeAtCommit() {
         let h = CoachHistory()
-        h.commit([.user("a"), .rawItems([#"{"type":"reasoning","id":"rs_1"}"#]), .user("b")])
+        h.commit([.user("a"), .rawItems([#"{"type":"reasoning","id":"rs_1"}"#]), .user("b")], at: 0)
         #expect(h.snapshot().compactMap(\.text) == ["a", "b"])
         #expect(!h.snapshot().contains { $0.rawItemsJSON != nil || $0.toolCalls != nil })
     }
@@ -97,9 +97,9 @@ import Testing
     @Test func compactionPrefixBoundsRespectTheTail() {
         let h = CoachHistory()
         #expect(h.compactionPrefix() == nil)                       // empty: nothing to split
-        h.commit([.user("only")])
+        h.commit([.user("only")], at: 0)
         #expect(h.compactionPrefix() == nil)                       // one message: nothing to split
-        h.commit([.user(String(repeating: "x", count: 4000)), .user("tail")])
+        h.commit([.user(String(repeating: "x", count: 4000)), .user("tail")], at: 0)
         let prefix = h.compactionPrefix()
         #expect(prefix != nil)
         #expect(prefix!.count < h.snapshot().count)                // the tail stays verbatim
@@ -107,7 +107,7 @@ import Testing
 
     @Test func compactReplacesPrefixWithSummary() {
         let h = CoachHistory()
-        h.commit([.user("old one"), .user("old two"), .user("recent")])
+        h.commit([.user("old one"), .user("old two"), .user("recent")], at: 0)
         let revision = h.compactionPrefix()!.revision
         #expect(h.compact(prefixCount: 2, summary: "the gist", revision: revision))
         let texts = h.snapshot().compactMap(\.text)
@@ -125,12 +125,12 @@ import Testing
     @Test func compactRejectsASummaryWrittenAgainstSupersededScreenText() {
         let h = CoachHistory()
         let ocr = JarvisPrompts.Coach.recognizedText("int hl = countHeight(root.left);")
-        h.commit([.init(role: .tool, text: ocr, toolCallId: "c1"), .user("first")])
+        h.commit([.init(role: .tool, text: ocr, toolCallId: "c1"), .user("first")], at: 0)
         let stale = h.compactionPrefix()!
 
         // A newer capture lands while the summary is still being written.
         h.commit([.init(role: .tool, text: JarvisPrompts.Coach.recognizedText("fixed line"),
-                        toolCallId: "c2")])
+                        toolCallId: "c2")], at: 0)
 
         #expect(!h.compact(prefixCount: stale.count, summary: "old screen said hl", revision: stale.revision))
         let texts = h.snapshot().compactMap(\.text).joined(separator: "\n")
@@ -148,10 +148,10 @@ import Testing
     @Test func estimateGrowsWithContent() {
         let h = CoachHistory()
         let before = h.estimatedTokens
-        h.commit([.user(String(repeating: "word ", count: 100))])
+        h.commit([.user(String(repeating: "word ", count: 100))], at: 0)
         let afterText = h.estimatedTokens
         #expect(afterText > before)
-        h.commit([.userImage("QUJD")])
+        h.commit([.userImage("QUJD")], at: 0)
         #expect(h.estimatedTokens > afterText)                    // the stub still counts…
         #expect(h.estimatedTokens < afterText + 100)              // …but nowhere near image cost
     }
@@ -160,11 +160,66 @@ import Testing
     /// character counts deliberately produce a more conservative estimate for non-ASCII scripts.
     @Test func estimateTreatsNonASCIITextConservatively() {
         let latin = CoachHistory()
-        latin.commit([.user(String(repeating: "a", count: 100))])
+        latin.commit([.user(String(repeating: "a", count: 100))], at: 0)
         let chinese = CoachHistory()
-        chinese.commit([.user(String(repeating: "中", count: 100))])
+        chinese.commit([.user(String(repeating: "中", count: 100))], at: 0)
 
         #expect(latin.estimatedTokens == 25)
         #expect(chinese.estimatedTokens == 100)
+    }
+
+    // MARK: - Screen-text staleness
+
+    /// The newest OCR is the one block superseding never reaches, so with no further capture it used
+    /// to describe "the screen" for the rest of the session. A live session audit caught the coach
+    /// answering a freshly asked coding question against the previous question's screen.
+    @Test func staleScreenTextExpiresToAStub() {
+        let h = CoachHistory()
+        h.commit([.init(role: .tool,
+                        text: "[05:00] screenshot captured\n\n\(JarvisPrompts.Coach.recognizedText("Question 1"))",
+                        toolCallId: "c1")], at: 300)
+
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 400) == false)   // 100s old: still the screen
+        #expect(h.snapshot().compactMap(\.text).contains { $0.contains("Question 1") })
+
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 425) == true)    // 125s old: retired
+        let text = h.snapshot().compactMap(\.text).joined()
+        #expect(!text.contains("Question 1"))
+        #expect(text.contains(JarvisPrompts.Coach.staleRecognizedTextStub))
+        #expect(text.contains("[05:00] screenshot captured"))                // when that look happened survives
+        // Neutral marker, like the superseded and image stubs: a "look again" cue repeated in
+        // user-role history drove capture-on-every-quiet-turn in an earlier session audit.
+        #expect(!text.contains("capture_screen"))
+    }
+
+    /// Expiry is idempotent, and a fresh capture restarts the clock rather than inheriting the old
+    /// one's age — otherwise the look the coach just took would expire on the next request.
+    @Test func freshCaptureRestartsTheStalenessClock() {
+        let h = CoachHistory()
+        h.commit([.init(role: .tool,
+                        text: "[05:00] screenshot captured\n\n\(JarvisPrompts.Coach.recognizedText("old"))",
+                        toolCallId: "c1")], at: 300)
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 425) == true)
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 999) == false)   // nothing left to retire
+
+        h.commit([.init(role: .tool,
+                        text: "[16:39] screenshot captured\n\n\(JarvisPrompts.Coach.recognizedText("new"))",
+                        toolCallId: "c2")], at: 999)
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 1_050) == false)
+        #expect(h.snapshot().compactMap(\.text).contains { $0.contains("new") })
+    }
+
+    /// Compaction reads the history, then writes its summary much later. Expiry rewrites committed
+    /// messages in place, so a summary written across one must be rejected — applying it would put
+    /// the screen text expiry just retired straight back into history.
+    @Test func compactRejectsASummaryWrittenAcrossAnExpiry() {
+        let h = CoachHistory()
+        h.commit([.init(role: .tool,
+                        text: "[05:00] screenshot captured\n\n\(JarvisPrompts.Coach.recognizedText("Question 1"))",
+                        toolCallId: "c1"), .user("first")], at: 300)
+        h.commit([.user("second")], at: 310)
+        let prefix = h.compactionPrefix()!
+        #expect(h.expireStaleScreenText(olderThan: 120, at: 425) == true)
+        #expect(h.compact(prefixCount: prefix.count, summary: "…", revision: prefix.revision) == false)
     }
 }

--- a/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
+++ b/Tests/JarvisCoreTests/Coach/ToolDefsTests.swift
@@ -47,10 +47,31 @@ import Testing
     }
 
     @Test func coachPromptTreatsFreshCaptureAsSatisfyingScreenGate() {
-        #expect(JarvisPrompts.Coach.system.contains("A fresh screenshot or OCR in the current input"))
+        #expect(JarvisPrompts.Coach.system.contains("Only a result from the current request counts as current screen context"))
         #expect(JarvisPrompts.Coach.system.contains("A fresh capture result satisfies the screen gate"))
         #expect(JarvisPrompts.Coach.system.contains("do not capture again"))
         #expect(JarvisPrompts.Coach.system.contains("the same request"))
+    }
+
+    /// A capture result is stamped like a transcript line, so the prompt has to tell the model a
+    /// stamped result describes that moment rather than now — otherwise the stamp is decoration and
+    /// an old OCR block still reads as the screen.
+    @Test func coachPromptDatesCaptureResults() {
+        #expect(JarvisPrompts.Coach.system.contains("[mm:ss] session stamp as transcript lines"))
+        #expect(JarvisPrompts.Coach.system.contains("describes the screen at that moment, not now"))
+    }
+
+    /// A question read aloud lands in the transcript, so the gate's "absent from the conversation"
+    /// test used to be satisfied without ever looking: a live session coached two coding questions
+    /// off the interviewer's speech alone, one of them for 18 minutes with no capture at all. The
+    /// screen is the source of truth for a problem statement, and one look settles it — a standing
+    /// recapture cue is what drove capture-on-every-quiet-turn before.
+    @Test func coachPromptCapturesAtTheStartOfANewQuestion() {
+        #expect(JarvisPrompts.Coach.system.contains("start of a new coding or technical question"))
+        #expect(JarvisPrompts.Coach.system.contains("capture once before your first tip on it"))
+        #expect(JarvisPrompts.Coach.system.contains("is the source of truth there"))
+        #expect(JarvisPrompts.Coach.system.contains("One capture settles the question"))
+        #expect(JarvisPrompts.Coach.system.contains("A behavioral question has no such shared screen"))
     }
 
     @Test func coachPromptRequiresOneActionPerModelResponse() {

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -102,8 +102,23 @@ moments the model judges worthwhile.
    or “here” — and no fresh capture is already available for that request. It may also capture when
    a silence trigger leaves progress unclear. The harness returns a silent screenshot plus OCR; that
    fresh result satisfies the screen gate, so the next model response must speak or stay silent
-   rather than capture the same request again. Fully stated questions do not require a reflexive
-   capture.
+   rather than capture the same request again.
+
+   The start of a new coding or technical question is its own trigger, **even when the interviewer
+   states it in full aloud**: one capture before the first tip on it. A missing-context test alone
+   never fires there, because a spoken statement lands in the transcript and so is not missing — yet
+   the shared editor is the source of truth. Speech arrives through transcription that garbles
+   symbols, numbers, and names (“find the max *edge*” for *max h*), and the written statement carries
+   the constraints, examples, and starting signature a spoken one skips. The trigger is one capture
+   per question rather than a standing cue: recapture language living in user-role history biases the
+   coach toward capturing on every quiet turn. A behavioral question has no shared screen and does not
+   trigger it. Beyond that, a fully stated question still needs no reflexive capture.
+
+   Every capture result opens with the same `[mm:ss]` session stamp as a transcript line, and only a
+   result from the current request counts as current screen context. `CoachHistory` retires an OCR
+   block older than `Config.screenTextStalenessSeconds` to a stub: superseding fires only when a
+   *newer* capture lands, so without this the last dump of a session goes on describing “the screen”
+   to the end of it.
 5. The model calls `speak(lines)` — a tip of up to ~3 short lines, returned **already split**
    into an array (Structured Outputs / `strict:true`), so the client never splits prose on
    punctuation — or `stay_silent`. A tool call is **required** on every model response: silence is an

--- a/wiki/status.md
+++ b/wiki/status.md
@@ -13,8 +13,11 @@ implemented.** The coach covers behavioral, system-design, and coding questions,
 Behavioral and System Design specialist skills under `Sources/JarvisCore/Resources/Skills/`; their
 policy is defined in [architecture.md → Models and APIs](./architecture.md#models-and-apis). A direct request
 whose specific answer depends on visible context missing from the conversation calls `capture_screen`
-before `speak`; a fresh screenshot/OCR satisfies that request, while a fully stated question can be
-answered without a reflexive capture. The independent Transcription setting keeps **OpenAI as the
+before `speak`, as does the start of a new coding or technical question even when the interviewer
+states it aloud in full; a fresh screenshot/OCR satisfies that request, and capture results are dated
+so screen text that has aged past `Config.screenTextStalenessSeconds` stops reading as the current
+screen. Beyond a question's start, a fully stated question is still answered without a reflexive
+capture. The independent Transcription setting keeps **OpenAI as the
 default**, keeps **GPT-4o Transcribe** as its default model, adds opt-in **GPT Transcribe** and
 **GPT Live Transcribe**, adds opt-in, on-device **Apple Speech** on macOS 26 or later, and adds
 opt-in **Gemini** over the Gemini Live WebSocket — server-owned turn detection (no client commit, no
@@ -241,7 +244,10 @@ OpenAI and starting again leaves the primary path unregressed.
 
 Then run the live prompt smoke on a fresh session: show an interview question without speaking its
 details, ask “Jarvis, how can I solve this in one pass?”, and confirm the first action is
-exactly one `capture_screen` followed by a screen-specific reply. Then ask a fully stated behavioral
+exactly one `capture_screen` followed by a screen-specific reply. Then, with a coding question posted
+on screen, read it aloud in full without referring to the screen and confirm the first action is
+still one `capture_screen` before the first tip, and that later turns on that same question do not
+keep re-capturing. Then ask a fully stated behavioral
 question and confirm it can answer without an unnecessary capture. Finish the in-app Claude Code
 provider smoke: confirm Settings shows it signed in, then confirm a coaching turn and screen request.
 While that session runs, switch providers and confirm the next completed turn preserves context and


### PR DESCRIPTION
## The bug

In session `2026-09-09_06-59-17_21DC`, Jarvis coached both coding questions off the interviewer's
speech without ever checking the screen at the start of either.

| | question stated | last screen look | next screen look |
|---|---|---|---|
| Q1 (tree diameter) | 07:14:46 | 07:14:45, showing a **blank** problem pane | 07:17:48, three minutes and three tips later |
| Q2 (H-index) | 07:45:42 | 07:42:17, showing **Q1's** problem and Q1's Java | never, for the remaining 18 minutes |

The 07:17:48 capture proves what was there to find: Q1's full written statement plus its example
tree and expected output. During the blind window Jarvis told the user to "Confirm it's n-ary, and
how children are given", which the screen already answered.

## Root cause

**The screen gate keyed on absence.** It fired when a reply "depends on current visible information
that is absent from the conversation". A question read aloud lands in the transcript, so nothing was
absent and the gate stayed shut. This was deliberate and documented (`Fully stated questions do not
require a reflexive capture`), trading question-start grounding for capture restraint.

**Capture results were undated and the newest never aged.** `CoachHistory` collapses an OCR block
only when a *newer* capture lands, so with no further look the last dump sat in history verbatim
under a present-tense header for the rest of the session. At the moment Q2 was asked, the model's
newest "screen context" was Q1's problem and Q1's Java, five minutes stale and unmarked, while every
speech line around it carried an `[mm:ss]` stamp.

## The change

- **Screen gate** now also covers the start of a new coding or technical question, including one
  stated in full aloud. Scoped to one capture per question and exempting behavioral questions, so it
  does not become the standing recapture cue that previously biased the coach into capturing on
  every quiet turn.
- **Capture results are dated** with the same `[mm:ss]` session stamp as transcript lines, read at
  the moment of the shot.
- **`CoachHistory.expireStaleScreenText`** retires an OCR block older than
  `Config.screenTextStalenessSeconds` (5 min) to a neutral stub, called by the attempt runner just
  before it snapshots. The stamp survives into the stub, so a retired look still says when it
  happened. This is a backstop against one dump outliving its screen indefinitely, not the mechanism
  that grounds a new question: the screen gate captures at a question's start, well before this
  fires.

## Verification

**Gate:** `swift build && ./scripts/run-tests.sh` — build clean, 0 failures.

**Prompt behavior** is not covered by the Gate, so the recorded conversations were replayed against
the old and new prompts, 5 trials each, with only the system prompt varying:

| fixture | old prompt | new prompt |
|---|---|---|
| Q1 asked aloud | 4/5 `speak` | **5/5 `capture_screen`** |
| Q2 asked aloud, stale Q1 OCR in history | 5/5 `speak` | **5/5 `capture_screen`** |
| mid-problem, user progressing | 5/5 `stay_silent` | 5/5 `stay_silent` |
| behavioral question | 5/5 `speak` | 5/5 `speak` |

The session directory was pruned from disk before the replay, so the two coding fixtures are
reconstructed from the recorded `brain-traffic.jsonl` excerpts quoted above rather than replayed
byte-for-byte.

New unit tests cover expiry, the staleness clock restarting on a fresh capture, compaction rejecting
a summary written across an expiry, and the three prompt rules.

**Live smoke** (added to `wiki/status.md`): with a coding question posted on screen, read it aloud in
full without referring to the screen, and confirm the first action is one `capture_screen` before
the first tip, and that later turns on that question do not keep re-capturing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Screen captures now include session timestamps, clarifying when displayed text was captured.
  - OCR context expires after a configurable period (default: 300 seconds) and is replaced with a stale-context indicator.
  - A fresh capture restarts the context freshness period.
  - Coding and technical questions trigger one screen capture at the start, including when stated aloud; behavioral questions do not.

- **Documentation**
  - Updated architecture, status, and coaching guidance to explain capture timing and OCR freshness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->