### PR TITLE
ci: let the review workflow run on the pipeline app's PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -18,6 +18,10 @@ jobs:
       && github.actor != 'dependabot[bot]'
       && !startsWith(github.head_ref, 'release-please--')
     uses: JINGBANZ/workflows/.github/workflows/claude-code-review.yml@main
+    with:
+      # The issue-worker opens PRs as the pipeline's GitHub App; without this allow-list entry the
+      # review action rejects bot-initiated runs, so agent PRs would land unreviewed-by-Claude.
+      allowed-bots: jingbanz-agent
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
PR #303 — the first PR the issue-worker opened as the `jingbanz-agent` app — failed its Claude review job: claude-code-action rejects workflows initiated by bots unless allow-listed (*"Workflow initiated by non-human actor: jingbanz-agent (type: Bot)"*). The old BOT_PAT pipeline never hit this because PAT-authored PRs look human.

Passes the app slug through the shared workflow's new `allowed-bots` input (JINGBANZ/workflows#13); dependabot and every other bot stay rejected.

Merge order: JINGBANZ/workflows#13 first, then this. After both, I'll close/reopen #303 to re-run its review.

Workflow-only change; CI runs the gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)