### PR TITLE
fix(coach): start the recovery ceiling at the first failed cycle and report the latest cause

### DIFF
--- a/Sources/JarvisApp/App/AppDelegate.swift
+++ b/Sources/JarvisApp/App/AppDelegate.swift
@@ -1010,8 +1010,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, BrainCompositionHost {
         let firstFailure = !readiness.hasFailedCoachingCycle
         observeReadiness(.brainCycleFailed(provider), for: readinessSession)
         guard firstFailure else { return }
-        let message = "Model cycle failed."
-        overlayCaption?.showError(message)
+        overlayCaption?.showError("Coaching failed. I'm still listening.")
     }
 
     func brainTargetDidChange(_ target: BrainTarget?) {

--- a/Sources/JarvisApp/App/BrainComposition.swift
+++ b/Sources/JarvisApp/App/BrainComposition.swift
@@ -297,6 +297,11 @@ final class BrainComposition {
                       self.host.liveSessionDirectory == sessionDirectory else { return }
                 self.host.reportBrainError(
                     .brainRouteExhausted(target: target, failure: failure), context: .runtime)
+            },
+            onRecoveryExpired: { [weak self] failure in
+                guard let self, self.host.liveCoachDriver != nil,
+                      self.host.liveSessionDirectory == sessionDirectory else { return }
+                self.host.reportBrainError(.brainRecoveryExpired(failure: failure), context: .runtime)
             })
     }
 

--- a/Sources/JarvisApp/MenuBar/MenuBarController.swift
+++ b/Sources/JarvisApp/MenuBar/MenuBarController.swift
@@ -173,7 +173,7 @@ private extension JarvisReadiness.Status {
         case .blocked(let blocker):
             "Jarvis is blocked — \(blocker.menuDescription)"
         case .cycleFailed(let provider):
-            "\(provider.displayName) cycle failed — listening continues"
+            "\(provider.displayName) coaching failed, still listening"
         case .recovering(.brainResponse(let provider), _):
             "\(provider.displayName) coaching attempt failed — listening continues; retrying"
         case .recovering(let requirement, let attempt):

--- a/Sources/JarvisApp/Viewer/ActivityViewer.swift
+++ b/Sources/JarvisApp/Viewer/ActivityViewer.swift
@@ -507,7 +507,7 @@ private extension JarvisReadiness.Status {
         case .blocked:
             ("Blocked", "blocked")
         case .cycleFailed(let provider):
-            ("\(provider.displayName) cycle failed — listening continues", "blocked")
+            ("\(provider.displayName) coaching failed, still listening", "blocked")
         case .recovering(.brainResponse(let provider), _):
             ("\(provider.displayName) coaching attempt failed — retrying", "recovering")
         case .recovering:

--- a/Sources/JarvisBrainProviders/LocalAgent/CLIBrainClient.swift
+++ b/Sources/JarvisBrainProviders/LocalAgent/CLIBrainClient.swift
@@ -87,10 +87,6 @@ public struct CLIBrainClient: BrainClient, Sendable {
         }
     }
 
-    public func terminate() {
-        runtimeLease.release()
-    }
-
     public func prepare() {
         runtime.prepareInBackground(for: configuration)
     }

--- a/Sources/JarvisCore/Brain/Brain.swift
+++ b/Sources/JarvisCore/Brain/Brain.swift
@@ -145,8 +145,6 @@ public protocol BrainClient: Sendable {
     func makeConversation() async throws -> any BrainConversation
     /// Begin preparing provider resources for the currently reachable route target.
     func prepare()
-    /// Release provider resources when a route target can no longer be selected this session.
-    func terminate()
 }
 
 public extension BrainClient {
@@ -163,9 +161,6 @@ public extension BrainClient {
 
     /// Stateless clients have no provider runtime to prepare.
     func prepare() {}
-
-    /// Stateless clients have no provider runtime to release.
-    func terminate() {}
 }
 
 private struct ForwardingBrainConversation: BrainConversation {

--- a/Sources/JarvisCore/Coach/BrainCycleRecovery.swift
+++ b/Sources/JarvisCore/Coach/BrainCycleRecovery.swift
@@ -2,28 +2,45 @@ import Foundation
 
 /// Session health survives failed cycle budgets; only successful coaching resets the streak.
 struct BrainCycleRecovery {
-    private(set) var failedCycles = 0
-    private(set) var lastSuccess: TimeInterval
+    /// How long a streak of failed cycles may last before the session ends. The clock starts at the
+    /// streak's first failed cycle, not at the last success: a quiet stretch with no coaching is not
+    /// an outage, so it must not end the session on the first failure that follows it.
+    static let ceiling: TimeInterval = 600
+
+    /// Consecutive failed cycles since the last success.
+    struct Streak {
+        let startedAt: TimeInterval
+        var cycles: Int
+        /// The most recent cycle's cause, which the ceiling's session end reports.
+        var lastFailure: ProviderFailure
+    }
+
+    private(set) var streak: Streak?
     private(set) var nextCycleAt: TimeInterval = 0
     private(set) var permanentFailures: [BrainTarget: ProviderFailure] = [:]
 
-    init(startedAt: TimeInterval) { lastSuccess = startedAt }
-
     mutating func markPermanent(_ target: BrainTarget, failure: ProviderFailure) { permanentFailures[target] = failure }
 
-    mutating func fail(at now: TimeInterval) {
+    mutating func fail(at now: TimeInterval, failure: ProviderFailure) {
         let delays: [TimeInterval] = [0, 5, 15, 45, 120]
-        nextCycleAt = now + delays[min(failedCycles, delays.count - 1)]
-        failedCycles += 1
+        let previousCycles = streak?.cycles ?? 0
+        nextCycleAt = now + delays[min(previousCycles, delays.count - 1)]
+        streak = Streak(
+            startedAt: streak?.startedAt ?? now, cycles: previousCycles + 1, lastFailure: failure)
     }
 
-    mutating func succeed(at now: TimeInterval) {
-        lastSuccess = now
-        failedCycles = 0
+    mutating func succeed() {
+        streak = nil
         nextCycleAt = 0
     }
 
+    /// Seconds before the current streak reaches the ceiling; infinite while no cycle has failed.
+    func remainingBeforeCeiling(at now: TimeInterval) -> TimeInterval {
+        guard let streak else { return .infinity }
+        return max(0, streak.startedAt + Self.ceiling - now)
+    }
+
     func ceilingReached(at now: TimeInterval) -> Bool {
-        failedCycles > 0 && now - lastSuccess >= 600
+        remainingBeforeCeiling(at: now) == 0
     }
 }

--- a/Sources/JarvisCore/Coach/CoachDriver.swift
+++ b/Sources/JarvisCore/Coach/CoachDriver.swift
@@ -49,7 +49,7 @@ public final class CoachDriver: @unchecked Sendable {
     private let stateLock = NSLock()
     private let recoveryDelay: @Sendable (TimeInterval) async throws -> Void
     private let clock: Clock
-    private var recovery: BrainCycleRecovery
+    private var recovery = BrainCycleRecovery()
     private var recoveryDeadlineTask: Task<Void, Never>?
     private var sessionTerminated = false
 
@@ -117,6 +117,7 @@ public final class CoachDriver: @unchecked Sendable {
         /// redirect the already-committed event to a second callback nor suppress this one.
         let callback: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)?
         var terminalCallback: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)? = nil
+        var expiredCallback: (@MainActor @Sendable (ProviderFailure) -> Void)? = nil
     }
 
     // Committing a route notice and delivering it are deliberately separate phases: the commit
@@ -181,7 +182,6 @@ public final class CoachDriver: @unchecked Sendable {
     ) {
         self.recoveryDelay = recoveryDelay
         self.clock = clock
-        self.recovery = BrainCycleRecovery(startedAt: sessionStart ?? clock.now())
         self.plan = plan
         self.activity = activity
         self._prepMaterial = prepMaterial
@@ -291,7 +291,8 @@ public final class CoachDriver: @unchecked Sendable {
             onSkipped: route.onSkipped,
             onRecoveryChanged: route.onRecoveryChanged,
             onExhausted: route.onExhausted,
-            onTerminated: route.onTerminated)
+            onTerminated: route.onTerminated,
+            onRecoveryExpired: route.onRecoveryExpired)
         let activeReplacement = refreshesActiveTarget && !routeIsExhausted
             ? configuredRoute.targets[routeSession.activeIndex]
             : nil
@@ -321,7 +322,8 @@ public final class CoachDriver: @unchecked Sendable {
             onSkipped: route.onSkipped,
             onRecoveryChanged: route.onRecoveryChanged,
             onExhausted: route.onExhausted,
-            onTerminated: route.onTerminated)
+            onTerminated: route.onTerminated,
+            onRecoveryExpired: route.onRecoveryExpired)
         let activeReplacement = routeIsExhausted
             ? nil
             : configuredRoute.targets[routeSession.activeIndex]
@@ -667,7 +669,8 @@ public final class CoachDriver: @unchecked Sendable {
                 target: configured.target,
                 failure: failure,
                 callback: configuredRoute.onExhausted,
-                terminalCallback: configuredRoute.onTerminated)
+                terminalCallback: configuredRoute.onTerminated,
+                expiredCallback: configuredRoute.onRecoveryExpired)
         case .stay:
             preconditionFailure("skipping an unavailable target cannot stay")
         }
@@ -735,7 +738,8 @@ public final class CoachDriver: @unchecked Sendable {
                     target: attempt.target,
                     failure: failure,
                     callback: configuredRoute.onExhausted,
-                terminalCallback: configuredRoute.onTerminated))
+                terminalCallback: configuredRoute.onTerminated,
+                expiredCallback: configuredRoute.onRecoveryExpired))
         }
     }
 
@@ -743,7 +747,7 @@ public final class CoachDriver: @unchecked Sendable {
         stateLock.lock()
         // A committed hint or silence is session progress even if Settings replaced the route
         // while its snapshotted attempt was running. Only cursor health belongs to that topology.
-        recovery.succeed(at: clock.now())
+        recovery.succeed()
         recoveryDeadlineTask?.cancel()
         recoveryDeadlineTask = nil
         if routeTopologyRevision == attempt.routeTopologyRevision
@@ -787,24 +791,25 @@ public final class CoachDriver: @unchecked Sendable {
                 jlog("Jarvis coach: ignoring route exhaustion from a superseded Settings revision")
                 return false
             }
-            let health = stateLock.withLock { () -> (terminalFailure: ProviderFailure?, delay: TimeInterval) in
-                recovery.fail(at: clock.now())
+            let health = stateLock.withLock { () -> (allPermanent: Bool, expired: Bool, remaining: TimeInterval) in
+                recovery.fail(at: clock.now(), failure: delivery.failure)
                 let allPermanent = configuredRoute.targets.allSatisfy {
                     recovery.permanentFailures[$0.target] != nil
                 }
                 let expired = recovery.ceilingReached(at: clock.now())
                 sessionTerminated = allPermanent || expired
-                return (allPermanent ? delivery.failure : (expired ? Self.ceilingFailure(delivery.target) : nil),
-                    max(0, recovery.lastSuccess + 600 - clock.now()))
+                return (allPermanent, expired, recovery.remainingBeforeCeiling(at: clock.now()))
             }
-            if let failure = health.terminalFailure {
-                delivery.terminalCallback?(delivery.target, failure)
+            if health.allPermanent {
+                delivery.terminalCallback?(delivery.target, delivery.failure)
+            } else if health.expired {
+                delivery.expiredCallback?(delivery.failure)
             } else {
                 activity?.record(.coachingCycleFailed(failure: delivery.failure))
                 delivery.callback?(delivery.target, delivery.failure)
                 stateLock.withLock {
                     if recoveryDeadlineTask == nil {
-                        recoveryDeadlineTask = makeRecoveryDeadlineTask(after: health.delay, delivery: delivery)
+                        recoveryDeadlineTask = makeRecoveryDeadlineTask(after: health.remaining)
                     }
                 }
             }
@@ -822,34 +827,29 @@ public final class CoachDriver: @unchecked Sendable {
 
     // Keep self weak while sleeping and cancel explicitly on success/teardown. Constructing this
     // task inside the nested MainActor delivery closure triggers a Swift 6.3 task-allocation trap.
-    private func makeRecoveryDeadlineTask(
-        after seconds: TimeInterval, delivery: RouteExhaustionDelivery
-    ) -> Task<Void, Never> {
+    private func makeRecoveryDeadlineTask(after seconds: TimeInterval) -> Task<Void, Never> {
         let delay = recoveryDelay
         return Task.detached { [weak self] in
             do { try await delay(seconds) } catch { return }
             guard !Task.isCancelled, let self else { return }
-            await self.terminateExpiredRecovery(delivery)
+            await self.terminateExpiredRecovery()
         }
     }
 
-    private func terminateExpiredRecovery(_ delivery: RouteExhaustionDelivery) async {
+    /// The deadline task is created by the streak's first failed cycle, so it reads the streak's
+    /// latest failure when it fires rather than the one it was created with.
+    private func terminateExpiredRecovery() async {
         await MainActor.run {
-            let callback = stateLock.withLock {
-                guard !Task.isCancelled, !sessionTerminated,
-                      recovery.ceilingReached(at: clock.now()) else {
-                    return Optional<(@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)>.none
-                }
+            let expiry = stateLock.withLock {
+                () -> (callback: (@MainActor @Sendable (ProviderFailure) -> Void)?, failure: ProviderFailure)? in
+                guard !Task.isCancelled, !sessionTerminated, let streak = recovery.streak,
+                      recovery.ceilingReached(at: clock.now()) else { return nil }
                 sessionTerminated = true
-                return configuredRoute.onTerminated
+                return (configuredRoute.onRecoveryExpired, streak.lastFailure)
             }
-            callback?(delivery.target, Self.ceilingFailure(delivery.target))
+            guard let expiry else { return }
+            expiry.callback?(expiry.failure)
         }
-    }
-
-    private static func ceilingFailure(_ target: BrainTarget) -> ProviderFailure {
-        ProviderFailure(source: .brain(target.provider), stage: .request, category: .unknown,
-            disposition: .permanent, identity: .init(), message: "No coaching cycle succeeded in 10 minutes.")
     }
 
     private func waitForCycleCooldown() async -> Bool {

--- a/Sources/JarvisCore/Coach/ConfiguredBrainRoute.swift
+++ b/Sources/JarvisCore/Coach/ConfiguredBrainRoute.swift
@@ -12,8 +12,11 @@ public struct ConfiguredBrainRoute: Sendable {
     let onSkipped: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)?
     let onRecoveryChanged: (@MainActor @Sendable (BrainProvider?) -> Void)?
     let onExhausted: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)?
-
+    /// Every configured target is permanently unavailable; carries the last target proven so.
     let onTerminated: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)?
+    /// A failure streak reached `BrainCycleRecovery.ceiling` without a success; carries the most
+    /// recent cycle's failure.
+    let onRecoveryExpired: (@MainActor @Sendable (ProviderFailure) -> Void)?
 
     public init(
         targets: [ConfiguredBrainTarget],
@@ -22,7 +25,8 @@ public struct ConfiguredBrainRoute: Sendable {
         onSkipped: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)? = nil,
         onRecoveryChanged: (@MainActor @Sendable (BrainProvider?) -> Void)? = nil,
         onExhausted: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)? = nil,
-        onTerminated: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)? = nil
+        onTerminated: (@MainActor @Sendable (BrainTarget, ProviderFailure) -> Void)? = nil,
+        onRecoveryExpired: (@MainActor @Sendable (ProviderFailure) -> Void)? = nil
     ) {
         precondition(!targets.isEmpty, "a configured brain route needs a primary target")
         self.targets = targets
@@ -31,6 +35,7 @@ public struct ConfiguredBrainRoute: Sendable {
         self.onSkipped = onSkipped
         self.onExhausted = onExhausted
         self.onTerminated = onTerminated
+        self.onRecoveryExpired = onRecoveryExpired
         self.onRecoveryChanged = onRecoveryChanged
     }
 }

--- a/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
+++ b/Sources/JarvisCore/Diagnostics/ActivityEvent.swift
@@ -108,7 +108,7 @@ public enum ActivityEvent: Sendable {
         case .coachingCycleFailed(let failure):
             return (
                 .coachingCycleFailed,
-                "⚠️ \(failure.activitySentenceWithoutAdvice) — coaching cycle failed; listening continues"
+                "⚠️ \(failure.activitySentenceWithoutAdvice) — coaching failed; listening continues"
                     + failure.activityAdvice,
                 nil
             )

--- a/Sources/JarvisCore/Diagnostics/SessionEndReason.swift
+++ b/Sources/JarvisCore/Diagnostics/SessionEndReason.swift
@@ -12,6 +12,8 @@ public enum SessionEndReason: Sendable, Equatable {
     case openAIAPIKeyMissing
     case permissionsMissing
     case brainRouteExhausted(last: ProviderFailure)
+    /// Coaching kept failing for `BrainCycleRecovery.ceiling`; carries the most recent failure.
+    case brainRecoveryExpired(last: ProviderFailure)
     case transcriptionStopped(failure: ProviderFailure)
     case audioCaptureUnavailable(failure: ProviderFailure)
     /// Jarvis-authored copy from the error catalog for a stop with no provider behind it.
@@ -31,6 +33,8 @@ public enum SessionEndReason: Sendable, Equatable {
             "session ended by error — a required permission is missing; check System Settings → Privacy & Security"
         case .brainRouteExhausted(let last):
             "session ended by error — all configured provider targets were exhausted; last target: \(last.activitySentence)"
+        case .brainRecoveryExpired(let last):
+            "session ended by error — coaching kept failing for \(Int(BrainCycleRecovery.ceiling / 60)) minutes; last error: \(last.activitySentence)"
         case .transcriptionStopped(let failure):
             "session ended by error — \(failure.activitySentence)"
         case .audioCaptureUnavailable(let failure):

--- a/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
+++ b/Sources/JarvisCore/Diagnostics/UserFacingError+Catalog.swift
@@ -104,6 +104,15 @@ public extension UserFacingError {
               sessionEndReason: .brainRouteExhausted(last: failure))
     }
 
+    /// A streak of failed coaching cycles reached the recovery ceiling without one success. Ends as
+    /// quietly as route exhaustion; Activity carries the most recent failure as the explanation.
+    static func brainRecoveryExpired(failure: ProviderFailure) -> UserFacingError {
+        .init(title: "Coaching stopped",
+              message: "\(failure.activitySentence)\n\nCoaching kept failing for \(Int(BrainCycleRecovery.ceiling / 60)) minutes, so the session ended. Check Settings → Brain, then Start again.",
+              severity: .terminal,
+              sessionEndReason: .brainRecoveryExpired(last: failure))
+    }
+
     /// Audio capture couldn't be built or started (no input device, permission, unreadable rate, …).
     /// Fatal — there's nothing to coach from.
     static func captureFailed(failure: ProviderFailure) -> UserFacingError {

--- a/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainClientTests.swift
+++ b/Tests/JarvisBrainProvidersTests/LocalAgent/CLIBrainClientTests.swift
@@ -53,9 +53,6 @@ import JarvisCore
         #expect(BrainWorkloadTimeout.liveCoaching == 15)
         #expect(claude.configuration.timeout == BrainWorkloadTimeout.liveCoaching)
         #expect(codex.configuration.timeout == BrainWorkloadTimeout.liveCoaching)
-
-        claude.terminate()
-        codex.terminate()
     }
 
     @Test func historyCompactionDeadlineIsProviderNeutral() throws {
@@ -80,9 +77,6 @@ import JarvisCore
                 == BrainWorkloadTimeout.historyCompaction)
         #expect(codexSummarizer.configuration.timeout
                 == BrainWorkloadTimeout.historyCompaction)
-
-        claudeSummarizer.terminate()
-        codexSummarizer.terminate()
     }
 
     /// Setup and inference are budgeted separately, so a slow runtime start cannot quietly shorten
@@ -361,48 +355,48 @@ import JarvisCore
         let backend = FakeLocalAgentRuntime(
             replies: [#"{"tool":"stay_silent","arguments":{}}"#])
         let runtime = CLIBrainRuntime(backend: backend)
-        let firstTargetCoach = makeClient(
-            provider: .codexCLI,
-            workDir: workDir,
-            runtime: runtime,
-            systemPrompt: "first coach",
-            tools: coachTools)
-        let firstTargetSummarizer = makeClient(
-            provider: .codexCLI,
-            workDir: workDir,
-            runtime: runtime,
-            systemPrompt: "first summarizer",
-            tools: [])
-        let fallbackCoach = makeClient(
-            provider: .codexCLI,
-            workDir: workDir,
-            runtime: runtime,
-            systemPrompt: "fallback coach",
-            tools: coachTools)
-        let fallbackSummarizer = makeClient(
-            provider: .codexCLI,
-            workDir: workDir,
-            runtime: runtime,
-            systemPrompt: "fallback summarizer",
-            tools: [])
+        // A client holds its runtime lease for as long as it exists, so dropping a client from this
+        // table is how its owner releases the runtime.
+        var clients = [
+            "first coach": makeClient(
+                provider: .codexCLI,
+                workDir: workDir,
+                runtime: runtime,
+                systemPrompt: "first coach",
+                tools: coachTools),
+            "first summarizer": makeClient(
+                provider: .codexCLI,
+                workDir: workDir,
+                runtime: runtime,
+                systemPrompt: "first summarizer",
+                tools: []),
+            "fallback coach": makeClient(
+                provider: .codexCLI,
+                workDir: workDir,
+                runtime: runtime,
+                systemPrompt: "fallback coach",
+                tools: coachTools),
+            "fallback summarizer": makeClient(
+                provider: .codexCLI,
+                workDir: workDir,
+                runtime: runtime,
+                systemPrompt: "fallback summarizer",
+                tools: []),
+        ]
 
-        firstTargetCoach.terminate()
-        firstTargetSummarizer.terminate()
+        clients["first coach"] = nil
+        clients["first summarizer"] = nil
         #expect(backend.terminationCount == 0)
 
-        _ = try await fallbackCoach.respond(
+        _ = try await clients["fallback coach"]?.respond(
             messages: [.system("fallback coach"), .user("continue forward")],
             tools: coachTools,
             toolChoice: .required)
         #expect(await backend.openCount == 1)
 
-        fallbackCoach.terminate()
+        clients["fallback coach"] = nil
         #expect(backend.terminationCount == 0)
-        fallbackSummarizer.terminate()
-        #expect(backend.terminationCount == 1)
-
-        firstTargetCoach.terminate()
-        fallbackSummarizer.terminate()
+        clients["fallback summarizer"] = nil
         #expect(backend.terminationCount == 1)
     }
 
@@ -533,7 +527,6 @@ import JarvisCore
             toolChoice: .required)
 
         #expect(response.toolCalls.isEmpty == false)
-        client.terminate()
     }
 
     /// The other half of the contract: drift is still rejected loudly. Tool names alone are not
@@ -558,7 +551,6 @@ import JarvisCore
             #expect(String(describing: error)
                 .contains("instructions changed after runtime initialization"))
         }
-        client.terminate()
     }
 
     private func makeClient(

--- a/Tests/JarvisCoreTests/Coach/BrainCycleRecoveryTests.swift
+++ b/Tests/JarvisCoreTests/Coach/BrainCycleRecoveryTests.swift
@@ -2,33 +2,44 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct BrainCycleRecoveryTests {
+    private func failure(_ message: String) -> ProviderFailure {
+        ProviderFailure(source: .brain(.openAI), stage: .request, category: .unknown,
+            disposition: .temporary, identity: .init(), message: message)
+    }
+
     @Test func cooldownCapsAndSuccessResetsWithoutForgettingPermanentTargets() {
-        var health = BrainCycleRecovery(startedAt: 10)
+        var health = BrainCycleRecovery()
         let target = BrainTarget(provider: .openAI, modelID: "test")
         health.markPermanent(target, failure: ProviderFailure(source: .brain(.openAI), stage: .request,
             category: .unknown, disposition: .permanent, identity: .init(), message: "invalid key"))
         for delay in [0.0, 5, 15, 45, 120, 120] {
-            health.fail(at: 20)
+            health.fail(at: 20, failure: failure("timed out"))
             #expect(health.nextCycleAt == 20 + delay)
         }
-        health.succeed(at: 30)
-        #expect(health.failedCycles == 0)
-        #expect(health.lastSuccess == 30)
+        #expect(health.streak?.cycles == 6)
+        health.succeed()
+        #expect(health.streak == nil)
         #expect(health.permanentFailures[target] != nil)
-        health.fail(at: 40)
+        health.fail(at: 40, failure: failure("timed out"))
         #expect(health.nextCycleAt == 40)
     }
 
-    @Test func ceilingRequiresFailureAndMeasuresFromLastSuccess() {
-        var health = BrainCycleRecovery(startedAt: 10)
-        #expect(!health.ceilingReached(at: 999))
-        health.fail(at: 600)
-        #expect(!health.ceilingReached(at: 609))
-        #expect(health.ceilingReached(at: 610))
-        health.succeed(at: 650)
-        #expect(!health.ceilingReached(at: 1500))
-        health.fail(at: 1200)
-        #expect(!health.ceilingReached(at: 1249))
-        #expect(health.ceilingReached(at: 1250))
+    /// Quiet time before a failure is not an outage, so the ceiling runs from the streak's first
+    /// failed cycle, and the session end reports the streak's latest cause.
+    @Test func ceilingRunsFromTheStreaksFirstFailureAndKeepsTheLatestCause() {
+        var health = BrainCycleRecovery()
+        #expect(!health.ceilingReached(at: 10_000))
+        health.fail(at: 1_440, failure: failure("first outage"))
+        #expect(!health.ceilingReached(at: 1_440))
+        health.fail(at: 1_700, failure: failure("latest outage"))
+        #expect(health.remainingBeforeCeiling(at: 1_700) == 340)
+        #expect(!health.ceilingReached(at: 2_039))
+        #expect(health.ceilingReached(at: 2_040))
+        #expect(health.streak?.lastFailure.message == "latest outage")
+        health.succeed()
+        #expect(!health.ceilingReached(at: 5_000))
+        health.fail(at: 5_000, failure: failure("new outage"))
+        #expect(!health.ceilingReached(at: 5_599))
+        #expect(health.ceilingReached(at: 5_600))
     }
 }

--- a/Tests/JarvisCoreTests/Coach/BrainRouteSessionTests.swift
+++ b/Tests/JarvisCoreTests/Coach/BrainRouteSessionTests.swift
@@ -2,14 +2,14 @@ import Testing
 @testable import JarvisCore
 
 @Suite struct BrainRouteSessionTests {
-    @Test func lastTargetEndsRequestAfterThreeTemporaryFailures() {
+    @Test func lastTargetEndsCycleAfterThreeTemporaryFailures() {
         var route = BrainRouteSession(targetCount: 1)
         #expect(route.recordFailure(.temporary) == .stay(failureCount: 1))
         #expect(route.recordFailure(.temporary) == .stay(failureCount: 2))
         #expect(route.recordFailure(.temporary) == .exhausted(last: 0))
     }
 
-    @Test func newRequestStartsWithFreshRouteBudget() {
+    @Test func newCycleStartsWithFreshRouteBudget() {
         var route = BrainRouteSession(targetCount: 2)
         _ = route.recordFailure(.permanent)
         _ = route.recordFailure(.permanent)

--- a/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
+++ b/Tests/JarvisCoreTests/Coach/CoachDriverPipelineTests.swift
@@ -700,7 +700,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
 
     /// A complete response that ignores `tool_choice: required` is a failed attempt, not a
     /// deliberate silence decision.
-    @Test func noToolCallsEndRequestAfterThreeAttemptsWithoutRendering() async {
+    @Test func noToolCallsEndCycleAfterThreeAttemptsWithoutRendering() async {
         let clock = ManualClock(now: 0)
         let brain = ScriptedBrain(script: Array(repeating: .init(toolCalls: []), count: 4)
             + [.init(toolCalls: [.staySilent(callId: "complete")])])
@@ -1097,7 +1097,6 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         transcript.append(.init(speaker: .me, text: "continue on fallback", at: 1))
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
         #expect(refreshedPrimary.callCount == 0)
-        #expect(refreshedPrimary.terminationCount == 0)
         #expect(refreshedFallback.calls.count == 1)
     }
 
@@ -1128,7 +1127,6 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
         #expect(reconfiguredPrimary.callCount == 0)
         #expect(reconfiguredPrimary.preparationCount == 0)
-        #expect(reconfiguredPrimary.terminationCount == 0)
         #expect(reconfiguredFallback.calls.count == 1)
         #expect(reconfiguredFallback.preparationCount == 1)
     }
@@ -1627,16 +1625,12 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await driver.handleTrigger(.turnEnd) == .brainError)
         #expect(first.callCount == 3)
         #expect(second.callCount == 1)
-        #expect(first.terminationCount == 0)
-        #expect(second.terminationCount == 0)
         #expect(exhausted.targets.map(\.provider) == [.claudeCode])
         #expect(await driver.handleTrigger(.turnEnd) == .brainError)
         #expect(exhausted.targets.count == 1)
-        #expect(first.terminationCount == 0)
-        #expect(second.terminationCount == 0)
     }
 
-    @Test func advancingTheRouteRetainsClientsForAFutureCycle() async {
+    @Test func advancingPastAPermanentPrimarySpeaksOnTheFallback() async {
         let primaryTarget = BrainTarget(provider: .claudeCode, modelID: "claude-sonnet-5")
         let fallbackTarget = BrainTarget(provider: .openAI, modelID: "gpt-5.5")
         let permanent = brainFailure(.permanent, "provider boundary is permanently unavailable")
@@ -1663,8 +1657,6 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         transcript.append(.init(speaker: .me, text: "advance cleanly", at: 0))
 
         #expect(await driver.handleTrigger(.turnEnd) == .spoke)
-        #expect(primary.terminationCount == 0)
-        #expect(summarizer.terminationCount == 0)
         #expect(fallback.calls.count == 1)
     }
 
@@ -2318,7 +2310,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 
     /// Incomplete output never renders, even across an outage longer than the fallback threshold.
-    @Test func incompleteResponsesEndRequestWithoutRenderingPartialOutput() async {
+    @Test func incompleteResponsesEndCycleWithoutRenderingPartialOutput() async {
         let brain = ScriptedBrain(script: Array(repeating:
             .init(toolCalls: [], rawToolCalls: [], incompleteReason: "max_output_tokens"), count: 4)
             + [.init(toolCalls: [.staySilent(callId: "complete")])])
@@ -2331,7 +2323,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
     }
 
     /// Each exhausted tool loop becomes a fresh attempt without rendering unfinished work.
-    @Test func repeatedToolLoopExhaustionEndsRequest() async {
+    @Test func repeatedToolLoopExhaustionEndsCycle() async {
         let brain = ScriptedBrain(script: Array(repeating:
             .init(toolCalls: [.captureScreen(callId: "c")],
                   rawToolCalls: [RawToolCall(id: "c", name: "capture_screen", argumentsJSON: "{}")]),
@@ -2432,8 +2424,9 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(recorder.providers == [.openAI, .openAI, nil])
         #expect(replacement.callCount == 0)
         clock.set(650)
+        // The replacement's first failed cycle starts a new streak, so its ceiling is a full one.
         #expect(await driver.handleTrigger(.manualHint) == .brainError)
-        #expect(await waitUntilAsync { await delays.durations == [50] })
+        #expect(await waitUntilAsync { await delays.durations == [600] })
         driver.cancelBackgroundWork()
     }
 
@@ -2588,7 +2581,6 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
                 target: BrainTarget(provider: .openAI, modelID: "gpt-5.5"), brain: brain)],
                 onTerminated: { _, failure in recorder.record(failure) }),
             screen: FakeScreen(), overlay: FakeOverlay(), clock: clock, automaticAttemptDelay: { _ in })
-        clock.set(600)
         #expect(await driver.handleTrigger(.manualHint) == .brainError)
         #expect(await driver.handleTrigger(.manualHint) == .brainError)
         #expect(brain.callCount == 1)
@@ -2596,29 +2588,60 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(recorder.failures.first?.message == "invalid key")
     }
 
-    @Test func failedCycleDeadlineEndsSessionWithoutAnotherTrigger() async {
+    /// The deadline belongs to the streak's first failed cycle, but the session end reports the
+    /// streak's latest cause through its own reason rather than route exhaustion.
+    @Test func failedCycleDeadlineEndsSessionWithTheLatestFailure() async {
         let clock = ManualClock()
         let deadline = AsyncGate()
-        let recorder = RouteFailureRecorder()
-        let brain = ThrowingBrain()
-        let transcript = RollingTranscript()
-        let driver = CoachDriver(config: .default, transcript: transcript,
+        let expired = RouteFailureRecorder()
+        let exhausted = RouteFailureRecorder()
+        // The first cycle throws; every later attempt returns no tool call, a different failure.
+        let brain = ScriptedThrowBrain(
+            script: [nil, nil, nil, .init(toolCalls: [])],
+            error: brainFailure(.temporary, "first outage"))
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
             route: ConfiguredBrainRoute(targets: [ConfiguredBrainTarget(
                 target: BrainTarget(provider: .openAI, modelID: "gpt-5.5"), brain: brain)],
-                onTerminated: { _, failure in recorder.record(failure) }),
+                onTerminated: { _, failure in exhausted.record(failure) },
+                onRecoveryExpired: { expired.record($0) }),
             screen: FakeScreen(), overlay: FakeOverlay(), clock: clock, automaticAttemptDelay: { _ in },
             recoveryDelay: { _ in await deadline.enter() })
         defer { driver.cancelBackgroundWork() }
         #expect(await driver.handleTrigger(.manualHint) == .brainError)
+        #expect(await driver.handleTrigger(.manualHint) == .brainError)
         await deadline.waitUntilEntered()
         clock.set(600)
         await deadline.release()
-        #expect(await waitUntilAsync { recorder.failures.count == 1 })
-        #expect(recorder.failures.first?.message == "No coaching cycle succeeded in 10 minutes.")
-        #expect(brain.callCount == 3)
+        #expect(await waitUntilAsync { expired.failures.count == 1 })
+        #expect(expired.messages == ["provider returned no required coaching tool call"])
+        #expect(exhausted.failures.isEmpty)
+        #expect(brain.calls.count == 6)
     }
 
-    @Test func successCancelsDeadlineAndLaterFailureUsesNewSuccessTime() async {
+    /// Idle time is not an outage. The first failure after a long quiet stretch keeps the session
+    /// and starts a full ceiling of its own.
+    @Test func firstFailureAfterLongQuietKeepsTheSession() async {
+        let clock = ManualClock()
+        let delays = RecoveryDelayProbe()
+        let ended = RouteFailureRecorder()
+        let brain = ThrowingBrain(error: brainFailure(.temporary, "provider timed out"))
+        let driver = CoachDriver(config: .default, transcript: RollingTranscript(),
+            route: ConfiguredBrainRoute(targets: [ConfiguredBrainTarget(
+                target: BrainTarget(provider: .openAI, modelID: "gpt-5.5"), brain: brain)],
+                onTerminated: { _, failure in ended.record(failure) },
+                onRecoveryExpired: { ended.record($0) }),
+            screen: FakeScreen(), overlay: FakeOverlay(), clock: clock, automaticAttemptDelay: { _ in },
+            recoveryDelay: { seconds in try await delays.wait(seconds) })
+        defer { driver.cancelBackgroundWork() }
+        clock.set(1_440)
+        #expect(await driver.handleTrigger(.manualHint) == .brainError)
+        #expect(await waitUntilAsync { await delays.durations == [600] })
+        #expect(await driver.handleTrigger(.manualHint) == .brainError)
+        #expect(brain.callCount == 6)
+        #expect(ended.failures.isEmpty)
+    }
+
+    @Test func successCancelsDeadlineAndTheNextStreakRestartsTheCeiling() async {
         let clock = ManualClock()
         let delays = RecoveryDelayProbe()
         let recorder = RouteFailureRecorder()
@@ -2638,7 +2661,7 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await waitUntilAsync { await delays.cancellations == 1 })
         clock.set(650)
         #expect(await driver.handleTrigger(.manualHint) == .brainError)
-        #expect(await waitUntilAsync { await delays.durations == [600, 50] })
+        #expect(await waitUntilAsync { await delays.durations == [600, 600] })
         #expect(recorder.failures.isEmpty)
     }
 
@@ -2696,7 +2719,6 @@ final class FakeOverlay: OverlayRendering, @unchecked Sendable {
         #expect(await outcome.value == .cancelled)
         #expect(recorder.failures.isEmpty)
         #expect(brain.callCount == 2)
-        #expect(brain.terminationCount == 0)
     }
 
     @Test func newSpeechWakesFastRetryWithLatestTranscript() async {
@@ -2964,10 +2986,8 @@ final class ThrowingBrain: BrainClient, @unchecked Sendable {
     private let error: Error
     private var calls = 0
     private var preparations = 0
-    private var terminations = 0
     var callCount: Int { lock.withLock { calls } }
     var preparationCount: Int { lock.withLock { preparations } }
-    var terminationCount: Int { lock.withLock { terminations } }
 
     init(error: Error = NSError(
         domain: "test", code: 401,
@@ -2982,10 +3002,6 @@ final class ThrowingBrain: BrainClient, @unchecked Sendable {
 
     func prepare() {
         lock.withLock { preparations += 1 }
-    }
-
-    func terminate() {
-        lock.withLock { terminations += 1 }
     }
 }
 

--- a/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/ActivityLogTests.swift
@@ -241,7 +241,7 @@ import Foundation
         let persisted = try Self.persistedRows(in: dir)
         #expect(persisted.count == 1)
         #expect(persisted[0].message == "⚠️ Codex CLI didn't respond in time "
-            + "(local agent runtime timed out after 60s) — coaching cycle failed; listening continues")
+            + "(local agent runtime timed out after 60s) — coaching failed; listening continues")
         #expect(persisted[0].kind == ActivityEvent.Kind.coachingCycleFailed.rawValue)
         #expect(ActivityLog.isHumanFacing(message: persisted[0].message, imageFile: nil))
         // Rows written before event kinds existed carry the two older wordings; the legacy filter
@@ -277,7 +277,7 @@ import Foundation
         #expect(persisted[0].message
             == "\u{26A0}\u{FE0F} OpenAI API couldn't be reached for coaching "
             + "(network -1009: the internet connection appears to be offline) "
-            + "\u{2014} coaching cycle failed; listening continues; check your network or VPN")
+            + "\u{2014} coaching failed; listening continues; check your network or VPN")
         #expect(persisted[1].message
             == "\u{26A0}\u{FE0F} Claude Code isn't signed in \u{2014} skipping it; "
             + "sign in to the CLI and press Start again")
@@ -374,7 +374,7 @@ import Foundation
         #expect(messages[1] == "⏹ session ended by error — all configured provider targets were exhausted; last target: Codex CLI failed (exit 1: OAuth token expired; Authorization: Bearer …)")
         #expect(ActivityLog.cssClass(for: messages[1]) == "err")
         #expect(messages[2] == "⏹ session ended by error — audio capture became unavailable (no input device)")
-        #expect(messages[3] == "⚠️ Codex CLI failed (exit 1: OAuth token expired; Authorization: Bearer …) — coaching cycle failed; listening continues")
+        #expect(messages[3] == "⚠️ Codex CLI failed (exit 1: OAuth token expired; Authorization: Bearer …) — coaching failed; listening continues")
         #expect(messages[4] == "⚠️ system audio stopped — the transcription connection to OpenAI was lost (close 1006); microphone coaching continues")
         #expect(messages[5].contains("current coaching session continues"))
         // Provider text reaches a row only after redaction, so a quoted message can never carry a
@@ -420,6 +420,7 @@ import Foundation
             .transcriptionStopped(failure: region),
             .audioCaptureUnavailable(failure: capture),
             .unexpectedError(detail: "Couldn't prepare Apple Speech"),
+            .brainRecoveryExpired(last: leaky),
         ]
         let rendered = reasons.map { ActivityEvent.sessionEnded(reason: $0).rendered }
         let messages = rendered.map { $0.message }
@@ -436,6 +437,8 @@ import Foundation
         #expect(ActivityLog.cssClass(for: messages[6]) == "err")
         #expect(messages[7] == "⏹ session ended by error — audio capture became unavailable (no input device)")
         #expect(messages[8] == "⏹ session ended by error — Couldn't prepare Apple Speech")
+        #expect(messages[9] == "⏹ session ended by error — coaching kept failing for 10 minutes; last error: Codex CLI failed (exit 1: OAuth token expired; Authorization: Bearer …)")
+        #expect(ActivityLog.cssClass(for: messages[9]) == "err")
         #expect(messages.allSatisfy { !$0.contains("abc123token") })
         #expect(rendered.map { $0.kind } == Array(
             repeating: ActivityEvent.Kind.sessionEnded,

--- a/Tests/JarvisCoreTests/Diagnostics/JarvisReadinessTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/JarvisReadinessTests.swift
@@ -287,7 +287,7 @@ import Testing
         #expect(readiness.status == .ready(.full))
     }
 
-    @Test func failedRequestKeepsSessionAndClearsOnNextRequest() {
+    @Test func failedCycleKeepsSessionAndClearsOnSuccess() {
         let (readiness, session) = fullReadyReadiness()
         _ = readiness.observe(.brainCycleFailed(.openAI), for: session)
         #expect(readiness.status == .cycleFailed(.openAI))

--- a/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
+++ b/Tests/JarvisCoreTests/Diagnostics/UserFacingErrorCatalogTests.swift
@@ -165,4 +165,17 @@ import Testing
         #expect(e.message.contains("Claude Code"))
         #expect(e.sessionEndReason == .brainRouteExhausted(last: failure))
     }
+
+    @Test func expiredBrainRecoveryStopsQuietlyAndCarriesTheLatestFailure() {
+        let failure = ProviderFailure(
+            source: .brain(.openAI), stage: .request, category: .unavailable,
+            disposition: .temporary, identity: .init(), message: "upstream overloaded")
+        let e = UserFacingError.brainRecoveryExpired(failure: failure)
+        #expect(e.severity == .terminal)
+        #expect(!e.severity.showsAlert)
+        #expect(e.severity.stopsSession)
+        #expect(e.message.contains("upstream overloaded"))
+        #expect(e.message.contains("10 minutes"))
+        #expect(e.sessionEndReason == .brainRecoveryExpired(last: failure))
+    }
 }

--- a/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
+++ b/Tests/JarvisOverlayTests/OverlayInvisibilityTests.swift
@@ -33,8 +33,8 @@ import AppKit
         let panel = OverlayCaptionPanel()
         panel.setEnabled(true)
         defer { panel.setEnabled(false) }
-        panel.showError("Model cycle failed.")
-        #expect(panel.currentText == "Model cycle failed.")
+        panel.showError("Coaching failed. I'm still listening.")
+        #expect(panel.currentText == "Coaching failed. I'm still listening.")
         #expect(panel.currentSharingType == .none)
     }
 

--- a/wiki/architecture.md
+++ b/wiki/architecture.md
@@ -464,12 +464,17 @@ cycle with the provider's redacted cause.
 A later explicit coaching shortcut or new finalized speech starts a fresh cycle at the primary;
 silence without new transcript does not. Consecutive failed cycles delay that admission by 0, 5, 15,
 45, then at most 120 seconds. New input coalesces during the cooldown, and the admitted attempt
-snapshots the latest conversation. Any successful terminal coaching action resets the cooldown.
+snapshots the latest conversation. Any successful terminal coaching action resets the cooldown and
+ends the failure streak.
 Proven permanent target failures remain excluded for the session, including across fresh cycles and
-Settings edits; when all configured targets are permanently unavailable, the existing terminal
-`brainRouteExhausted` path ends the session and Activity names the cause. If at least one cycle has
-failed and ten minutes pass since the last success (or session start), the same path ends the session
-with that explanation, even without new speech. These terminal paths add no live presentation.
+Settings edits; when all configured targets are permanently unavailable, `brainRouteExhausted` ends
+the session and Activity names the cause. A failure streak that reaches the recovery ceiling
+([`BrainCycleRecovery.ceiling`](../Sources/JarvisCore/Coach/BrainCycleRecovery.swift), ten minutes)
+without a success ends the session through its own `brainRecoveryExpired` reason, even without new
+speech, and Activity quotes the most recent failed cycle's cause. The ceiling clock starts at the
+streak's first failed cycle, not at the last success. Silence probes stop after a long quiet stretch,
+so a clock measured from the last success would end an idle session on its first failure. These
+terminal paths add no live presentation.
 
 Provider clients remain owned until replacement or session teardown. Stop cancels pending/in-flight
 work and the recovery deadline. This policy is implemented by `BrainRouteSession`,


### PR DESCRIPTION
## Summary

Addresses the follow-ups from the approval review of #283.

- **Ceiling clock.** The ten-minute recovery ceiling now starts at the first failed cycle of the current streak, and a success still resets it. A session that sat quiet past the silence-probe cutoff no longer ends on its first failure.
- **Ceiling end reason.** Reaching the ceiling ends the session with its own `brainRecoveryExpired` reason. Activity quotes the most recent failed cycle's real cause, not a synthesized failure. The deadline reads the latest failure when it fires, so a streak that changes cause reports the newest one. Routes where every target is permanently unavailable still end through `brainRouteExhausted`.
- **"Cycle" stays a code word.** The caption reads "Coaching failed. I'm still listening." The menu and Activity badge read "OpenAI coaching failed, still listening". The Activity row reads "coaching failed; listening continues". Test names that used "Request" for a cycle now say "Cycle".
- **Dead `BrainClient.terminate()`.** Removed from the protocol, its default, and `CLIBrainClient`. Clients stay owned until replacement or session teardown, and a CLI runtime lease is released when its last client is dropped. Releasing an excluded CLI runtime early would change that documented ownership rule, so it is not part of this PR.
- **Retry-After.** Tracked in #306.

The architecture page's ordered-route section describes the new clock and end reason.

## Validation

- The required Gate (`swift build && ./scripts/run-tests.sh`) exits 0 with no failure marks, and the ghost-mode guard passes. The local AppKit runner exits mid-suite without a completion summary, so the log has no complete test count. CI will report the full count.
- A focused rerun of `CoachDriverPipelineTests` passes all 97 tests, including the new latest-failure deadline, long-quiet, and restarted-streak tests.
- Focused runs of the recovery, route session, readiness, Activity log, error catalog, CLI client, and overlay invisibility suites pass.
- `topologyEditKeepsOutageUntilCommittedSuccess` now expects a full 600-second deadline for the replacement's first failed cycle, because that failure starts a new streak.

## Scope

No change to cooldown timing, per-target budgets, readiness precedence, or live presentation paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146579uJ67JWTaWDAkS14rj
